### PR TITLE
docs: add backlog ticket (logger/Sentry wrapper)

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -353,6 +353,7 @@ development_status:
   #   ~31 className files; shared/theme preserved. Ships ATOMICALLY (no partial release).
   epic-16: backlog
   16-1-migrate-nativewind-to-unistyles: drafted # drafted in party mode 2026-06-04; ONE atomic story (decided NOT to split — solo dev, no partial release). Open decisions for refinement: incremental dev approach + Unistyles v3 plugin coexistence. NOT yet sprinted.
+  16-2-implement-logger-sentry-wrapper: backlog # follow-up from Story 9.2 code review (2026-06-07): docs prescribe a logger/Sentry wrapper but features/ uses console.* directly, so prod error reporting never fires. Implement wrapper + migrate call sites project-wide. Story file drafted.
   epic-16-retrospective: optional
 
   # Epic 17: Apple Wallet Pass Support — FEASIBILITY-FIRST

--- a/docs/sprint-artifacts/stories/16-2-implement-logger-sentry-wrapper.md
+++ b/docs/sprint-artifacts/stories/16-2-implement-logger-sentry-wrapper.md
@@ -1,0 +1,54 @@
+# Story 16.2: Implement logger/Sentry wrapper and migrate console.\* call sites
+
+Status: backlog
+
+Epic: 16 — Platform & Tech Debt
+
+## Story
+
+As a maintainer,
+I want a single logging wrapper that gates debug output on `__DEV__` and routes errors to Sentry in production,
+so that production error reporting actually fires and logging is consistent across the codebase.
+
+## Background / Context
+
+Surfaced during **Story 9.2** code review (2026-06-07). `docs/project_context.md` (Error Handling → Logging) and `CONTRIBUTING.md` prescribe a `logger` wrapper with `Sentry.captureException` in production instead of `console.*`. However:
+
+- **No `logger` wrapper is implemented or used anywhere in `features/`.**
+- Hooks and components call `console.error` / `console.log` directly — e.g. `features/cards/hooks/useTrackCardUsage.ts`, `useDeleteCard.ts`, `useEditCard.ts`, `useAddCard.ts`, `useToggleFavorite.ts`, `features/cards/components/CardDetails.tsx`, `features/settings/hooks/useImportData.ts`, and others.
+- **Net effect: production errors are never captured by Sentry** for these paths.
+
+This is a pre-existing, codebase-wide convention divergence — not introduced by any single feature story — so it should be fixed project-wide in one change.
+
+## Acceptance Criteria (draft — refine before dev)
+
+1. A `logger` module exists (likely `core/utils/logger.ts`, exported from `core/utils`) with `log` / `warn` / `error`:
+   - `log` / `warn` are dev-only (gated on `__DEV__`).
+   - `error` always logs and, in production (`!__DEV__`), calls `Sentry.captureException`.
+2. Sentry is initialised appropriately per environment, or the wrapper degrades gracefully if Sentry isn't configured — and never leaks PII / card data (GDPR — see privacy rules).
+3. All `console.error` / `console.log` / `console.warn` call sites in `features/`, `core/`, `shared/`, and `app/` are migrated to the wrapper (excluding intentional build/dev tooling under `scripts/`).
+4. Tests that currently assert on `console.error` (e.g. `useTrackCardUsage.test.ts`, `useToggleFavorite.test.ts`, `useDeleteCard.test.ts`) are updated to assert on the wrapper.
+5. ESLint enforces the convention (e.g. `no-console`, allowing only the wrapper) so it cannot regress.
+6. `yarn lint`, `yarn typecheck`, `yarn test` all pass; coverage threshold maintained.
+
+## Tasks / Subtasks (draft)
+
+- [ ] Add `core/utils/logger.ts` (+ export from `core/utils`): `log`/`warn`/`error`, `__DEV__` gating, prod `Sentry.captureException`.
+- [ ] Decide on / wire Sentry init (confirm `@sentry/react-native` dependency, env config, PII scrubbing) — or a graceful no-op if Sentry is deferred.
+- [ ] Migrate `console.*` call sites across `features/`, `core/`, `shared/`, `app/` to the wrapper.
+- [ ] Update tests that assert on `console.*` to target the wrapper.
+- [ ] Add/enable an ESLint `no-console` rule (wrapper-allowed); fix violations.
+- [ ] Run all quality gates.
+
+## Tech Notes
+
+- Reference: `docs/project_context.md` → "Error Handling → Logging" (prescribed shape) and "Critical Anti-Patterns" ("Use `console.log` directly ❌ → Use `logger` wrapper ✅").
+- Sibling precedent intentionally left on `console.error` pending this story: `useToggleFavorite.ts` (Story 9.2), `useTrackCardUsage.ts` (Story 9.1).
+- Privacy: do not send card data / PII to Sentry (GDPR rules).
+- Confirm whether `@sentry/*` is already a dependency; if not, installing it is part of this story.
+
+## Definition of Ready (before moving to ready-for-dev)
+
+- [ ] Confirm Sentry is the chosen provider + how it's initialised per environment (dev/prod).
+- [ ] Confirm the exact logger API surface and the ESLint enforcement approach.
+- [ ] Confirm PII-scrubbing requirements.


### PR DESCRIPTION
## Summary

Adds a **backlog ticket** (Epic 16 — Platform & Tech Debt) to implement a `logger`/Sentry wrapper and migrate `console.*` call sites project-wide. Docs-only; no code changes.

## Why

Surfaced during **Story 9.2** review: `docs/project_context.md` (Error Handling → Logging) and `CONTRIBUTING.md` prescribe a `logger` wrapper with `Sentry.captureException` in production — but `features/` calls `console.*` directly, so **production errors are never captured**. This is a pre-existing, codebase-wide convention gap, best fixed in one dedicated change.

## Adds

- `docs/sprint-artifacts/stories/16-2-implement-logger-sentry-wrapper.md` — drafted story: background, draft ACs, draft tasks, Tech Notes, and a Definition-of-Ready (confirm Sentry provider/init, logger API, PII scrubbing).
- `docs/sprint-artifacts/sprint-status.yaml` — `16-2-implement-logger-sentry-wrapper: backlog` under Epic 16.

## Notes

- **Backlog** (to be picked up soon) — not scheduled into a sprint yet.
- Separate from the Story 9.2 PR (#124) so the 9.2 feature stays focused.
- Per CONTRIBUTING, I'm not self-merging — maintainer to review & merge.
