### PR TITLE
feat: open-source contribution infrastructure & story-status automation (Story 11.7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: 🐛 Bug Report
+description: Report something that isn't working so we can fix it.
+title: '[Bug]: '
+labels: ['bug', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! 🙏
+        Please search [existing issues](https://github.com/ifero/myLoyaltyCards/issues) first to avoid duplicates.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I can reproduce this on the latest version of the app.
+          required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform(s)
+      description: Where does the bug happen?
+      multiple: true
+      options:
+        - iOS (phone)
+        - Android (phone)
+        - Apple Watch (watchOS)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      placeholder: e.g. 1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: device-os
+    attributes:
+      label: Device & OS version
+      placeholder: e.g. iPhone 15 Pro · iOS 18.2 — Apple Watch Series 9 · watchOS 11
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: media
+    attributes:
+      label: Screenshots / screen recording
+      description: |
+        Drag & drop images or videos here — they help a lot.
+        📍 For Apple Watch sync issues, Console.app logs from a physical device are especially valuable (watch sync must be verified on a real device, not just by code review).
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any console output or stack traces.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/catalogue_request.yml
+++ b/.github/ISSUE_TEMPLATE/catalogue_request.yml
@@ -1,0 +1,66 @@
+name: 🏷️ Brand Catalogue Request
+description: Request a new brand (or a correction) in the loyalty-card catalogue.
+title: '[Catalogue]: '
+labels: ['catalogue']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us grow coverage across the EU! 🌍
+        Adding a brand yourself is the lightest way to contribute — see [Contributing Brand Catalogue Entries](https://github.com/ifero/myLoyaltyCards/blob/main/CONTRIBUTING.md#contributing-brand-catalogue-entries). Or just fill this in and we'll take care of it.
+
+  - type: input
+    id: brand
+    attributes:
+      label: Brand / retailer name
+      placeholder: e.g. Esselunga
+    validations:
+      required: true
+
+  - type: input
+    id: country
+    attributes:
+      label: Country
+      description: Which country's catalogue does this belong to?
+      placeholder: e.g. Italy
+    validations:
+      required: true
+
+  - type: input
+    id: website
+    attributes:
+      label: Official website (optional)
+      placeholder: https://...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: barcode-format
+    attributes:
+      label: Barcode format (if known)
+      options:
+        - Not sure
+        - CODE128
+        - EAN13
+        - EAN8
+        - QR
+        - CODE39
+        - UPCA
+    validations:
+      required: false
+
+  - type: textarea
+    id: logo
+    attributes:
+      label: Logo
+      description: If you can, attach the brand logo or link to an official asset (drag & drop here).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Would you like to contribute this yourself?
+      options:
+        - label: I'd like to open a PR adding this entry to `catalogue/` (we'll guide you!).
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Read the Contributing Guide first
+    url: https://github.com/ifero/myLoyaltyCards/blob/main/CONTRIBUTING.md
+    about: This project is spec-first (BMAD SDD). See how features, fixes, and catalogue entries flow before opening an issue.
+  - name: 💬 Questions & Discussions
+    url: https://github.com/ifero/myLoyaltyCards/discussions
+    about: Have a question or want to discuss an idea before it becomes a feature request? Start here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: 💡 Feature Request
+description: Suggest an idea or improvement.
+title: '[Feature]: '
+labels: ['enhancement', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea! 💡
+
+        ℹ️ **How features work here:** myLoyaltyCards is spec-first (BMAD SDD). New capabilities enter through **planning** (PRD / epic) before a story is created and implemented — so this request is the start of a conversation, **not** a direct PR. See the [Contributing Guide](https://github.com/ifero/myLoyaltyCards/blob/main/CONTRIBUTING.md#the-bmad-sdd-methodology).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and discussions and this isn't already proposed.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Focus on the user problem / job-to-be-done, not the implementation.
+      placeholder: "When I'm at the checkout, I can't ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Which platform(s) would this affect?
+      multiple: true
+      options:
+        - iOS (phone)
+        - Android (phone)
+        - Apple Watch (watchOS)
+        - Wear OS (planned)
+        - All / cross-platform
+    validations:
+      required: false
+
+  - type: textarea
+    id: mockups
+    attributes:
+      label: Mockups / screenshots / references
+      description: Drag & drop any sketches, screenshots, or links that illustrate the idea.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,70 @@
+<!--
+  Thanks for contributing to myLoyaltyCards! 🎉
+  This project is spec-first (BMAD SDD): every code change traces back to a story.
+  Please read CONTRIBUTING.md before opening this PR.
+
+  Title format:  <type>(<scope>): <summary> (Story X.Y)
+  Example:       feat(watch): render barcode complication (Story 5.9)
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? 1–3 sentences. -->
+
+## Related story / issue
+
+<!-- Code PRs must reference a `ready-for-dev` story. Catalogue-only PRs may reference an issue instead. -->
+
+- Story: `docs/sprint-artifacts/stories/<id>.md`
+- Closes #
+
+## Type of change
+
+- [ ] ✨ `feat` — new feature
+- [ ] 🐛 `fix` — bug fix
+- [ ] ♻️ `refactor` — no behavior change
+- [ ] 📝 `docs` — documentation / specs
+- [ ] ✅ `test` — tests only
+- [ ] 🔧 `chore` — tooling / maintenance
+- [ ] 🏷️ `catalogue` — brand catalogue entry
+
+## Acceptance criteria
+
+<!-- Copy the story's acceptance criteria and tick the ones this PR satisfies. -->
+
+- [ ] AC1 —
+- [ ] AC2 —
+
+## Screenshots / screen recordings
+
+<!--
+  REQUIRED for any user-visible change. Drag & drop images or videos below.
+  Include the Apple Watch as well as the phone where relevant, and both light & dark mode.
+  If this is not a UI change, tick the box and delete the table.
+-->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+- [ ] Not a user-visible change (no screenshots needed)
+
+## How was this tested?
+
+<!-- Manual steps, devices/simulators used, and automated test summary. -->
+
+- Test results:
+- Coverage (if relevant):
+
+## Author checklist
+
+- [ ] A `ready-for-dev` story exists and its acceptance criteria are met
+- [ ] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally (I did **not** use `--no-verify`)
+- [ ] New behavior has co-located tests; coverage is not regressed
+- [ ] Follows the layer boundaries & rules in `docs/project_context.md` and `AGENTS.md`
+- [ ] `docs/sprint-artifacts/sprint-status.yaml` and the story file are updated
+- [ ] I performed a self-review of my own changes
+
+---
+
+> 🔍 A maintainer reviews and merges — **please don't merge your own PR.** After merge, the story moves to `done`.

--- a/.github/workflows/mark-story-done.yml
+++ b/.github/workflows/mark-story-done.yml
@@ -1,0 +1,78 @@
+name: Mark story done after merge
+
+# When a PR is merged, this reads the story it references and commits the status
+# update (sprint-status.yaml + the story file) straight to the default branch.
+# The commit is tagged [skip ci] so it does not re-trigger any pipelines.
+# Works for fork PRs too, since the commit lands on the base repo's branch.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write # push the status commit to the default branch
+  pull-requests: write # comment on the merged PR
+
+# Serialize so concurrent merges don't race on the default branch.
+concurrency:
+  group: mark-story-done-after-merge
+  cancel-in-progress: false
+
+jobs:
+  mark-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          # GITHUB_TOKEN is enough for an unprotected default branch. If the branch
+          # is protected against direct pushes, provide a STORY_BOT_TOKEN secret
+          # (PAT or App token) that is allowed to bypass the rule.
+          token: ${{ secrets.STORY_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Mark story done in sprint-status & story file
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/mark-story-done.mjs
+
+      - name: Commit & push status update
+        id: commit
+        run: |
+          if [ -z "$(git status --porcelain -- docs/sprint-artifacts)" ]; then
+            echo "No story status changes to commit."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/sprint-artifacts/sprint-status.yaml docs/sprint-artifacts/stories
+          git commit -m "chore(sprint): mark story done after merge [skip ci]"
+          git push origin "HEAD:${{ github.event.pull_request.base.ref }}"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          OUTCOME: ${{ steps.commit.outcome }}
+          COMMITTED: ${{ steps.commit.outputs.committed }}
+        run: |
+          if [ "$OUTCOME" = "success" ] && [ "$COMMITTED" = "true" ]; then
+            gh pr comment "$PR" \
+              --body "✅ Story marked **done** on \`${{ github.event.pull_request.base.ref }}\` (\`sprint-status.yaml\` + story file) in a \`[skip ci]\` follow-up commit."
+          elif [ "$OUTCOME" = "success" ]; then
+            gh pr comment "$PR" \
+              --body "ℹ️ No story status change applied — either it was already \`done\`, or no story could be matched. Link a \`docs/sprint-artifacts/stories/<id>.md\` story in the PR body or end the title with \`(Story X.Y)\`."
+          else
+            gh pr comment "$PR" \
+              --body "⚠️ Could not push the story status update to \`${{ github.event.pull_request.base.ref }}\`. If the branch is protected against direct pushes, add a \`STORY_BOT_TOKEN\` secret allowed to bypass it. See the workflow run logs."
+          fi

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,0 +1,34 @@
+name: PR conventions
+
+# Fails the PR if it doesn't follow the machine-checkable rules in CONTRIBUTING.md:
+# Conventional Commit title, branch naming, and a spec-first story reference for
+# code changes (docs:/chore: titles and catalogue PRs are exempt).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    # Skip drafts and bot PRs (e.g. Dependabot).
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Validate PR against CONTRIBUTING rules
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: node scripts/check-pr-conventions.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,11 +236,14 @@ feat(watch): render barcode complication on the watch face (Story 5.9)
 
 Quality is enforced at three levels. **All must pass — bypassing them is forbidden.**
 
-| Gate           | When                      | What runs                                                 |
-| -------------- | ------------------------- | --------------------------------------------------------- |
-| **pre-commit** | `git commit`              | `lint-staged` → ESLint `--fix` + Prettier on staged files |
-| **pre-push**   | `git push`                | `yarn typecheck` → `yarn lint` → `yarn test`              |
-| **CI**         | every PR & push to `main` | `lint` → `typecheck` → `test:coverage` (+ watchOS tests)  |
+| Gate                    | When                      | What runs                                                                            |
+| ----------------------- | ------------------------- | ------------------------------------------------------------------------------------ |
+| **pre-commit**          | `git commit`              | `lint-staged` → ESLint `--fix` + Prettier on staged files                            |
+| **pre-push**            | `git push`                | `yarn typecheck` → `yarn lint` → `yarn test`                                         |
+| **CI — quality**        | every PR & push to `main` | `lint` → `typecheck` → `test:coverage` (+ watchOS tests)                             |
+| **CI — PR conventions** | every PR                  | Conventional-Commit title, branch naming, and spec-first story link (see note below) |
+
+The **PR conventions** check ([`pr-conventions.yml`](.github/workflows/pr-conventions.yml)) fails the PR if the title isn't a Conventional Commit, the branch doesn't use an allowed prefix, or a **code change** references no story. `docs:`/`chore:` titles and catalogue PRs are exempt from the story requirement.
 
 🚫 **`--no-verify` is strictly forbidden** for both `git commit` and `git push`. If a hook fails:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,378 @@
+# Contributing to myLoyaltyCards
+
+Thank you for your interest in contributing! 🎉 myLoyaltyCards is a community-driven, open-source project with no monetization — it grows through code, brand-catalogue additions, bug reports, and ideas from people like you.
+
+This project is built **spec-first** using the [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) **Spec-Driven Development (SDD)** methodology. Contributing here is a little different from a typical "fork and PR" project: **work follows a spec, and every code change traces back to a documented story.** This guide explains exactly how to do that.
+
+> **The golden rule:** No production code is written without a spec. Before you write code, there must be a **story** (for changes inside an existing epic) or, for genuinely new scope, a planning artifact (PRD/epic) that the story derives from. This is non-negotiable and is what keeps the codebase coherent, testable, and contribution-friendly.
+
+---
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [The BMAD SDD Methodology](#the-bmad-sdd-methodology)
+- [Where the Specs Live](#where-the-specs-live)
+- [Local Setup](#local-setup)
+- [The Contribution Workflow (step by step)](#the-contribution-workflow-step-by-step)
+- [Branching Conventions](#branching-conventions)
+- [Commit Conventions](#commit-conventions)
+- [Quality Gates (never bypass)](#quality-gates-never-bypass)
+- [Coding Standards](#coding-standards)
+- [Code Review & Pull Requests](#code-review--pull-requests)
+- [Contributing Brand Catalogue Entries](#contributing-brand-catalogue-entries)
+- [Reporting Bugs & Requesting Features](#reporting-bugs--requesting-features)
+- [Using the BMAD Agents](#using-the-bmad-agents)
+- [Quick Reference](#quick-reference)
+
+---
+
+## Code of Conduct
+
+Be respectful, constructive, and inclusive. This is a hobby project maintained in people's spare time — assume good intent, keep discussions focused on the work, and welcome newcomers. Harassment or hostile behavior is not tolerated.
+
+---
+
+## Ways to Contribute
+
+| Contribution                 | Path                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 🐛 **Bug report**            | Open a GitHub issue (see [Reporting Bugs](#reporting-bugs--requesting-features)).                      |
+| 💡 **Feature idea**          | Open a GitHub issue/discussion. New features enter through **planning**, not a direct PR.              |
+| 🏷️ **Brand catalogue entry** | The lightest path — see [Contributing Brand Catalogue Entries](#contributing-brand-catalogue-entries). |
+| 💻 **Code change**           | Must follow the [SDD workflow](#the-contribution-workflow-step-by-step) below.                         |
+| 📝 **Docs / specs**          | Same SDD workflow, using a `docs/` story or a `docs:` change.                                          |
+
+---
+
+## The BMAD SDD Methodology
+
+BMAD is installed under [`_bmad/`](_bmad/) (v6.0.4: modules `core`, `bmm`, `bmb`, `cis`, `tea`). It drives the project through **four phases**, each owned by a specialized agent and producing a tangible artifact:
+
+```
+Phase 0 — Discovery        (optional)
+  Analyst:    brainstorming · research · product brief
+
+Phase 1 — Planning
+  PM:          PRD              → docs/prd.md            (Functional & Non-Functional Requirements)
+  UX Designer: UX design        → docs/ux-design-specification.md
+
+Phase 2 — Solutioning
+  Architect:   Architecture     → docs/architecture.md
+  PM:          Epics & Stories  → docs/epics.md
+  Test Arch.:  Test design      → docs/test-design-system.md
+  Architect:   Implementation Readiness gate → docs/implementation-readiness-report-*.md
+
+Phase 3 — Implementation        (this is where most contributions happen)
+  Scrum Master: Sprint planning  → docs/sprint-artifacts/sprint-status.yaml
+  Scrum Master: Create story      → docs/sprint-artifacts/stories/<id>.md
+  Dev:          Implement story   (code + tests)
+  Dev/QA:       Code review
+  Maintainer:   Merge PR
+  Team:         Retrospective     → docs/sprint-artifacts/epic-*-retro-*.md
+```
+
+**Why this matters for you as a contributor:**
+
+- A **small change inside an existing epic** (bug fix, refinement, an already-planned story) → you work in **Phase 3**: create/claim a story, implement it, and PR.
+- A **brand-new capability** (new screen, new platform behavior, new requirement) → it must first be reflected in **Planning/Solutioning** (PRD/epic) before a story can be drafted. Open an issue to discuss scope; a maintainer (or you, with the PM/Architect agents) updates the relevant spec, then a story is created.
+
+This prevents "drive-by" features that don't fit the architecture and keeps every PR reviewable against clear, pre-agreed acceptance criteria.
+
+---
+
+## Where the Specs Live
+
+| Artifact                                     | Location                                                                               | Phase |
+| -------------------------------------------- | -------------------------------------------------------------------------------------- | ----- |
+| Product Requirements (PRD)                   | [`docs/prd.md`](docs/prd.md)                                                           | 1     |
+| UX Design                                    | [`docs/ux-design-specification.md`](docs/ux-design-specification.md)                   | 1     |
+| Architecture                                 | [`docs/architecture.md`](docs/architecture.md)                                         | 2     |
+| Epics & stories breakdown                    | [`docs/epics.md`](docs/epics.md)                                                       | 2     |
+| Test design                                  | [`docs/test-design-system.md`](docs/test-design-system.md)                             | 2     |
+| Enforced implementation rules                | [`docs/project_context.md`](docs/project_context.md)                                   | —     |
+| Sprint status (source of truth for progress) | [`docs/sprint-artifacts/sprint-status.yaml`](docs/sprint-artifacts/sprint-status.yaml) | 3     |
+| Individual story specs                       | [`docs/sprint-artifacts/stories/`](docs/sprint-artifacts/stories/)                     | 3     |
+| Agent operating rules                        | [`AGENTS.md`](AGENTS.md)                                                               | —     |
+
+Read [`docs/project_context.md`](docs/project_context.md) and [`AGENTS.md`](AGENTS.md) **before writing any code** — they contain the rules CI and reviewers enforce.
+
+---
+
+## Local Setup
+
+See the [README — Getting Started](README.md#getting-started) for prerequisites (Node 24, Yarn, Ruby 4.0.5, Xcode/Android Studio) and install/run commands. In short:
+
+```bash
+git clone https://github.com/ifero/myLoyaltyCards.git
+cd myLoyaltyCards
+yarn install
+cp .env.example .env   # fill in values
+yarn ios               # or: yarn android / yarn start
+```
+
+---
+
+## The Contribution Workflow (step by step)
+
+Follow these steps for any **code or docs** contribution. Steps 1–2 are the SDD part; steps 3–9 are the implementation loop.
+
+### 1. Find or define the work
+
+- **Browse existing stories** in [`docs/sprint-artifacts/stories/`](docs/sprint-artifacts/stories/) and the current sprint in [`sprint-status.yaml`](docs/sprint-artifacts/sprint-status.yaml). If a story already exists for what you want to do, comment on the related issue/PR to claim it.
+- **New scope?** Open a GitHub issue describing the problem and proposed change. A maintainer will confirm whether it fits the current epics or needs a planning update (PRD/epic) first. **Do not start coding new scope before this is agreed.**
+
+### 2. Make sure a story exists (spec-first gate)
+
+Every implementation needs a story file in `docs/sprint-artifacts/stories/<epic>-<n>-<slug>.md` containing, at minimum:
+
+- **Status** (`drafted` → `ready-for-dev` before dev starts)
+- **Story** (the user-facing goal)
+- **Context** (links to PRD/epic/architecture sections)
+- **Acceptance Criteria** (testable ACs — `AC1`, `AC2`, …)
+- **Tasks / Subtasks** (mapped to ACs)
+- **Tech Notes** and a **Definition of Ready** checklist
+
+Create it with the Scrum Master agent (`create-story`) or by copying the structure of a recent story. A story must be **`ready-for-dev`** (acceptance criteria approved) before implementation begins.
+
+### 3. Create a branch
+
+Branch from `main` using the [naming convention](#branching-conventions):
+
+```bash
+git checkout main && git pull
+git checkout -b feature/5-9-watch-complication
+```
+
+### 4. Implement the story
+
+- Implement **only what the story's acceptance criteria require** — keep scope tight.
+- Follow [`docs/project_context.md`](docs/project_context.md) and [`AGENTS.md`](AGENTS.md): layer boundaries, Zod-as-source-of-truth, client-side UUIDs, ISO-8601 UTC dates, transactional DB writes, the `logger` wrapper, etc.
+- **Add/extend tests** co-located with the source (`Foo.tsx` → `Foo.test.tsx`). New behavior needs new tests.
+- For libraries, consult the official docs (Context7 / Expo docs) and install with `npx expo install <pkg>` — **not** `yarn add` — for Expo-managed packages.
+
+### 5. Keep commits atomic and conventional
+
+Commit small, logical units using [Conventional Commits](#commit-conventions). Reference the story where relevant.
+
+### 6. Pass the quality gates locally
+
+The pre-push hook runs them automatically, but you can run them yourself:
+
+```bash
+yarn lint
+yarn typecheck
+yarn test           # or: yarn test:all  (includes watchOS tests)
+```
+
+**Never use `--no-verify`.** If a gate fails, fix it.
+
+### 7. Update sprint status
+
+Update [`sprint-status.yaml`](docs/sprint-artifacts/sprint-status.yaml) to move the story to `review`, and reflect progress in the story file.
+
+### 8. Request a code review
+
+Push your branch and request review. The project favors a **fresh-context review** (a different reviewer/agent than the author) against the [review checklist](#code-review--pull-requests). Address feedback with focused follow-up commits and re-request review until approved.
+
+### 9. Open the Pull Request
+
+Open a PR following the [PR requirements](#code-review--pull-requests). **Do not merge your own PR** — a maintainer reviews and merges. After merge, the story is marked `done`; once an epic completes, a retrospective is run.
+
+---
+
+## Branching Conventions
+
+Branch from `main` with a descriptive, prefixed name. Where a story exists, include its id:
+
+```
+feature/<story-id>-<short-description>     # new feature / planned story
+fix/<short-description>                     # bug fix
+refactor/<short-description>                # behavior-preserving refactor
+docs/<short-description>                     # documentation / specs
+
+# examples
+feature/5-9-watch-complication
+fix/barcode-scanner-crash
+docs/contributing-guide
+```
+
+| Prefix      | Use for                             |
+| ----------- | ----------------------------------- |
+| `feature/`  | New features or planned stories     |
+| `fix/`      | Bug fixes                           |
+| `refactor/` | Refactors with no functional change |
+| `docs/`     | Documentation & spec updates        |
+
+---
+
+## Commit Conventions
+
+Use **[Conventional Commits](https://www.conventionalcommits.org/)**. Each commit should be small, focused, and self-contained.
+
+```
+<type>(<scope>): <short summary>
+
+- what changed and why
+- acceptance criteria addressed (e.g. AC2)
+```
+
+**Allowed types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+
+Example:
+
+```
+feat(watch): render barcode complication on the watch face (Story 5.9)
+
+- add ComplicationProvider entry for the active card
+- map card color to complication tint
+- covers AC1, AC2
+```
+
+---
+
+## Quality Gates (never bypass)
+
+Quality is enforced at three levels. **All must pass — bypassing them is forbidden.**
+
+| Gate           | When                      | What runs                                                 |
+| -------------- | ------------------------- | --------------------------------------------------------- |
+| **pre-commit** | `git commit`              | `lint-staged` → ESLint `--fix` + Prettier on staged files |
+| **pre-push**   | `git push`                | `yarn typecheck` → `yarn lint` → `yarn test`              |
+| **CI**         | every PR & push to `main` | `lint` → `typecheck` → `test:coverage` (+ watchOS tests)  |
+
+🚫 **`--no-verify` is strictly forbidden** for both `git commit` and `git push`. If a hook fails:
+
+1. Read the error.
+2. Fix the underlying issue (lint, type error, failing test).
+3. Re-run the command.
+
+Do not bypass gates "just this once" — CI will fail anyway, and it keeps shared branches green for everyone.
+
+---
+
+## Coding Standards
+
+The authoritative rules are in [`docs/project_context.md`](docs/project_context.md) and [`AGENTS.md`](AGENTS.md). Highlights:
+
+- **TypeScript, strict mode** for all new code. No `any` escapes without justification.
+- **`const` arrow functions** everywhere (including exported/async) — no `function` declarations.
+- **Layer boundaries** (ESLint-enforced): `app → features → shared → core` (+ `catalogue`). No cross-feature imports, no `core → features` imports.
+- **Route files re-export only** — no `useState`/`useEffect`/business logic in `app/`.
+- **Zod schemas are the source of truth** for data types.
+- **Client-side UUIDs**, **ISO-8601 UTC** date strings, **all JSON fields present** (`null`, never omitted).
+- **Transactional DB writes** (`withTransactionAsync`); use the `logger` wrapper, not `console.log`.
+- **Tests co-located** with source; cross-platform fixtures live in `test-fixtures/`.
+- **Apple Watch is read-only** — never add mutation paths to the watch.
+- **UI:** respect safe-area insets for edge controls; avoid `Pressable` `style={({pressed}) => …}` callbacks (use `onPressIn`/`onPressOut` + state) — see `AGENTS.md` for the rationale.
+
+Run `yarn lint` and `yarn typecheck` to catch most violations automatically.
+
+---
+
+## Code Review & Pull Requests
+
+### Before opening a PR
+
+- [ ] A `ready-for-dev` story exists and its acceptance criteria are met.
+- [ ] `yarn lint`, `yarn typecheck`, and `yarn test` all pass locally.
+- [ ] New behavior has tests; coverage is not regressed.
+- [ ] `sprint-status.yaml` and the story file are updated.
+
+### PR description must include
+
+- **Title:** `feat(scope): description (Story X.Y)` (or appropriate type).
+- **Summary** of the changes.
+- **Acceptance-criteria checklist** with completed items checked.
+- **Test results** (counts / coverage where relevant).
+- **Link** to the story and to any review approval.
+
+### Reviewer checklist
+
+- [ ] Follows project conventions, patterns, and layer boundaries.
+- [ ] Acceptance criteria are fully satisfied.
+- [ ] Test coverage is adequate (new tests for new behavior).
+- [ ] No performance, security, or privacy/GDPR regressions.
+- [ ] TypeScript types are sound; no unjustified `any`.
+- [ ] Edge cases handled; comments/docs are clear and necessary.
+
+### Merging
+
+- **Do not merge your own PR.** A maintainer reviews and merges to `main`.
+- **Status update is automated.** When a PR is **merged**, the [`mark-story-done`](.github/workflows/mark-story-done.yml) workflow reads the story referenced in the PR and commits its status → `done` (in both `sprint-status.yaml` and the story file) directly to the default branch. The commit is tagged `[skip ci]` so it doesn't re-run any pipelines. This works for fork PRs too. _(Maintainers can also apply it by hand: `node scripts/mark-story-done.mjs <story-id>`.)_
+- When an epic completes, run a **retrospective** and capture lessons in `docs/sprint-artifacts/`.
+
+---
+
+## Contributing Brand Catalogue Entries
+
+Expanding the brand catalogue is the easiest and most-welcomed way to contribute — and it's how the app grows across the EU.
+
+1. The catalogue source of truth lives in [`catalogue/`](catalogue/) (e.g. `catalogue/italy.json`).
+2. Add or correct a brand entry, matching the existing JSON shape and the schema in `catalogue/types.ts`. Keep all fields present.
+3. **Regenerate the watch catalogue** so the watch app stays in sync:
+   ```bash
+   yarn watch:catalogue:generate
+   ```
+   CI runs `yarn check:catalogue-generated` to ensure the generated watch catalogue matches the source — commit the regenerated output.
+4. Run `yarn lint && yarn test` (catalogue files have tests, e.g. `catalogue/italy.test.ts`).
+5. Open a PR titled `feat(catalogue): add <brand> to <country>`. Catalogue-only PRs are lighter-weight and usually don't need a full story, but please reference an issue if one exists.
+
+---
+
+## Reporting Bugs & Requesting Features
+
+**Bugs** — open a GitHub issue with:
+
+- What you expected vs. what happened.
+- Steps to reproduce.
+- Platform & version (iOS/Android/watchOS, app version, device/OS).
+- Logs/screenshots if available. For watch-sync issues, Console.app traces are especially helpful (watch sync must be verified on a **physical device**, not just by code review).
+
+**Features** — open an issue or discussion describing the problem to solve and the proposed value. Remember: features enter through **planning** (PRD/epic), so this is the first step toward a future story — not a direct PR.
+
+---
+
+## Using the BMAD Agents
+
+You don't have to drive the methodology by hand. BMAD ships agents and workflows you can invoke from your AI IDE (Claude Code, Cursor, or GitHub Copilot — all preconfigured under [`_bmad/_config/ides/`](_bmad/_config/)). The workflows most relevant to contributors:
+
+| You want to…                        | Agent / workflow                               |
+| ----------------------------------- | ---------------------------------------------- |
+| Draft the next story                | Scrum Master — `create-story`                  |
+| Implement a `ready-for-dev` story   | Dev — `dev-story`                              |
+| Review code against the checklist   | Dev/QA — `code-review`                         |
+| Plan a sprint from the epics        | Scrum Master — `sprint-planning`               |
+| Add/refine requirements (new scope) | PM — `create-prd` / `create-epics-and-stories` |
+| Make a system design decision       | Architect — `create-architecture`              |
+| Handle a mid-sprint scope change    | `correct-course`                               |
+| Check we're ready to implement      | Architect — `check-implementation-readiness`   |
+| Close out an epic                   | `retrospective`                                |
+
+For very small, well-scoped changes, the **Quick Flow** (`quick-spec` → `quick-dev`) provides a lighter spec path — still spec-first, just leaner.
+
+---
+
+## Quick Reference
+
+**Story lifecycle:**
+
+```
+backlog → drafted → ready-for-dev → in-progress → review → done
+```
+
+**The loop, in one line:**
+
+```
+find/create story → branch → implement (+ tests) → atomic conventional commits
+→ pass gates → update sprint-status → code review → PR → maintainer merges → done
+```
+
+**Three rules you must not break:**
+
+1. **Spec-first** — no code without a `ready-for-dev` story (or an agreed planning update for new scope).
+2. **Never bypass quality gates** — `--no-verify` is forbidden; fix the failure instead.
+3. **Don't merge your own PR** — a maintainer reviews and merges.
+
+Welcome aboard, and thank you for helping make checkout friction a thing of the past! 🚀

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Andrea Pacino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,84 +1,305 @@
 # myLoyaltyCards
 
-[![CI](https://github.com/ifero/myLoyaltyCards/actions/workflows/ci-quality-gates.yml/badge.svg)](https://github.com/ifero/myLoyaltyCards/actions/workflows/ci-quality-gates.yml) [![coverage](https://img.shields.io/badge/coverage-80%25-yellow.svg)](docs/)
+[![CI — Quality Gates](https://github.com/ifero/myLoyaltyCards/actions/workflows/ci-quality-gates.yml/badge.svg)](https://github.com/ifero/myLoyaltyCards/actions/workflows/ci-quality-gates.yml)
+[![watchOS Tests](https://github.com/ifero/myLoyaltyCards/actions/workflows/watchos-tests.yml/badge.svg)](https://github.com/ifero/myLoyaltyCards/actions/workflows/watchos-tests.yml)
+[![Expo SDK 55](https://img.shields.io/badge/Expo%20SDK-55-000020.svg?logo=expo)](https://expo.dev)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](#license)
 
-A mobile app for managing loyalty cards
+> Your loyalty cards, on your wrist — instant, offline, and friction-free at the checkout.
 
-## BMAD-METHOD Integration
+**myLoyaltyCards** is an offline-first mobile app for storing and instantly displaying retail loyalty cards. It pairs a React Native (Expo) phone app with a native **Apple Watch** companion so you can raise your wrist, tap once, and show your barcode — **no phone, no network, no waiting** at the moment that matters most.
 
-This project uses [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) (Breakthrough Method of Agile AI-Driven Development) for spec-driven development.
+It is a community-driven, open-source passion project with **no monetization and no advertising**, built end-to-end with the [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) **Spec-Driven Development (SDD)** methodology.
 
-### What is BMAD?
+---
 
-BMAD is a framework that utilizes specialized AI agents to manage the complete agile development cycle:
+## Table of Contents
 
-- **Analyst** - Requirements gathering and analysis
-- **PM (Product Manager)** - Product planning and prioritization
-- **Architect** - System design and technical decisions
-- **Dev (Developer)** - Implementation and coding
-- **QA (Quality Assurance)** - Testing and quality control
-- **SM (Scrum Master)** - Sprint planning and process management
+- [Why myLoyaltyCards?](#why-myloyaltycards)
+- [Key Features](#key-features)
+- [Platforms & Status](#platforms--status)
+- [Tech Stack](#tech-stack)
+- [Architecture Overview](#architecture-overview)
+- [Apple Watch Sync](#apple-watch-sync)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Common Scripts](#common-scripts)
+- [Testing & Quality Gates](#testing--quality-gates)
+- [Spec-Driven Development (BMAD)](#spec-driven-development-bmad)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
 
-### Using BMAD in This Project
+---
 
-The BMAD framework is installed in the `.bmad-core/` directory with the following structure:
+## Why myLoyaltyCards?
+
+Existing loyalty-card apps fail at the **payment moment** for two reasons:
+
+1. **Network dependency** — they show a loading spinner, or refuse to open at all, exactly when you are standing at the register with items in hand and people waiting behind you.
+2. **No real wearable** — most "watch apps" are thin remotes that need the phone awake nearby, so you still end up fumbling for your phone.
+
+myLoyaltyCards is built around a single goal: **display the right card in ≤3 seconds, every time, even fully offline.** Cards are cached locally on both the phone and the watch, sorted intelligently, and rendered as crisp barcodes optimized for small screens.
+
+The app targets the **European Union** market, beginning with an Italian brand catalogue, and is designed to grow through community catalogue contributions.
+
+---
+
+## Key Features
+
+- 📴 **Offline-first** — every card is stored locally (SQLite on the phone, SwiftData on the watch). The app is fully functional in airplane mode, basements, and rural areas. No loading screens.
+- ⌚ **Apple Watch companion** — a native watchOS app that displays your cards and barcodes directly on your wrist, kept in sync from the phone.
+- ➕ **Card management** — add cards by scanning a barcode with the camera, scanning from a photo, or entering details manually. Edit, delete, and mark favorites.
+- 🔢 **Multi-format barcodes** — render CODE128, EAN13, EAN8, QR, CODE39, and UPC-A, with a high-contrast / brightness-boost display mode for reliable scanning.
+- 🧠 **Smart sorting** — most-recently-used and frequently-used cards float to the top; pinned favorites stay one tap away.
+- 🏷️ **Brand catalogue** — a curated catalogue (starting with Italy) provides brand logos and metadata, delivered as JSON and cacheable offline. The same catalogue is generated for the watch.
+- 🔐 **Optional accounts & cloud sync** — use the app fully as a guest, or sign in (Supabase Auth, OTP email verification) to back up and sync cards across devices.
+- 🛡️ **Privacy & GDPR** — built for EU compliance: data export, account/data deletion, and explicit consent.
+- 🌍 **Internationalization** — English and Italian, with light & dark mode that follows the system preference.
+
+---
+
+## Platforms & Status
+
+| Platform        | Status               | Notes                                                                  |
+| --------------- | -------------------- | ---------------------------------------------------------------------- |
+| iOS (phone)     | ✅ Active            | Primary platform                                                       |
+| Apple Watch     | ✅ Active            | Native watchOS app embedded in the iOS app via `@bacons/apple-targets` |
+| Android (phone) | ✅ Active            | Shared React Native codebase                                           |
+| Wear OS         | 🗺️ Planned (Epic 10) | Native Kotlin / Jetpack Compose companion                              |
+
+> **Note:** Apple does not allow standalone watchOS binary uploads. The watch app ships **inside the iOS app archive** (Continuous Native Generation), not as a separate build.
+
+---
+
+## Tech Stack
+
+### Phone app (React Native)
+
+| Technology                      | Version    | Purpose                        |
+| ------------------------------- | ---------- | ------------------------------ |
+| Expo SDK                        | 55         | Development framework          |
+| React                           | 19.2       | UI library (React Compiler on) |
+| React Native                    | 0.83       | Mobile framework               |
+| TypeScript                      | 5.9 strict | Language                       |
+| Expo Router                     | 55         | File-based navigation          |
+| NativeWind (Tailwind)           | 4          | Styling                        |
+| React Hook Form + Zod           | 7 / 4      | Forms & schema validation      |
+| expo-sqlite                     | 55         | Local database (repository)    |
+| expo-secure-store               | 55         | Secure token storage           |
+| i18next / react-i18next         | —          | Internationalization (EN / IT) |
+| @shopify/flash-list             | 2          | High-performance lists         |
+| react-native-reanimated         | 4          | Native-thread animations       |
+| react-native-watch-connectivity | 1          | Phone ↔ Watch messaging        |
+
+### Watch app (native)
+
+| Platform | Language           | UI              | Storage   |
+| -------- | ------------------ | --------------- | --------- |
+| watchOS  | Swift              | SwiftUI         | SwiftData |
+| Wear OS  | Kotlin _(planned)_ | Jetpack Compose | Room      |
+
+### Backend & tooling
+
+| Technology                | Purpose                                |
+| ------------------------- | -------------------------------------- |
+| Supabase                  | PostgreSQL + Auth + Row Level Security |
+| GitHub Actions            | CI quality gates & release pipelines   |
+| Fastlane                  | iOS/Android build & signing automation |
+| Jest + RNTL               | Unit / component testing               |
+| ESLint + Prettier + Husky | Linting, formatting, git hooks         |
+
+> The system was designed in [`docs/architecture.md`](docs/architecture.md); for the canonical, enforced implementation rules see [`docs/project_context.md`](docs/project_context.md).
+
+---
+
+## Architecture Overview
+
+The codebase uses a **feature-first, layered architecture** with boundaries enforced automatically by ESLint (`eslint-plugin-boundaries`):
 
 ```
-.bmad-core/
-├── agents/           # AI agent definitions
-├── tasks/            # Executable tasks
-├── templates/        # Document templates (PRD, architecture, stories)
-├── checklists/       # Quality checklists
-├── data/             # Knowledge base and technical preferences
-├── workflows/        # Workflow definitions
-├── core-config.yaml  # Project configuration
-└── user-guide.md     # Detailed usage guide
+app/         → Thin route files (re-export from features only — no logic)
+features/    → Self-contained feature modules (UI + local hooks)
+shared/      → Cross-feature UI components & React hooks
+core/        → Business logic: database, sync, auth, catalogue (no React, except where noted)
+catalogue/   → Brand data (JSON source of truth) + parsing
 ```
 
-### Getting Started with BMAD
+**Allowed import direction:** `app → features → shared → core` (+ `catalogue`).
+Cross-feature imports (`features/X → features/Y`) and upward imports (`core → features`) are **forbidden** and fail CI.
 
-1. **Read the User Guide**: Start by reading `.bmad-core/user-guide.md` for detailed instructions
-2. **Review Technical Preferences**: Check `.bmad-core/data/technical-preferences.md` for the project's tech stack
-3. **Use the Agents**: Invoke BMAD agents in your AI IDE to assist with various development tasks
+Other foundational rules (full list in [`docs/project_context.md`](docs/project_context.md)):
 
-### Tech Stack
+- **Zod schemas are the source of truth** for all data types (`type X = z.infer<typeof xSchema>`).
+- **UUIDs are generated client-side** on every platform; the server never assigns IDs.
+- **Dates are always UTC ISO-8601** strings (`2025-12-24T10:30:00.123Z`).
+- **Database writes use transactions** (`withTransactionAsync`).
+- **JSON payloads include every field** (`"brandId": null`, never omitted) for cross-platform parsing.
 
-- **Frontend Framework**: React Native / Expo
-- **Navigation**: Expo Router
-- **Language**: TypeScript
-- **Styling**: StyleSheet / NativeWind (optional)
+---
 
-### Documentation
+## Apple Watch Sync
 
-- [CI/CD Pipeline Guide](docs/cicd.md)
-
-For more information about BMAD-METHOD, visit:
-
-- [BMAD-METHOD Official Repository](https://github.com/bmad-code-org/BMAD-METHOD)
-
-## Apple Watch Sync Architecture (Overview)
-
-The Apple Watch companion app for myLoyaltyCards è progettata per essere **read-only**: tutte le modifiche (aggiunta, modifica, eliminazione carte) avvengono solo sull’app iPhone. La sincronizzazione avviene tramite WatchConnectivity:
-
-- **Flusso di sync**: quando una carta viene aggiunta/modificata/eliminata su iPhone, l’app invia un messaggio di sync al Watch contenente la versione e il payload della carta.
-- **Gestione conflitti**: la logica last-write-wins viene applicata lato telefono prima dell’invio; il Watch accetta sempre l’ultimo payload ricevuto.
-- **Retry e resilienza**: se il Watch non è connesso, il telefono effettua retry con backoff (fino a 3 tentativi) e logga eventuali errori.
-- **Storage locale**: il Watch salva le carte ricevute in UserDefaults/SwiftData, ma non permette modifiche locali.
-- **Read-only enforcement**: la UI e il modello CardStore non espongono azioni di modifica; eventuali tentativi di scrittura sono ignorati.
-
-### Diagramma di flusso (semplificato)
+The Apple Watch app is intentionally **read-only**: all changes (add / edit / delete) happen on the iPhone. Synchronization flows one way over **WatchConnectivity** (`WCSession`):
 
 ```
-Phone (iOS)                Watch (watchOS)
-    |   add/edit/delete        |
-    |------------------------>|  (sync message: {version, card payload, brandId})
-    |                         |
-    |<------------------------|  (ack)
-    |   retry on failure      |
+Phone (iOS / React Native)              Watch (watchOS / SwiftUI)
+        │   add / edit / delete card           │
+        │──────────────────────────────────────▶  sync message { version, type, payload }
+        │                                       │   WatchSessionManager writes to SwiftData
+        │◀──────────────────────────────────────  (delivery handled by WCSession)
+        │   retry with backoff on failure       │   UI reads via @Query (read-only)
 ```
 
-Per dettagli implementativi, vedi:
+- **Versioned messages** — every sync message carries a `version` and a `type` (`CARDS_UPDATED`, `CARD_ADDED`, `CARD_DELETED`, `REQUEST_FULL_SYNC`); unknown versions trigger a full-sync request.
+- **Conflict handling** — last-write-wins is resolved on the phone before sending; the watch always accepts the latest payload.
+- **Resilience** — if the watch is unreachable, the phone retries with exponential backoff.
+- **Read-only enforcement** — the watch UI and model expose no mutation actions.
 
-- core/watch-connectivity.ts
-- CardListView.swift
-- CardStoreTests.swift
+Implementation entry points: [`core/watch-connectivity.ts`](core/watch-connectivity.ts), the native target under [`targets/watch/`](targets/watch/) (e.g. `WatchSessionManager.swift`, `CardListView.swift`), and the watch tests in [`watch-ios/Tests`](watch-ios/Tests).
+
+---
+
+## Project Structure
+
+```
+myLoyaltyCards/
+├── app/                  # Expo Router routes (thin re-exports)
+├── features/             # Feature modules (cards, add-card, auth, settings, onboarding, help, privacy)
+├── shared/               # Shared UI, hooks, i18n, theme, supabase client, types
+├── core/                 # Business logic: database, sync, auth, catalogue, settings, privacy, schemas
+├── catalogue/            # Brand catalogue JSON (e.g. italy.json) + types
+├── targets/watch/        # Native watchOS app (SwiftUI + SwiftData), generated via @bacons/apple-targets
+├── watch-ios/            # watchOS test/build scripts, unit & UI tests, catalogue generator
+├── supabase/             # Supabase migrations & Edge Functions
+├── fastlane/             # Build & signing automation
+├── scripts/              # Helper scripts (catalogue generation, watch build, vendor fixups)
+├── docs/                 # SDD artifacts: PRD, architecture, epics, UX, CI/CD, sprint artifacts
+├── _bmad/                # BMAD-METHOD installation (agents, workflows, config) — v6.0.4
+├── .github/workflows/    # CI & release pipelines
+└── AGENTS.md             # Operating rules for AI agents working in this repo
+```
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js 24** (see [`.nvmrc`](.nvmrc)) and **Yarn**
+- **Xcode** (for iOS / Apple Watch) and/or **Android Studio** (for Android)
+- **Ruby 4.0.5** (see [`.ruby-version`](.ruby-version)) + Bundler, for CocoaPods & Fastlane
+- A device or simulator. The watch app requires a **development build** (it cannot run in Expo Go).
+
+> **CocoaPods note:** on Homebrew Ruby, `pod install` can crash with an `Encoding::CompatibilityError`. Prefix the command with `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8`.
+
+### Install
+
+```bash
+git clone https://github.com/ifero/myLoyaltyCards.git
+cd myLoyaltyCards
+yarn install
+cp .env.example .env   # then fill in Supabase / environment values
+```
+
+### Run the phone app
+
+```bash
+yarn ios        # build & run on iOS simulator/device
+yarn android    # build & run on Android emulator/device
+yarn start      # start the Metro dev server
+```
+
+### Run the Apple Watch app
+
+```bash
+yarn ios:watch        # build the phone app, then build & launch the watch app
+# or, against a booted Apple Watch simulator:
+yarn watch:run
+```
+
+### Local Supabase (optional, for auth/sync work)
+
+```bash
+yarn supabase:start     # start the local stack
+yarn supabase:status    # show local credentials & URLs
+yarn supabase:reset     # reset the local database to migrations
+```
+
+---
+
+## Common Scripts
+
+| Script                           | What it does                                           |
+| -------------------------------- | ------------------------------------------------------ |
+| `yarn start` / `ios` / `android` | Start Metro / build & run native apps                  |
+| `yarn lint`                      | ESLint (incl. layer-boundary rules)                    |
+| `yarn typecheck`                 | TypeScript `--noEmit`                                  |
+| `yarn test`                      | Jest unit/component tests                              |
+| `yarn test:coverage`             | Jest with coverage report                              |
+| `yarn test:all`                  | JS tests **+** watchOS tests                           |
+| `yarn watch:build` / `watch:run` | Build / run the native watchOS app                     |
+| `yarn watch:catalogue:generate`  | Regenerate the watch brand catalogue from `catalogue/` |
+| `yarn format`                    | Prettier write                                         |
+
+See [`package.json`](package.json) for the full list (Fastlane match, Supabase functions, etc.).
+
+---
+
+## Testing & Quality Gates
+
+Quality is enforced both locally (git hooks) and in CI:
+
+- **Pre-commit** (Husky + lint-staged): ESLint `--fix` and Prettier on staged files.
+- **Pre-push** (Husky): full `typecheck`, `lint`, and `test` must pass.
+- **CI — Quality Gates** ([`ci-quality-gates.yml`](.github/workflows/ci-quality-gates.yml)) runs on every PR: `lint` → `typecheck` → `test:coverage`. PRs are blocked on failure.
+- **watchOS tests** run in their own workflow ([`watchos-tests.yml`](.github/workflows/watchos-tests.yml)).
+
+> ⚠️ **Never bypass hooks** (`--no-verify` is forbidden). If a gate fails, fix the issue and re-run. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## Spec-Driven Development (BMAD)
+
+This project is built **spec-first** using the [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) (Breakthrough Method of Agile AI-Driven Development), installed under [`_bmad/`](_bmad/) (v6.0.4). Specialized AI agents (Analyst, PM, UX Designer, Architect, Scrum Master, Dev, QA/Test Architect, Tech Writer) drive the lifecycle through four phases:
+
+```
+Phase 0  Discovery     →  brainstorming, research, product brief        (optional)
+Phase 1  Planning      →  PRD  +  UX design                              docs/prd.md, docs/ux-design-specification.md
+Phase 2  Solutioning   →  Architecture  +  Epics & Stories  +  Test      docs/architecture.md, docs/epics.md
+                          Design  +  Implementation Readiness gate
+Phase 3  Implementation→  Sprint planning → per-story specs → dev →      docs/sprint-artifacts/
+                          code review → PR → retrospective
+```
+
+**The core rule: code follows a spec.** Every implementation traces back to a **story** in `docs/sprint-artifacts/stories/`, which itself traces back to the epics, PRD, and architecture. Stories move through `backlog → drafted → ready-for-dev → in-progress → review → done`, tracked in [`docs/sprint-artifacts/sprint-status.yaml`](docs/sprint-artifacts/sprint-status.yaml).
+
+➡️ **If you want to contribute, read [CONTRIBUTING.md](CONTRIBUTING.md) first** — it explains how to work within this methodology in detail.
+
+---
+
+## Documentation
+
+| Document                                                             | Purpose                                  |
+| -------------------------------------------------------------------- | ---------------------------------------- |
+| [`docs/prd.md`](docs/prd.md)                                         | Product Requirements (FRs / NFRs)        |
+| [`docs/architecture.md`](docs/architecture.md)                       | System architecture & decisions          |
+| [`docs/epics.md`](docs/epics.md)                                     | Epics & story breakdown                  |
+| [`docs/ux-design-specification.md`](docs/ux-design-specification.md) | UX design specification                  |
+| [`docs/project_context.md`](docs/project_context.md)                 | Enforced implementation rules for agents |
+| [`docs/test-design-system.md`](docs/test-design-system.md)           | Test strategy & design                   |
+| [`docs/cicd.md`](docs/cicd.md)                                       | CI/CD pipeline & release runbooks        |
+| [`docs/sprint-artifacts/`](docs/sprint-artifacts/)                   | Sprint status, stories, retrospectives   |
+| [`AGENTS.md`](AGENTS.md)                                             | Operating rules for AI agents            |
+
+---
+
+## Contributing
+
+Contributions — code, brand-catalogue additions, bug reports, and ideas — are welcome. This project enforces the **BMAD Spec-Driven Development** methodology, so please read **[CONTRIBUTING.md](CONTRIBUTING.md)** before opening a pull request. It covers the spec-first workflow, branch & commit conventions, quality gates, code review, and how to contribute brand catalogue entries.
+
+---
+
+## License
+
+Released under the **MIT License** — see [`LICENSE`](LICENSE) for the full text. © 2025–2026 Andrea Pacino.

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-01-03
-# updated: 2026-05-24
+# updated: 2026-06-04
 # project: myLoyaltyCards
 # tracking_system: file-system
 # story_location: docs/sprint-artifacts
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-01-03
-updated: 2026-05-24
+updated: 2026-06-04
 project: myLoyaltyCards
 tracking_system: file-system
 story_location: docs/sprint-artifacts
@@ -164,6 +164,7 @@ current_sprint:
     - 15-2-italian-language-in-app
     - 14-1-household-collaboration
     - 6-18a-otp-verification-followup
+    - 11-7-contribution-infrastructure
   waves:
     wave_1:
       stories: [5-7, 5-8, 2-9, 2-10, 5-10, 15-2, 6-18a]
@@ -171,6 +172,9 @@ current_sprint:
     wave_2:
       stories: [14-1]
       note: 'Begin household collaboration discovery and alignment once core sprint capacity is confirmed.'
+    wave_3:
+      stories: [11-7]
+      note: 'Developer-experience follow-up: open-source contribution docs (README, CONTRIBUTING, LICENSE), GitHub PR/issue templates, and merge-time story-status automation. Maps to NFR-M3 and NFR-M5.'
   notes: |
     Sprint 14 has started. The focus is on completing Apple Watch reliability work, Italian in-app readiness, beginning household collaboration discovery, and absorbing the OTP verification follow-up bugfix discovered after Story 6.18 shipped.
     On 2026-05-24, two additional bugfix planning stories were added and refined to ready-for-dev: Story 2.10 (phone barcode/QR readability + quiet-zone padding) and Story 5.10 (watch barcode legibility + list density polish).
@@ -336,6 +340,7 @@ development_status:
   11-4-rollback-on-failed-deploy: cancelled # rollback doesn't apply to mobile app store binaries
   11-5-document-cicd-pipeline: done # depends on 11-6
   11-6-watchos-testflight-pipeline: done # embed watchOS in iOS build via @bacons/apple-targets
+  11-7-contribution-infrastructure: review # Sprint 14 follow-up — open-source docs, GitHub templates & story-status automation (epic-11 stays done)
   epic-11-retrospective: done
 
   # Epic 12: App-Wide Design Overhaul (Figma) ✅ COMPLETE

--- a/docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md
+++ b/docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md
@@ -50,6 +50,11 @@ This work directly satisfies **NFR-M3** (_"project structure must be organized f
 - [x] On PR **merge**, the story referenced by the PR is set to `done` in **both** `sprint-status.yaml` and the story file, committed to the default branch with `[skip ci]`.
 - [x] Backed by `scripts/mark-story-done.mjs` (resolves the story from the PR body path or a `(Story X.Y)` title; idempotent; supports `DRY_RUN=1`) and `.github/workflows/mark-story-done.yml`.
 
+### AC6: CI enforces the contribution rules
+
+- [x] A CI check fails any PR that violates the machine-checkable CONTRIBUTING rules: a non-Conventional-Commit title, an off-convention branch name, or a code change with no story reference (`docs:`/`chore:` titles and catalogue PRs are exempt).
+- [x] Implemented as `scripts/check-pr-conventions.mjs` (sharing the story resolver in `scripts/lib/story-refs.mjs`) and run by `.github/workflows/pr-conventions.yml`.
+
 ## Tasks / Subtasks
 
 - [x] **T1 (AC1):** Rewrite `README.md`.
@@ -57,6 +62,7 @@ This work directly satisfies **NFR-M3** (_"project structure must be organized f
 - [x] **T3 (AC3):** Add `LICENSE` (MIT) and link it from the README.
 - [x] **T4 (AC4):** Add the PR template, three issue forms, and `config.yml`; create the labels.
 - [x] **T5 (AC5):** Add `scripts/mark-story-done.mjs` + `.github/workflows/mark-story-done.yml`; verify with a dry-run and a real run + revert.
+- [x] **T6 (AC6):** Extract the shared story resolver (`scripts/lib/story-refs.mjs`), add `scripts/check-pr-conventions.mjs` and `.github/workflows/pr-conventions.yml`; verify pass/fail scenarios locally.
 
 ## Tech Notes
 

--- a/docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md
+++ b/docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md
@@ -1,0 +1,73 @@
+# Story 11-7: Open-Source Contribution Infrastructure & Story-Status Automation
+
+**Epic:** 11 — CI/CD & Quality Gates
+**Status:** review
+**Sprint:** 14
+**Priority:** Low — developer-experience / open-source readiness follow-up
+**Type:** Follow-up (added after Epic 11 closed; `epic-11` remains `done`, same pattern as Story 1-6 under Epic 1)
+
+## Story
+
+As a project maintainer and prospective open-source contributor,
+I want accurate project documentation, a license, standardized GitHub PR/issue templates, and automated story-status bookkeeping,
+so that contributions consistently follow the BMAD spec-first process and sprint tracking stays accurate without manual effort.
+
+## Context
+
+The repository was missing the basics that make an open-source project contribution-ready, and the existing README had drifted from reality:
+
+- `README.md` referenced the old `.bmad-core/` path, contained a mixed-language watch-sync section, and listed libraries (Zustand, TanStack Query) that are not actually used.
+- No `CONTRIBUTING` guide, no `LICENSE`, and no GitHub PR/issue templates — leaving contributors without a clear, enforceable process.
+- Closing a story still required manually editing two files (`sprint-status.yaml` and the story file), which is easy to forget.
+
+This work directly satisfies **NFR-M3** (_"project structure must be organized for easy navigation by contributors"_) and **NFR-M5** (_"contribution guidelines must be clearly documented"_), and extends the Epic 11 process/automation theme.
+
+**Reference:** `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.github/`, `scripts/mark-story-done.mjs`.
+
+## Acceptance Criteria
+
+### AC1: Project README (English)
+
+- [x] Full English project description: value proposition, key features, platforms & status, accurate tech stack, layered architecture, Apple Watch sync, setup, scripts, testing/quality gates, BMAD SDD overview, and a documentation index.
+- [x] Stale content corrected (`_bmad/` path, English watch-sync section, actual libraries only).
+
+### AC2: Contribution guide (BMAD SDD enforced)
+
+- [x] `CONTRIBUTING.md` documents the spec-first rule (no code without a `ready-for-dev` story), the four BMAD phases, the story lifecycle, branch & Conventional Commit conventions, the quality gates (with `--no-verify` forbidden), code-review/PR rules, and the brand-catalogue path.
+
+### AC3: License
+
+- [x] `LICENSE` file (MIT) added at the repo root and linked from the README.
+
+### AC4: GitHub community templates
+
+- [x] PR template (`.github/PULL_REQUEST_TEMPLATE.md`) aligned with the CONTRIBUTING checklist (linked story, AC checklist, screenshots, gates).
+- [x] Issue forms for bug report, feature request, and brand-catalogue request, plus `config.yml`.
+- [x] Supporting labels `needs-triage` and `catalogue` created in the repo.
+
+### AC5: Story-status automation
+
+- [x] On PR **merge**, the story referenced by the PR is set to `done` in **both** `sprint-status.yaml` and the story file, committed to the default branch with `[skip ci]`.
+- [x] Backed by `scripts/mark-story-done.mjs` (resolves the story from the PR body path or a `(Story X.Y)` title; idempotent; supports `DRY_RUN=1`) and `.github/workflows/mark-story-done.yml`.
+
+## Tasks / Subtasks
+
+- [x] **T1 (AC1):** Rewrite `README.md`.
+- [x] **T2 (AC2):** Write `CONTRIBUTING.md`.
+- [x] **T3 (AC3):** Add `LICENSE` (MIT) and link it from the README.
+- [x] **T4 (AC4):** Add the PR template, three issue forms, and `config.yml`; create the labels.
+- [x] **T5 (AC5):** Add `scripts/mark-story-done.mjs` + `.github/workflows/mark-story-done.yml`; verify with a dry-run and a real run + revert.
+
+## Tech Notes
+
+- The automation triggers on `pull_request: [closed]` guarded by `merged == true`, and pushes to `github.event.pull_request.base.ref`. It prefers a `STORY_BOT_TOKEN` secret (for branches protected against direct pushes) and falls back to `GITHUB_TOKEN`.
+- The commit is tagged `[skip ci]` so the docs-only change does not re-run pipelines.
+- A temporary `sync-labels.yml` workflow was used to bootstrap the labels and then removed once the labels existed.
+- **Self-reference caveat:** because the automation is introduced in this same change, the workflow on the default branch cannot auto-complete Story 11-7 on its own merge. This story is therefore moved to `done` manually (or by running `node scripts/mark-story-done.mjs 11-7`); subsequent stories are handled automatically.
+
+## Definition of Done
+
+- [x] All acceptance criteria met.
+- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass; all docs/templates pass Prettier.
+- [x] Updater script verified on a real story (non-destructive; reverted after testing).
+- [ ] PR reviewed and merged by the maintainer; story marked `done`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,18 @@ export default [
     },
   },
   {
+    // Node scripts (build/CI tooling): the Node runtime provides process, console,
+    // etc. Mirror the TS rule choice and let the runtime/types handle undefined refs.
+    files: ['scripts/**/*.{mjs,js}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'no-undef': 'off',
+    },
+  },
+  {
     ignores: [
       'node_modules/**',
       '.expo/**',

--- a/scripts/check-pr-conventions.mjs
+++ b/scripts/check-pr-conventions.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Validates a pull request against the machine-checkable rules in CONTRIBUTING.md.
+// Exits non-zero (failing CI) on any violation.
+//
+// Rules enforced:
+//   1. PR title is a Conventional Commit: <type>(<scope>): <summary>
+//   2. Branch name uses an allowed prefix (feature/ fix/ refactor/ docs/ chore/)
+//   3. Spec-first: code changes reference an existing story
+//      (docs:/chore: titles and catalogue PRs are exempt)
+//
+// Inputs via env: PR_TITLE, PR_BODY, HEAD_REF, PR_LABELS (comma-separated).
+
+import { appendFileSync } from 'node:fs';
+import { resolveStorySlugs } from './lib/story-refs.mjs';
+
+const PR_TITLE = process.env.PR_TITLE ?? '';
+const PR_BODY = process.env.PR_BODY ?? '';
+const HEAD_REF = process.env.HEAD_REF ?? '';
+const LABELS = (process.env.PR_LABELS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const TYPES = ['feat', 'fix', 'refactor', 'docs', 'test', 'chore'];
+const BRANCH_PREFIXES = ['feature', 'fix', 'refactor', 'docs', 'chore'];
+
+const violations = [];
+
+// 1) Conventional Commit PR title
+const titleMatch = PR_TITLE.match(
+  /^(feat|fix|refactor|docs|test|chore)(\(([a-z0-9._-]+)\))?(!)?: .+/
+);
+if (!titleMatch) {
+  violations.push(
+    [
+      'PR title is not a Conventional Commit.',
+      `  Got:      "${PR_TITLE}"`,
+      '  Expected: <type>(<scope>): <summary>   e.g. "feat(watch): add complication (Story 5.9)"',
+      `  Allowed types: ${TYPES.join(', ')}`
+    ].join('\n')
+  );
+}
+const type = titleMatch?.[1];
+const scope = titleMatch?.[3];
+
+// 2) Branch naming
+if (HEAD_REF && !new RegExp(`^(${BRANCH_PREFIXES.join('|')})/.+`).test(HEAD_REF)) {
+  violations.push(
+    [
+      'Branch name does not follow the convention.',
+      `  Got:      "${HEAD_REF}"`,
+      `  Expected: one of ${BRANCH_PREFIXES.map((p) => `${p}/…`).join(', ')}`
+    ].join('\n')
+  );
+}
+
+// 3) Spec-first: code changes must reference an existing story
+const storyExempt =
+  ['docs', 'chore'].includes(type) || scope === 'catalogue' || LABELS.includes('catalogue');
+if (!storyExempt) {
+  const slugs = resolveStorySlugs(`${PR_TITLE}\n${PR_BODY}`);
+  if (slugs.length === 0) {
+    violations.push(
+      [
+        'Spec-first: this looks like a code change but references no story.',
+        '  Link a docs/sprint-artifacts/stories/<id>.md story in the PR body, or end the',
+        '  title with "(Story X.Y)". (docs:/chore: titles and catalogue PRs are exempt.)'
+      ].join('\n')
+    );
+  }
+}
+
+// ---- report -----------------------------------------------------------------
+
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+const writeSummary = (md) => {
+  if (summaryFile) {
+    try {
+      appendFileSync(summaryFile, md);
+    } catch {
+      /* summary is best-effort */
+    }
+  }
+};
+
+if (violations.length === 0) {
+  console.log('✓ PR follows the CONTRIBUTING conventions.');
+  writeSummary('### ✅ PR conventions\n\nThis PR follows the CONTRIBUTING.md conventions.\n');
+  process.exit(0);
+}
+
+console.log(`✗ PR does not follow CONTRIBUTING.md (${violations.length} issue(s)):\n`);
+for (const v of violations) {
+  console.log(`  • ${v}\n`);
+  // GitHub annotation (first line only)
+  console.log(`::error::${v.split('\n')[0]}`);
+}
+console.log('See CONTRIBUTING.md for the full contribution rules.');
+
+writeSummary(
+  `### ❌ PR conventions\n\n` +
+    `This PR does not follow [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md):\n\n` +
+    violations.map((v) => `- ${v.split('\n')[0]}`).join('\n') +
+    `\n`
+);
+
+process.exit(1);

--- a/scripts/lib/story-refs.mjs
+++ b/scripts/lib/story-refs.mjs
@@ -1,0 +1,54 @@
+// Shared helpers for resolving a story reference (from PR text / CLI input) to an
+// existing story slug under docs/sprint-artifacts/stories/. Used by both
+// scripts/mark-story-done.mjs and scripts/check-pr-conventions.mjs.
+
+import { existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const STORIES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'docs/sprint-artifacts/stories'
+);
+
+const listStories = (dir) =>
+  existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('.md')) : [];
+
+export const findStoryByPrefix = (prefix, dir = STORIES_DIR) => {
+  const files = listStories(dir);
+  if (files.includes(`${prefix}.md`)) return prefix;
+  const hit = files.find((f) => f.startsWith(`${prefix}-`));
+  return hit ? hit.replace(/\.md$/, '') : null;
+};
+
+// Resolve all story slugs referenced by `text`, returning only slugs whose story
+// file actually exists. Resolution order:
+//   0. an exact slug (e.g. "5-9-edit-card")
+//   1. story-file paths: stories/<slug>.md
+//   2. a "Story X.Y" / "X-Y" reference, matched against the stories dir
+export const resolveStorySlugs = (text, dir = STORIES_DIR) => {
+  const slugs = new Set();
+  const trimmed = (text ?? '').trim();
+
+  if (/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) && existsSync(join(dir, `${trimmed}.md`))) {
+    return [trimmed];
+  }
+
+  const pathRe = /stories\/([A-Za-z0-9][A-Za-z0-9._-]*?)\.md/g;
+  let m;
+  while ((m = pathRe.exec(text ?? ''))) {
+    if (existsSync(join(dir, `${m[1]}.md`))) slugs.add(m[1]);
+  }
+
+  if (slugs.size === 0) {
+    const numRe = /(?:story\s+)?(\d+)[.-](\d+[a-z]?)/gi;
+    while ((m = numRe.exec(text ?? ''))) {
+      const found = findStoryByPrefix(`${m[1]}-${m[2]}`, dir);
+      if (found) slugs.add(found);
+    }
+  }
+
+  return [...slugs];
+};

--- a/scripts/mark-story-done.mjs
+++ b/scripts/mark-story-done.mjs
@@ -17,13 +17,13 @@
 //   node scripts/mark-story-done.mjs "Story 5.9"     # by reference
 //   DRY_RUN=1 node scripts/mark-story-done.mjs 5-9    # preview only
 
-import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveStorySlugs, STORIES_DIR } from './lib/story-refs.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SPRINT_STATUS = join(ROOT, 'docs/sprint-artifacts/sprint-status.yaml');
-const STORIES_DIR = join(ROOT, 'docs/sprint-artifacts/stories');
 const DRY_RUN = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
 
 const log = (...a) => console.log('[mark-story-done]', ...a);
@@ -35,45 +35,6 @@ const write = (file, contents) => {
     return;
   }
   writeFileSync(file, contents);
-};
-
-const listStories = () =>
-  existsSync(STORIES_DIR) ? readdirSync(STORIES_DIR).filter((f) => f.endsWith('.md')) : [];
-
-const findStoryByPrefix = (prefix) => {
-  const files = listStories();
-  if (files.includes(`${prefix}.md`)) return prefix;
-  const hit = files.find((f) => f.startsWith(`${prefix}-`));
-  return hit ? hit.replace(/\.md$/, '') : null;
-};
-
-const resolveSlugs = (text) => {
-  const slugs = new Set();
-  const trimmed = text.trim();
-
-  // 0) exact slug passed directly
-  if (
-    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) &&
-    existsSync(join(STORIES_DIR, `${trimmed}.md`))
-  ) {
-    return [trimmed];
-  }
-
-  // 1) explicit story-file paths: stories/<slug>.md
-  const pathRe = /stories\/([A-Za-z0-9][A-Za-z0-9._-]*?)\.md/g;
-  let m;
-  while ((m = pathRe.exec(text))) slugs.add(m[1]);
-
-  // 2) fall back to a "Story X.Y" / "X-Y" reference resolved against the stories dir
-  if (slugs.size === 0) {
-    const numRe = /(?:story\s+)?(\d+)[.-](\d+[a-z]?)/gi;
-    while ((m = numRe.exec(text))) {
-      const found = findStoryByPrefix(`${m[1]}-${m[2]}`);
-      if (found) slugs.add(found);
-    }
-  }
-
-  return [...slugs];
 };
 
 const markStoryFile = (slug) => {
@@ -121,7 +82,7 @@ const input =
   process.argv.slice(2).join(' ').trim() ||
   `${process.env.PR_TITLE ?? ''}\n${process.env.PR_BODY ?? ''}`;
 
-const slugs = resolveSlugs(input);
+const slugs = resolveStorySlugs(input);
 
 if (slugs.length === 0) {
   log('No story reference found in input — nothing to do.');

--- a/scripts/mark-story-done.mjs
+++ b/scripts/mark-story-done.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Marks the story referenced by a PR as "done" in BOTH:
+//   - docs/sprint-artifacts/sprint-status.yaml   (the development_status map)
+//   - docs/sprint-artifacts/stories/<slug>.md    (the "**Status:**" line)
+//
+// Story reference resolution (first that matches wins):
+//   0. An exact slug passed as an arg (e.g. "5-9-edit-card").
+//   1. Any `docs/sprint-artifacts/stories/<slug>.md` path found in the input.
+//   2. A "Story X.Y" / "X-Y" reference, resolved by globbing the stories dir.
+//
+// Input comes from CLI args, or the PR_TITLE / PR_BODY env vars (used in CI).
+// Set DRY_RUN=1 to preview changes without writing.
+//
+// Usage:
+//   node scripts/mark-story-done.mjs                  # reads PR_TITLE + PR_BODY
+//   node scripts/mark-story-done.mjs 5-9              # by story number
+//   node scripts/mark-story-done.mjs "Story 5.9"     # by reference
+//   DRY_RUN=1 node scripts/mark-story-done.mjs 5-9    # preview only
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SPRINT_STATUS = join(ROOT, 'docs/sprint-artifacts/sprint-status.yaml');
+const STORIES_DIR = join(ROOT, 'docs/sprint-artifacts/stories');
+const DRY_RUN = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+const log = (...a) => console.log('[mark-story-done]', ...a);
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const write = (file, contents) => {
+  if (DRY_RUN) {
+    log(`(dry-run) would write ${file}`);
+    return;
+  }
+  writeFileSync(file, contents);
+};
+
+const listStories = () =>
+  existsSync(STORIES_DIR) ? readdirSync(STORIES_DIR).filter((f) => f.endsWith('.md')) : [];
+
+const findStoryByPrefix = (prefix) => {
+  const files = listStories();
+  if (files.includes(`${prefix}.md`)) return prefix;
+  const hit = files.find((f) => f.startsWith(`${prefix}-`));
+  return hit ? hit.replace(/\.md$/, '') : null;
+};
+
+const resolveSlugs = (text) => {
+  const slugs = new Set();
+  const trimmed = text.trim();
+
+  // 0) exact slug passed directly
+  if (
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) &&
+    existsSync(join(STORIES_DIR, `${trimmed}.md`))
+  ) {
+    return [trimmed];
+  }
+
+  // 1) explicit story-file paths: stories/<slug>.md
+  const pathRe = /stories\/([A-Za-z0-9][A-Za-z0-9._-]*?)\.md/g;
+  let m;
+  while ((m = pathRe.exec(text))) slugs.add(m[1]);
+
+  // 2) fall back to a "Story X.Y" / "X-Y" reference resolved against the stories dir
+  if (slugs.size === 0) {
+    const numRe = /(?:story\s+)?(\d+)[.-](\d+[a-z]?)/gi;
+    while ((m = numRe.exec(text))) {
+      const found = findStoryByPrefix(`${m[1]}-${m[2]}`);
+      if (found) slugs.add(found);
+    }
+  }
+
+  return [...slugs];
+};
+
+const markStoryFile = (slug) => {
+  const file = join(STORIES_DIR, `${slug}.md`);
+  if (!existsSync(file)) {
+    log(`⚠ story file not found: ${slug}.md`);
+    return false;
+  }
+  const before = readFileSync(file, 'utf8');
+  const after = before.replace(/^\*\*Status:\*\*.*$/m, '**Status:** done');
+  if (after === before) {
+    log(`• story file unchanged (already done or no "**Status:**" line): ${slug}.md`);
+    return false;
+  }
+  write(file, after);
+  log(`✓ story file → done: ${slug}.md`);
+  return true;
+};
+
+const markSprintStatus = (slug) => {
+  if (!existsSync(SPRINT_STATUS)) {
+    log('⚠ sprint-status.yaml not found');
+    return false;
+  }
+  const before = readFileSync(SPRINT_STATUS, 'utf8');
+  // "  <slug>: <status>[ # trailing comment]" — set status to done, keep the comment
+  const re = new RegExp(`^(\\s*${escapeRe(slug)}:\\s*)(\\S+)(.*)$`, 'm');
+  if (!re.test(before)) {
+    log(`⚠ sprint-status has no development_status entry for: ${slug}`);
+    return false;
+  }
+  const after = before.replace(re, (_full, head, _status, tail) => `${head}done${tail}`);
+  if (after === before) {
+    log(`• sprint-status unchanged (already done): ${slug}`);
+    return false;
+  }
+  write(SPRINT_STATUS, after);
+  log(`✓ sprint-status → done: ${slug}`);
+  return true;
+};
+
+// ---- main -------------------------------------------------------------------
+
+const input =
+  process.argv.slice(2).join(' ').trim() ||
+  `${process.env.PR_TITLE ?? ''}\n${process.env.PR_BODY ?? ''}`;
+
+const slugs = resolveSlugs(input);
+
+if (slugs.length === 0) {
+  log('No story reference found in input — nothing to do.');
+  process.exit(0);
+}
+
+log(`Resolved story slug(s): ${slugs.join(', ')}`);
+
+let changed = false;
+for (const slug of slugs) {
+  const storyChanged = markStoryFile(slug);
+  const statusChanged = markSprintStatus(slug);
+  changed = changed || storyChanged || statusChanged;
+}
+
+log(changed ? 'Done — files updated.' : 'No changes (already up to date).');
+process.exit(0);


### PR DESCRIPTION
## Summary

Open-source contribution readiness for myLoyaltyCards: a full English README, a BMAD-SDD `CONTRIBUTING` guide, an MIT `LICENSE`, standardized GitHub PR/issue templates, and two CI automations — one that marks a story `done` on merge, and one that validates PRs against the documented conventions.

## Related story / issue

- Story: `docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md` (Story 11.7)

## Type of change

- [x] ✨ `feat` — story-status automation + PR conventions check
- [x] 📝 `docs` — README, CONTRIBUTING, LICENSE, story
- [x] 🔧 `chore` — GitHub templates, ESLint config

_(One story; see the atomic commits for the per-type breakdown.)_

## Acceptance criteria

- [x] **AC1** — Full English README (stale `.bmad-core/`, Italian watch section, unused libs corrected)
- [x] **AC2** — `CONTRIBUTING.md` enforcing the BMAD spec-first methodology
- [x] **AC3** — MIT `LICENSE`, linked from the README
- [x] **AC4** — PR template + bug/feature/catalogue issue forms + config; `needs-triage` & `catalogue` labels created
- [x] **AC5** — Merge-time story-status automation (`sprint-status.yaml` + story file, committed with `[skip ci]`)
- [x] **AC6** — CI check enforcing Conventional-Commit title, branch naming & spec-first story link

## Screenshots / screen recordings

- [x] Not a user-visible change (docs, templates & CI only — no app UI affected)

## How was this tested?

- `scripts/mark-story-done.mjs`: dry-run + real run on a real story (diff verified, then reverted); correctly resolves Story 11-7.
- `scripts/check-pr-conventions.mjs`: 7 scenarios — valid PR passes; bad title / bad branch / code-without-story fail; `docs:` and catalogue PRs are exempt.
- Quality gates green locally: `yarn typecheck` ✓, `yarn lint` ✓, `yarn test` ✓ (147 suites, 1431 tests). All docs/templates/workflows pass Prettier; scripts pass `node --check`.

## Author checklist

- [x] A `review` story exists and its acceptance criteria are met
- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally (no `--no-verify`)
- [x] New behavior is verified (scripts exercised across scenarios)
- [x] Follows the rules in `docs/project_context.md` and `AGENTS.md`
- [x] `docs/sprint-artifacts/sprint-status.yaml` and the story file are updated
- [x] I performed a self-review of my own changes

---

> **Note:** the two new workflows (`mark-story-done.yml`, `pr-conventions.yml`) only take effect once they're on `main`; they do **not** run on this introducing PR. After merge, mark Story 11-7 `done` (or run `node scripts/mark-story-done.mjs 11-7`), since the automation can't self-complete this PR. To make the conventions check blocking, add **PR conventions** as a required status check in branch protection.
