### PR TITLE
fix(auth): align 8-digit OTP verification flow (Story 6.18a)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -34,6 +34,10 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Create .env file
+        run: |
+          echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
+          echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
       - name: Prebuild native projects
         run: npx expo prebuild --platform android
       - name: Set up Ruby

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -45,6 +45,10 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Create .env file
+        run: |
+          echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
+          echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
       - name: Prebuild native projects
         run: npx expo prebuild --platform ios
       - name: Generate watchOS catalogue (Brands.swift)

--- a/.github/workflows/store-upload.yml
+++ b/.github/workflows/store-upload.yml
@@ -40,6 +40,10 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Create .env file
+        run: |
+          echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
+          echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
       - name: Prebuild native projects
         run: npx expo prebuild --platform ios
       - name: Generate watchOS catalogue (Brands.swift)
@@ -73,6 +77,10 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Create .env file
+        run: |
+          echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
+          echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
       - name: Prebuild native projects
         run: npx expo prebuild --platform android
       - name: Set up Ruby

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -148,28 +148,29 @@ last_sprint:
 current_sprint:
   number: 14
   name: 'Sprint 14: WatchOS Reliability, Italian In-App, and Household Collaboration Planning'
-  goal: 'Complete Apple Watch reliability work, finish incremental catalogue generation, enable Italian in-app readiness, and begin household collaboration discovery.'
+  goal: 'Complete Apple Watch reliability work, finish incremental catalogue generation, enable Italian in-app readiness, begin household collaboration discovery, and repair the OTP verification regression from Story 6.18.'
   status: in-progress
   planning_date: 2026-05-03
   start_date: 2026-05-13
   end_date: 2026-05-26
   duration: 2 weeks
-  epics: [5, 15, 14]
+  epics: [5, 15, 14, 6]
   stories:
     - 5-7-create-watch-complication
     - 5-8-incremental-catalogue-generation
     - 2-9-scan-cards-from-image-screenshot
     - 15-2-italian-language-in-app
     - 14-1-household-collaboration
+    - 6-18a-otp-verification-followup
   waves:
     wave_1:
-      stories: [5-7, 5-8, 2-9, 15-2]
-      note: 'Primary implementation work on Apple Watch reliability, image-based scanning, and Italian in-app readiness.'
+      stories: [5-7, 5-8, 2-9, 15-2, 6-18a]
+      note: 'Primary implementation work on Apple Watch reliability, image-based scanning, Italian in-app readiness, and the OTP verification follow-up bugfix.'
     wave_2:
       stories: [14-1]
       note: 'Begin household collaboration discovery and alignment once core sprint capacity is confirmed.'
   notes: |
-    Sprint 14 has started. The focus is on completing Apple Watch reliability work, Italian in-app readiness, and beginning household collaboration discovery.
+    Sprint 14 has started. The focus is on completing Apple Watch reliability work, Italian in-app readiness, beginning household collaboration discovery, and absorbing the OTP verification follow-up bugfix discovered after Story 6.18 shipped.
     This sprint keeps scope tight while advancing the highest-value customer and platform work.
 
 next_sprint: null
@@ -259,6 +260,7 @@ development_status:
   6-16-user-profile-creation-on-signup: done # Sprint 13 — implementation and live local signup validated; awaiting review disposition
   6-17-design-otp-verification-screen: done # Sprint 13 — Figma OTP Verification page approved by Ifero on 2026-04-28; design dependency cleared
   6-18-otp-email-verification-flow: done # Sprint 13 — OTP verify flow implemented, full validation green, dev+QA subagent reviews approved on 2026-04-29
+  6-18a-otp-verification-followup: done # Sprint 14 — stakeholder-approved follow-up bugfix for 8-digit OTP + single-field redesign from Story 6.18
   epic-6-retrospective: optional
 
   # Epic 7: Cloud Synchronization

--- a/docs/sprint-artifacts/stories/6-18a-otp-verification-followup.md
+++ b/docs/sprint-artifacts/stories/6-18a-otp-verification-followup.md
@@ -1,0 +1,158 @@
+# Story 6.18a: OTP Verification Follow-up — Single Field + 8-Digit Alignment
+
+**Epic:** 6 - User Authentication & Privacy
+**Type:** Bug Fix + Design Alignment
+**Status:** done
+
+## Story
+
+As a new user verifying my email address,
+I want the app to accept the real 8-digit OTP in a single text field,
+so that verification succeeds reliably and the entry UI stays readable on mobile.
+
+## Context
+
+This is a post-merge bugfix follow-up to Story 6.18.
+
+Production-style validation exposed three regressions in the shipped OTP flow:
+
+1. **Length mismatch across the stack**
+   - The verification screen, tests, copy, and local Supabase config were hardcoded to 6 digits.
+   - The intended verification flow now uses an 8-digit email OTP and the merged UI does not match it.
+
+2. **Design mismatch for longer OTP entry**
+   - Story 6.17 delivered 6 individual OTP cells.
+   - That pattern becomes visually noisy and awkward for an 8-digit code.
+   - The approved follow-up direction for this bugfix is a **single OTP text field** on the existing `OTP Verification` Figma page, in both light and dark variants.
+
+3. **Verification call needs current-contract alignment**
+   - The existing auth wrapper still verifies email OTPs using the older `type: 'signup'` branch documented in Story 6.18.
+   - Current Supabase documentation for email OTP verification uses `verifyOtp({ email, token, type: 'email' })`.
+   - The follow-up must revalidate the live flow against the current auth contract and update the client/tests accordingly.
+
+**Design update order (locked by stakeholder request):** update Figma first, then update the code.
+
+**Figma file:** `https://www.figma.com/design/4PSsX8SyTUU0GCUdBAAEED/Test`
+**Figma page:** `OTP Verification`
+**Parent story:** `6.18 — OTP Email Verification Flow`
+
+## Acceptance Criteria
+
+### AC1: Figma follow-up is applied first
+
+- [x] Existing `OTP Verification` Figma page updated before app-code changes continue
+- [x] All light/dark state frames replace the OTP cell row with a single text field
+- [x] Subtitle copy reads `We sent an 8-digit code to {email}`
+- [x] Interaction annotation is updated from auto-submit on 6th digit to auto-submit on 8th digit
+
+### AC2: Supabase/email OTP configuration aligns to 8 digits
+
+- [x] `supabase/config.toml` sets `auth.email.otp_length = 8` for the email confirmation flow
+- [x] Confirmation email template remains OTP-based (`{{ .Token }}`) and still presents the longer code cleanly
+- [x] Any repo docs that still define the email verification OTP as 6 digits are corrected or superseded by this story
+
+### AC3: Auth verification flow uses the current email OTP contract
+
+- [x] `verifyEmailOtp(email, token)` verifies with the current Supabase email OTP type expected by the live flow
+- [x] `shared/supabase/auth.test.ts` asserts the exact `verifyOtp(...)` payload used by the client
+- [x] Existing stable UI error normalization remains intact (`invalid_otp`, `expired_otp`, `network_error`, `unknown_error`)
+
+### AC4: `/verify-email` screen uses a single 8-digit field
+
+- [x] `VerifyEmailScreen` uses one OTP `TextInput` / text field instead of per-digit cells
+- [x] The field accepts digits only and caps entry at 8 characters
+- [x] Full 8-digit paste works
+- [x] Entering the 8th digit triggers verification automatically
+- [x] The Confirm CTA stays disabled until exactly 8 digits are present
+- [x] Existing resend / error / success / wrong-email navigation states still work
+
+### AC5: Regression coverage and validation
+
+- [x] `features/auth/__tests__/VerifyEmailScreen.test.tsx` covers the new single-field 8-digit flow
+- [x] `shared/supabase/auth.test.ts` covers the aligned verification payload
+- [x] Targeted OTP tests pass
+- [x] `yarn lint`, `yarn typecheck`, and the relevant Jest coverage pass
+
+### AC6: Review workflow
+
+- [x] Dev review completed by a different model/agent with **0 comments / approved** before QA starts
+- [x] QA review runs only after dev approval and finishes approved
+
+## Technical Notes
+
+- Preserve current route and stack behavior from Story 6.18.
+- Keep resend cooldown persistence based on absolute expiry timestamps.
+- Prefer a centered, code-friendly single field over a generic left-aligned form input if that better matches the auth-screen layout.
+- Record any unavoidable production/dashboard follow-up separately if repo config and hosted config still need manual sync.
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Re-baseline the failing OTP contract** (AC2, AC3, AC5)
+  - [x] 1.1 Add/update failing tests for 8-digit verification input and the expected `verifyOtp(...)` payload
+  - [x] 1.2 Align local Supabase email OTP length config to 8 digits
+  - [x] 1.3 Reconfirm OTP error normalization coverage stays stable
+
+- [x] **Task 2: Replace the cell row with a single field** (AC1, AC4)
+  - [x] 2.1 Update Figma `OTP Verification` page first
+  - [x] 2.2 Refactor `VerifyEmailScreen` to a single centered OTP field
+  - [x] 2.3 Preserve resend, error, loading, and navigation states
+
+- [x] **Task 3: Validate the follow-up slice** (AC5)
+  - [x] 3.1 Run targeted OTP/auth tests
+  - [x] 3.2 Run lint + typecheck
+  - [x] 3.3 Run any broader Jest validation needed by touched auth files
+
+- [x] **Task 4: Review the fix in sequence** (AC6)
+  - [x] 4.1 Request dev review from a different model/agent
+  - [x] 4.2 Address review findings until approval with zero comments remaining
+  - [x] 4.3 Request QA review after dev approval
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Debug Log References
+
+- 2026-05-03: Follow-up story created after stakeholder reported the merged OTP flow as broken in production-style usage.
+- 2026-05-03: Existing Figma `OTP Verification` page updated first to replace the OTP cell row with a single 8-digit field across all approved states.
+- 2026-05-03: Investigation confirmed the repo still hardcoded 6 digits in UI/tests/docs and was still using the older verification contract.
+- 2026-05-03: Validation passed with targeted OTP/auth tests (70), full Jest suite (1320), `yarn lint`, and `yarn typecheck`.
+- 2026-05-03: First external review pass requested one substantive fix: allow formatted 8-digit paste values to sanitize correctly before auto-submit.
+- 2026-05-03: Second dev review returned `APPROVED`; QA review then requested only story/sprint tracking alignment to the real `review` phase.
+- 2026-05-03: Final QA review returned `APPROVED` after the story artifact and sprint tracking were aligned and the new story file was git-tracked.
+
+### Completion Notes List
+
+- Updated the existing Figma `OTP Verification` page first, replacing the OTP cell row with a single 8-digit field across all 20 light/dark state frames.
+- Switched local email OTP config to 8 digits and tightened the confirmation email OTP block styling for the longer token.
+- Refactored `VerifyEmailScreen` from per-digit cells to a single centered OTP field while preserving resend cooldown, error handling, and stack-reset navigation.
+- Aligned `verifyEmailOtp()` to the current email OTP verification payload and updated auth tests accordingly.
+- Added regression coverage for sequential entry, raw 8-digit paste, and formatted paste sanitization.
+- Dev review and QA review were both approved; stakeholder sign-off is now recorded and the story is marked `done` for handoff.
+
+### Change Log
+
+- 2026-05-03: Story created and moved directly to `in-progress` because stakeholder requested immediate follow-up implementation.
+- 2026-05-03: Figma page updated first per stakeholder instruction.
+- 2026-05-03: Updated local email OTP config, confirmation email styling, auth verification payload, and `VerifyEmailScreen` to the new 8-digit single-field flow.
+- 2026-05-03: Added OTP regression coverage, ran targeted + full validation, and addressed the first external review finding on formatted paste handling.
+- 2026-05-03: Moved the story artifact to `review` after dev approval and aligned tracking metadata to the latest validation run.
+- 2026-05-03: Recorded final QA approval after git-tracking the new story artifact and confirming sprint/story state alignment.
+- 2026-05-03: Recorded stakeholder approval, moved the follow-up to `done`, and prepared the change set for atomic commits + PR creation.
+
+### File List
+
+- `docs/sprint-artifacts/stories/6-18a-otp-verification-followup.md` — NEW: tracks the OTP single-field and 8-digit follow-up bugfix
+- `docs/sprint-artifacts/sprint-status.yaml` — MODIFIED: adds Story 6.18a to Sprint 14 tracking
+- `features/auth/VerifyEmailScreen.tsx` — MODIFIED: replaces the OTP cell row with a single centered 8-digit input and preserves existing verification states
+- `features/auth/__tests__/VerifyEmailScreen.test.tsx` — MODIFIED: updates the OTP component coverage for 8-digit entry, paste, and formatted paste sanitization
+- `shared/supabase/auth.ts` — MODIFIED: aligns email OTP verification to the current `verifyOtp(...)` payload
+- `shared/supabase/auth.test.ts` — MODIFIED: updates auth payload assertions and 8-digit OTP fixtures
+- `supabase/config.toml` — MODIFIED: sets email OTP length to 8 digits
+- `supabase/templates/confirmation.html` — MODIFIED: improves OTP token presentation for the longer code
+
+## Status
+
+done

--- a/features/auth/VerifyEmailScreen.tsx
+++ b/features/auth/VerifyEmailScreen.tsx
@@ -1,14 +1,7 @@
 import { MaterialIcons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Pressable,
-  Text,
-  TextInput,
-  TextInputKeyPressEventData,
-  NativeSyntheticEvent,
-  View
-} from 'react-native';
+import { Pressable, Text, TextInput, View } from 'react-native';
 
 import { isValidEmail } from '@/core/auth/validation';
 
@@ -18,7 +11,8 @@ import { useTheme } from '@/shared/theme';
 
 import { AuthLink, AuthScreenLayout, ErrorBanner } from './components';
 
-const OTP_LENGTH = 6;
+const OTP_LENGTH = 8;
+const OTP_INPUT_MAX_LENGTH = OTP_LENGTH * 2;
 const RESEND_COOLDOWN_MS = 60_000;
 const VERIFY_UNAVAILABLE_MESSAGE =
   "Couldn't verify right now. Check your connection and try again.";
@@ -31,8 +25,6 @@ const getSingleParam = (value: string | string[] | undefined): string | undefine
 
 const buildCooldownFlowKey = (email: string, sentAt: string | undefined) =>
   `${email}::${sentAt ?? 'initial'}`;
-
-const createEmptyDigits = () => Array.from({ length: OTP_LENGTH }, () => '');
 
 const formatCooldown = (remainingSeconds: number) => {
   const minutes = Math.floor(remainingSeconds / 60);
@@ -99,11 +91,11 @@ const VerifyEmailScreen = () => {
   const isEmailParamValid = isValidEmail(email);
   const cooldownFlowKey = useMemo(() => buildCooldownFlowKey(email, sentAt), [email, sentAt]);
 
-  const inputRefs = useRef<Array<TextInput | null>>([]);
+  const inputRef = useRef<TextInput | null>(null);
   const isVerifyingRef = useRef(false);
 
-  const [digits, setDigits] = useState<string[]>(createEmptyDigits);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [otpValue, setOtpValue] = useState('');
+  const [isOtpFocused, setIsOtpFocused] = useState(false);
   const [loading, setLoading] = useState(false);
   const [otpErrorMessage, setOtpErrorMessage] = useState<string | null>(null);
   const [bannerErrorMessage, setBannerErrorMessage] = useState<string | null>(null);
@@ -148,16 +140,30 @@ const VerifyEmailScreen = () => {
   }, [cooldownExpiresAt]);
 
   useEffect(() => {
-    inputRefs.current[0]?.focus();
+    inputRef.current?.focus();
   }, []);
 
   const remainingSeconds = useMemo(
     () => Math.max(0, Math.ceil((cooldownExpiresAt - now) / 1000)),
     [cooldownExpiresAt, now]
   );
-  const otpValue = digits.join('');
-  const isOtpComplete = /^\d{6}$/.test(otpValue);
+  const isOtpComplete = new RegExp(`^\\d{${OTP_LENGTH}}$`).test(otpValue);
   const resendDisabled = loading || remainingSeconds > 0;
+  const otpFieldBorderColor = otpErrorMessage
+    ? theme.error
+    : isOtpFocused
+      ? theme.primary
+      : otpValue.length > 0
+        ? theme.textSecondary
+        : theme.border;
+  const otpFieldBackgroundColor = loading
+    ? theme.backgroundSubtle
+    : otpErrorMessage
+      ? `${theme.error}14`
+      : isOtpFocused
+        ? `${theme.primary}14`
+        : theme.surfaceElevated;
+  const otpFieldBorderWidth = otpErrorMessage || isOtpFocused ? 2 : 1.5;
 
   const clearFeedback = useCallback(() => {
     setOtpErrorMessage(null);
@@ -165,14 +171,19 @@ const VerifyEmailScreen = () => {
     setSuccessMessage(null);
   }, []);
 
-  const focusInput = useCallback((index: number) => {
-    inputRefs.current[index]?.focus();
-    setActiveIndex(index);
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus();
+    setIsOtpFocused(true);
   }, []);
 
   const handleVerify = useCallback(
     async (code: string) => {
-      if (!isEmailParamValid || loading || isVerifyingRef.current || !/^\d{6}$/.test(code)) {
+      if (
+        !isEmailParamValid ||
+        loading ||
+        isVerifyingRef.current ||
+        !new RegExp(`^\\d{${OTP_LENGTH}}$`).test(code)
+      ) {
         return;
       }
 
@@ -214,74 +225,22 @@ const VerifyEmailScreen = () => {
     [clearFeedback, cooldownFlowKey, email, isEmailParamValid, loading, router]
   );
 
-  const commitDigits = useCallback(
-    (nextDigits: string[]) => {
-      setDigits(nextDigits);
-      const nextCode = nextDigits.join('');
-
-      if (/^\d{6}$/.test(nextCode)) {
-        void handleVerify(nextCode);
-      }
-    },
-    [handleVerify]
-  );
-
   const handleOtpChange = useCallback(
-    (index: number, value: string) => {
+    (value: string) => {
       if (loading) {
         return;
       }
 
-      const sanitized = value.replace(/\D/g, '');
+      const sanitized = value.replace(/\D/g, '').slice(0, OTP_LENGTH);
       clearFeedback();
 
-      if (!sanitized) {
-        const nextDigits = [...digits];
-        nextDigits[index] = '';
-        setDigits(nextDigits);
-        return;
+      setOtpValue(sanitized);
+
+      if (sanitized.length === OTP_LENGTH) {
+        void handleVerify(sanitized);
       }
-
-      const nextDigits = [...digits];
-
-      if (sanitized.length === 1) {
-        nextDigits[index] = sanitized;
-
-        if (index < OTP_LENGTH - 1) {
-          focusInput(index + 1);
-        }
-
-        commitDigits(nextDigits);
-        return;
-      }
-
-      sanitized
-        .slice(0, OTP_LENGTH - index)
-        .split('')
-        .forEach((digit, digitOffset) => {
-          nextDigits[index + digitOffset] = digit;
-        });
-
-      const lastFilledIndex = Math.min(index + sanitized.length - 1, OTP_LENGTH - 1);
-      focusInput(lastFilledIndex);
-      commitDigits(nextDigits);
     },
-    [clearFeedback, commitDigits, digits, focusInput, loading]
-  );
-
-  const handleOtpKeyPress = useCallback(
-    (index: number, event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
-      if (loading || event.nativeEvent.key !== 'Backspace' || digits[index] || index === 0) {
-        return;
-      }
-
-      clearFeedback();
-      const nextDigits = [...digits];
-      nextDigits[index - 1] = '';
-      setDigits(nextDigits);
-      focusInput(index - 1);
-    },
-    [clearFeedback, digits, focusInput, loading]
+    [clearFeedback, handleVerify, loading]
   );
 
   const handleResend = useCallback(async () => {
@@ -302,11 +261,11 @@ const VerifyEmailScreen = () => {
 
       const nextCooldownExpiresAt = Date.now() + RESEND_COOLDOWN_MS;
       resendCooldownExpiryByFlow.set(cooldownFlowKey, nextCooldownExpiresAt);
-      setDigits(createEmptyDigits());
+      setOtpValue('');
       setSuccessMessage(RESEND_SUCCESS_MESSAGE);
       setCooldownExpiresAt(nextCooldownExpiresAt);
       setNow(Date.now());
-      focusInput(0);
+      focusInput();
     } catch {
       setBannerErrorMessage(RESEND_FAILURE_MESSAGE);
     } finally {
@@ -322,64 +281,45 @@ const VerifyEmailScreen = () => {
     <AuthScreenLayout
       testID="verify-email-screen"
       heading="Verify your email"
-      subtitle={`We sent a 6-digit code to ${email}`}
+      subtitle={`We sent an 8-digit code to ${email}`}
       headingTestID="verify-email-title"
       subtitleTestID="verify-email-subtitle"
     >
       <View className="w-full" style={{ gap: spacing.md }}>
-        <View
-          className="w-full flex-row"
+        <TextInput
+          ref={inputRef}
+          testID="otp-input"
+          value={otpValue}
+          onChangeText={handleOtpChange}
+          onFocus={() => setIsOtpFocused(true)}
+          onBlur={() => setIsOtpFocused(false)}
+          editable={!loading}
+          keyboardType="number-pad"
+          textContentType="oneTimeCode"
+          autoComplete="one-time-code"
+          maxLength={OTP_INPUT_MAX_LENGTH}
+          selectTextOnFocus
+          placeholder="8-digit code"
+          placeholderTextColor={theme.textTertiary}
+          accessibilityLabel="8-digit verification code"
+          accessibilityHint="Enter the 8-digit code from your email"
+          accessibilityState={{ disabled: loading }}
           style={{
-            gap: spacing.sm,
-            justifyContent: 'space-between',
-            alignItems: 'center'
+            minHeight: 52,
+            borderRadius: 12,
+            borderWidth: otpFieldBorderWidth,
+            borderColor: otpFieldBorderColor,
+            backgroundColor: otpFieldBackgroundColor,
+            color: theme.textPrimary,
+            textAlign: 'center',
+            fontSize: 24,
+            lineHeight: 32,
+            fontWeight: '600',
+            letterSpacing: 1.5,
+            paddingHorizontal: spacing.md,
+            paddingVertical: 0
           }}
-        >
-          {digits.map((digit, index) => {
-            const borderColor = otpErrorMessage
-              ? theme.error
-              : activeIndex === index
-                ? theme.primary
-                : theme.border;
-
-            return (
-              <TextInput
-                key={`otp-cell-${index}`}
-                ref={(input) => {
-                  inputRefs.current[index] = input;
-                }}
-                testID={`otp-input-${index}`}
-                value={digit}
-                onChangeText={(value) => handleOtpChange(index, value)}
-                onKeyPress={(event) => handleOtpKeyPress(index, event)}
-                onFocus={() => setActiveIndex(index)}
-                editable={!loading}
-                keyboardType="number-pad"
-                textContentType="oneTimeCode"
-                autoComplete="one-time-code"
-                maxLength={OTP_LENGTH}
-                selectTextOnFocus
-                accessibilityLabel={`OTP digit ${index + 1}`}
-                accessibilityState={{ disabled: loading }}
-                style={{
-                  flex: 1,
-                  maxWidth: 40,
-                  minHeight: 52,
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor,
-                  backgroundColor: loading ? theme.backgroundSubtle : theme.surfaceElevated,
-                  color: theme.textPrimary,
-                  textAlign: 'center',
-                  fontSize: 28,
-                  lineHeight: 32,
-                  fontWeight: '600',
-                  paddingVertical: 0
-                }}
-              />
-            );
-          })}
-        </View>
+        />
 
         {otpErrorMessage ? <StatusNotice message={otpErrorMessage} tone="error" /> : null}
 

--- a/features/auth/__tests__/VerifyEmailScreen.test.tsx
+++ b/features/auth/__tests__/VerifyEmailScreen.test.tsx
@@ -69,16 +69,15 @@ describe('VerifyEmailScreen', () => {
     jest.useRealTimers();
   });
 
-  it('renders the email subtitle and six OTP cells', () => {
+  it('renders the email subtitle and single OTP field', () => {
     render(<VerifyEmailScreen />);
 
     expect(screen.getByText('Verify your email')).toBeTruthy();
-    expect(screen.getByText('We sent a 6-digit code to test@example.com')).toBeTruthy();
-    expect(screen.getByTestId('otp-input-0')).toBeTruthy();
-    expect(screen.getByTestId('otp-input-5')).toBeTruthy();
+    expect(screen.getByText('We sent an 8-digit code to test@example.com')).toBeTruthy();
+    expect(screen.getByTestId('otp-input')).toBeTruthy();
   });
 
-  it('auto-submits on the sixth digit and navigates home on success', async () => {
+  it('auto-submits on the eighth digit and navigates home on success', async () => {
     mockVerifyEmailOtp.mockResolvedValue({
       success: true,
       data: { user: { id: 'u1' }, session: { access_token: 'token' } }
@@ -86,21 +85,25 @@ describe('VerifyEmailScreen', () => {
 
     render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '1');
-    fireEvent.changeText(screen.getByTestId('otp-input-1'), '2');
-    fireEvent.changeText(screen.getByTestId('otp-input-2'), '3');
-    fireEvent.changeText(screen.getByTestId('otp-input-3'), '4');
-    fireEvent.changeText(screen.getByTestId('otp-input-4'), '5');
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '6');
+    const input = screen.getByTestId('otp-input');
+
+    fireEvent.changeText(input, '1');
+    fireEvent.changeText(input, '12');
+    fireEvent.changeText(input, '123');
+    fireEvent.changeText(input, '1234');
+    fireEvent.changeText(input, '12345');
+    fireEvent.changeText(input, '123456');
+    fireEvent.changeText(input, '1234567');
+    fireEvent.changeText(input, '12345678');
 
     await waitFor(() => {
-      expect(mockVerifyEmailOtp).toHaveBeenCalledWith('test@example.com', '123456');
+      expect(mockVerifyEmailOtp).toHaveBeenCalledWith('test@example.com', '12345678');
       expect(mockDismissTo).toHaveBeenCalledWith('/');
       expect(mockReplace).toHaveBeenCalledWith('/');
     });
   });
 
-  it('accepts a full 6-digit paste and auto-submits', async () => {
+  it('accepts a full 8-digit paste and auto-submits', async () => {
     mockVerifyEmailOtp.mockResolvedValue({
       success: true,
       data: { user: { id: 'u1' }, session: { access_token: 'token' } }
@@ -108,10 +111,25 @@ describe('VerifyEmailScreen', () => {
 
     render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '654321');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '87654321');
 
     await waitFor(() => {
-      expect(mockVerifyEmailOtp).toHaveBeenCalledWith('test@example.com', '654321');
+      expect(mockVerifyEmailOtp).toHaveBeenCalledWith('test@example.com', '87654321');
+    });
+  });
+
+  it('sanitizes a formatted 8-digit paste before auto-submitting', async () => {
+    mockVerifyEmailOtp.mockResolvedValue({
+      success: true,
+      data: { user: { id: 'u1' }, session: { access_token: 'token' } }
+    });
+
+    render(<VerifyEmailScreen />);
+
+    fireEvent.changeText(screen.getByTestId('otp-input'), '1234 5678');
+
+    await waitFor(() => {
+      expect(mockVerifyEmailOtp).toHaveBeenCalledWith('test@example.com', '12345678');
     });
   });
 
@@ -123,18 +141,13 @@ describe('VerifyEmailScreen', () => {
 
     render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '1');
-    fireEvent.changeText(screen.getByTestId('otp-input-1'), '2');
-    fireEvent.changeText(screen.getByTestId('otp-input-2'), '3');
-    fireEvent.changeText(screen.getByTestId('otp-input-3'), '4');
-    fireEvent.changeText(screen.getByTestId('otp-input-4'), '5');
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '6');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '12345678');
 
     await waitFor(() => {
       expect(screen.getByText('Incorrect code. Please try again.')).toBeTruthy();
     });
 
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '1234567');
 
     await waitFor(() => {
       expect(screen.queryByText('Incorrect code. Please try again.')).toBeNull();
@@ -150,12 +163,7 @@ describe('VerifyEmailScreen', () => {
 
     render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '1');
-    fireEvent.changeText(screen.getByTestId('otp-input-1'), '2');
-    fireEvent.changeText(screen.getByTestId('otp-input-2'), '3');
-    fireEvent.changeText(screen.getByTestId('otp-input-3'), '4');
-    fireEvent.changeText(screen.getByTestId('otp-input-4'), '5');
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '6');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '12345678');
 
     await waitFor(() => {
       expect(screen.getByText('This code has expired. Please request a new one.')).toBeTruthy();
@@ -177,12 +185,7 @@ describe('VerifyEmailScreen', () => {
 
     const view = render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '1');
-    fireEvent.changeText(screen.getByTestId('otp-input-1'), '2');
-    fireEvent.changeText(screen.getByTestId('otp-input-2'), '3');
-    fireEvent.changeText(screen.getByTestId('otp-input-3'), '4');
-    fireEvent.changeText(screen.getByTestId('otp-input-4'), '5');
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '6');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '12345678');
 
     await waitFor(() => {
       expect(screen.getByText('This code has expired. Please request a new one.')).toBeTruthy();
@@ -204,12 +207,7 @@ describe('VerifyEmailScreen', () => {
 
     render(<VerifyEmailScreen />);
 
-    fireEvent.changeText(screen.getByTestId('otp-input-0'), '1');
-    fireEvent.changeText(screen.getByTestId('otp-input-1'), '2');
-    fireEvent.changeText(screen.getByTestId('otp-input-2'), '3');
-    fireEvent.changeText(screen.getByTestId('otp-input-3'), '4');
-    fireEvent.changeText(screen.getByTestId('otp-input-4'), '5');
-    fireEvent.changeText(screen.getByTestId('otp-input-5'), '6');
+    fireEvent.changeText(screen.getByTestId('otp-input'), '12345678');
 
     await waitFor(() => {
       expect(

--- a/shared/supabase/auth.test.ts
+++ b/shared/supabase/auth.test.ts
@@ -405,12 +405,12 @@ describe('verifyEmailOtp', () => {
       error: null
     });
 
-    const result = await verifyEmailOtp('test@example.com', '123456');
+    const result = await verifyEmailOtp('test@example.com', '12345678');
 
     expect(mockVerifyOtp).toHaveBeenCalledWith({
       email: 'test@example.com',
-      token: '123456',
-      type: 'signup'
+      token: '12345678',
+      type: 'email'
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -425,7 +425,7 @@ describe('verifyEmailOtp', () => {
       error: { message: 'Token is invalid or has expired', code: 'otp_invalid' }
     });
 
-    const result = await verifyEmailOtp('test@example.com', '000000');
+    const result = await verifyEmailOtp('test@example.com', '00000000');
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -439,7 +439,7 @@ describe('verifyEmailOtp', () => {
       error: { message: 'Token has expired', code: 'otp_expired' }
     });
 
-    const result = await verifyEmailOtp('test@example.com', '123456');
+    const result = await verifyEmailOtp('test@example.com', '12345678');
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -450,7 +450,7 @@ describe('verifyEmailOtp', () => {
   it('returns network_error when verification throws for connectivity issues', async () => {
     mockVerifyOtp.mockRejectedValue(new Error('Network request failed'));
 
-    const result = await verifyEmailOtp('test@example.com', '123456');
+    const result = await verifyEmailOtp('test@example.com', '12345678');
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -464,7 +464,7 @@ describe('verifyEmailOtp', () => {
       error: { message: 'OTP verification unavailable', code: 'provider_down' }
     });
 
-    const result = await verifyEmailOtp('test@example.com', '123456');
+    const result = await verifyEmailOtp('test@example.com', '12345678');
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/shared/supabase/auth.ts
+++ b/shared/supabase/auth.ts
@@ -217,7 +217,7 @@ export const verifyEmailOtp = async (
     const { data, error } = await supabase.auth.verifyOtp({
       email,
       token,
-      type: 'signup'
+      type: 'email'
     });
 
     if (error) {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -212,7 +212,7 @@ secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.
-otp_length = 6
+otp_length = 8
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -18,7 +18,7 @@
             </tr>
             <tr>
               <td align="center" style="padding: 0 32px 32px;">
-                <div style="display: inline-flex; align-items: center; justify-content: center; width: 100%; max-width: 320px; padding: 24px 0; background: #111827; color: #ffffff; font-size: 42px; font-weight: 700; letter-spacing: 0.24em; border-radius: 20px;">
+                <div style="display: inline-flex; align-items: center; justify-content: center; width: 100%; max-width: 360px; padding: 22px 16px; background: #111827; color: #ffffff; font-size: 36px; font-weight: 700; letter-spacing: 0.18em; font-variant-numeric: tabular-nums; border-radius: 20px; box-sizing: border-box;">
                   {{ .Token }}
                 </div>
               </td>


### PR DESCRIPTION
## Summary
- align email OTP verification to the approved 8-digit single-field flow from Story 6.18a
- update Supabase email OTP config/template plus auth/test coverage to match the current verification contract
- add the required release-workflow `.env` setup so Expo prebuild jobs receive `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_KEY`

## What changed
- replaced the 6-cell OTP UI with a centered single `otp-input` that sanitizes formatted paste and auto-submits on the 8th digit
- switched `verifyEmailOtp()` to the current email OTP payload and updated related tests/fixtures
- moved Story `6-18a-otp-verification-followup` and `docs/sprint-artifacts/sprint-status.yaml` to `done` after stakeholder approval
- updated `android-release.yml`, `ios-release.yml`, and `store-upload.yml` to create `.env` from GitHub secrets before Expo prebuild

## Acceptance criteria
- [x] Figma follow-up applied first for the OTP Verification page
- [x] app flow accepts and verifies the 8-digit OTP in a single field
- [x] Supabase email OTP config/template align to 8 digits
- [x] sprint/story tracking updated after stakeholder approval
- [x] workflow YAML changes included as requested

## Validation
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` — 141 suites / 1317 tests passed (pre-push hook on 2026-05-03)

## Review status
- [x] dev review approved in-session
- [x] QA review approved in-session