### PR TITLE
docs(backlog): add design-in-code workflow stories (16-3..16-6)

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -354,6 +354,10 @@ development_status:
   epic-16: backlog
   16-1-migrate-nativewind-to-unistyles: drafted # drafted in party mode 2026-06-04; ONE atomic story (decided NOT to split — solo dev, no partial release). Open decisions for refinement: incremental dev approach + Unistyles v3 plugin coexistence. NOT yet sprinted.
   16-2-implement-logger-sentry-wrapper: done # follow-up from Story 9.2 code review (2026-06-07): docs prescribe a logger/Sentry wrapper but features/ uses console.* directly, so prod error reporting never fires. Implement wrapper + migrate call sites project-wide. Story file drafted.
+  16-3-design-contribution-workflow: backlog # design-in-code (party mode 2026-06-08): CONTRIBUTING-DESIGN.md + design label/issue template + PR-conventions exemption + Figma demotion + docs/design/ home. Engine-agnostic. Answers "contribute UX via PRs". NOT yet sprinted.
+  16-4-design-tokens-dtcg-style-dictionary: backlog # promote shared/theme tokens to portable DTCG JSON + Style Dictionary generating tokens.generated.ts; keep catalogue/statusBar/TAILWIND_* hand-authored. Engine-agnostic. NOT yet sprinted.
+  16-5-component-gallery-storybook-chromatic: backlog # web Storybook (react-native-web) + Chromatic (free OSS) for visual component PR review. BLOCKED BY 16-1 (styling engine). NOT yet sprinted.
+  16-6-stand-up-penpot-design-space: backlog # FOLLOW-UP (requested): open no-seat-limit Penpot as ideation surface; repo stays canonical. TRIGGER: real visual designers want in. NOT yet sprinted.
   epic-16-retrospective: optional
 
   # Epic 17: Apple Wallet Pass Support — FEASIBILITY-FIRST

--- a/docs/sprint-artifacts/stories/16-3-design-contribution-workflow.md
+++ b/docs/sprint-artifacts/stories/16-3-design-contribution-workflow.md
@@ -1,0 +1,59 @@
+# Story 16.3: Establish a design-in-code contribution workflow (docs + GitHub scaffolding)
+
+Status: backlog
+
+Epic: 16 — Platform & Tech Debt
+
+## Story
+
+As a maintainer of an open-source project,
+I want a documented, PR-based path for anyone to propose UX/UI changes against the git repo,
+so that design contributors aren't gated behind Figma seats and every design change is versioned and reviewed like code.
+
+## Background / Context
+
+myLoyaltyCards is MIT-licensed and public, but the UX/UI source of truth is a **Figma file** (`4PSsX8SyTUU0GCUdBAAEED`) — a seat-gated space not every contributor can edit. The coupling even leaks into code: Figma node IDs are hardcoded in component comments (`features/cards/components/CardList.tsx:39`, `features/cards/components/EmptyState.tsx:21`).
+
+The decision (party mode, 2026-06-08) is to move to **design-in-code**: the repo becomes the versioned source of truth for design, contributable via PRs. This story covers the **process + documentation + GitHub scaffolding** layer — the part that lets contributors actually find and follow the path. It is **engine-agnostic** (independent of NativeWind vs Unistyles).
+
+It must reconcile with the project's **spec-first** rule (`CONTRIBUTING.md`: no production code without a `ready-for-dev` story). The reconciliation is the crux: not every design tweak should require a full story, but new scope still must.
+
+Sibling stories: 16-4 (token source), 16-5 (Storybook/Chromatic preview — blocked by 16-1), 16-6 (Penpot follow-up).
+
+## Acceptance Criteria (draft — refine before dev)
+
+1. A new guide `docs/design/CONTRIBUTING-DESIGN.md` exists and documents:
+   - The **three design layers** and where each lives: tokens → `shared/theme/*.ts`; components → `shared/components/`, `features/**/components/`; flows/screens → `docs/ux-designs/*.md`, `docs/ux-design-specification.md`.
+   - How to propose a change to each layer via PR.
+   - How reviewers use the Storybook/Chromatic preview (links to 16-5 once it lands).
+   - A **decision table** answering "does this design change need a `ready-for-dev` story?" — token/visual polish with no behavior change → no (use the `design`-label fast-path); new screen/component/behavior → yes (normal spec-first flow).
+   - It **defers** to `CONTRIBUTING.md` for the golden rules rather than duplicating them.
+2. `CONTRIBUTING.md` gains a "🎨 Design / UI change" row in the _Ways to Contribute_ table and a short pointer subsection linking to the new guide (no rule duplication).
+3. A design issue template exists at `.github/ISSUE_TEMPLATE/design_request.yml`, mirroring `feature_request.yml` (YAML form, spec-first preamble, a `layer` dropdown: token / component / flow / not-sure, labels `design` + `needs-triage`).
+4. A `design` PR label is defined, and `scripts/check-pr-conventions.mjs` is extended so `design`-labelled PRs are story-exempt — a one-line addition (`|| LABELS.includes('design')`) to the existing `storyExempt` expression (currently `scripts/check-pr-conventions.mjs:58-59`), reusing the label seam already wired via `PR_LABELS`. The script header comment documents the new exemption. **No new Conventional-Commit type is introduced** (`design:` would fail the title regex; allowed types stay feat|fix|refactor|docs|test|chore).
+5. `.github/PULL_REQUEST_TEMPLATE.md` is updated so design PRs may link a Storybook/Chromatic preview in lieu of manual before/after screenshots — **with the explicit carve-out that the native (Swift) Apple Watch UI and any screen not covered by Storybook still require screenshots**. A `design`-label hint is added to the _Type of change_ list.
+6. The **Figma coupling is gracefully demoted**: the two hardcoded node-ID comments (`CardList.tsx:39`, `EmptyState.tsx:21`) are re-anchored to repo references (token names / Storybook story IDs once available), preserving the old node ID as a one-line historical breadcrumb. A single canonical "Figma is now ideation-only, the repo is canonical" note lives in the design guide. The ~11 soft "Figma: …" prose comments (no node ID) are left untouched this round.
+7. `docs/design/` is established as the home for versionable diagram sources — Excalidraw (`.excalidraw` JSON + exported `.svg`) for wireframes and Mermaid-in-markdown for flows — with a `docs/design/README.md` index. Existing `docs/ux-designs/` and `docs/ux-design-specification.md` are unchanged.
+
+## Tasks / Subtasks (draft)
+
+- [ ] Draft `docs/design/CONTRIBUTING-DESIGN.md` (layers, per-layer PR path, story-vs-no-story decision table, reviewer guide).
+- [ ] Add the _Ways to Contribute_ row + ToC pointer in `CONTRIBUTING.md`.
+- [ ] Create `.github/ISSUE_TEMPLATE/design_request.yml` (mirror `feature_request.yml`).
+- [ ] Add `|| LABELS.includes('design')` to `storyExempt` in `scripts/check-pr-conventions.mjs` + header comment; create the `design` GitHub label (`gh label create design`).
+- [ ] Update `.github/PULL_REQUEST_TEMPLATE.md` (Storybook/Chromatic link option + watch-UI screenshot carve-out + `design` type hint).
+- [ ] Re-anchor the 2 hardcoded Figma node-ID comments; add the canonical deprecation note to the guide.
+- [ ] Create `docs/design/` (`wireframes/`, `flows/`, `README.md` index).
+
+## Tech Notes
+
+- Keep it **lean** — this is process scaffolding, not a framework. Reuse the existing label-exemption mechanism rather than inventing new CI.
+- The `design`-label story exemption is the one genuinely new policy; keep it narrow (token/visual polish only).
+- Engine-agnostic: unaffected by 16-1 (NativeWind → Unistyles).
+- Reviewer-preview wording should link to 16-5 deliverables and degrade gracefully until 16-5 lands.
+
+## Definition of Ready (before moving to ready-for-dev)
+
+- [ ] Confirm the `design` GitHub label is (or will be) created.
+- [ ] Confirm the `docs/design/` location and structure.
+- [ ] Confirm the story-vs-no-story policy wording with the maintainer.

--- a/docs/sprint-artifacts/stories/16-4-design-tokens-dtcg-style-dictionary.md
+++ b/docs/sprint-artifacts/stories/16-4-design-tokens-dtcg-style-dictionary.md
@@ -1,0 +1,55 @@
+# Story 16.4: Make design tokens a portable DTCG source via Style Dictionary
+
+Status: backlog
+
+Epic: 16 — Platform & Tech Debt
+
+## Story
+
+As a design contributor,
+I want the design tokens available in a portable, human-diffable JSON format that generates the existing TypeScript,
+so that token changes are easy to review in a PR and the tokens are portable to other tools (Figma Tokens plugin, Penpot) — without breaking the app.
+
+## Background / Context
+
+Design tokens already live in code at `shared/theme/colors.ts`, `spacing.ts`, and `typography.ts`, but only as TypeScript — not a portable, tool-agnostic artifact. Moving the _canonical_ values into the **W3C Design Tokens (DTCG) JSON** format and generating the TS via **Style Dictionary** gives a single, diff-friendly, tool-portable source.
+
+**Verified constraints (these shape a layered, low-risk approach):**
+
+- `colors.ts` mixes pure tokens with **catalogue-runtime** data: `import catalogueData from '../../catalogue/italy.json'` → `BRAND_COLORS` / `getBrandColor`.
+- It also carries a non-token `statusBar: 'dark'|'light'` literal and a set of **derived `TAILWIND_*` exports** that `tailwind.config.js` consumes **by name**.
+- `spacing.ts` builds `TAILWIND_SPACING`/`TAILWIND_TOUCH_TARGET` by interpolation; `typography.ts` emits a Tailwind **tuple** shape (`['34px', { … }]`).
+- `colors.contrast.test.ts` imports `LIGHT_THEME`/`DARK_THEME`.
+
+⇒ Style Dictionary **cannot own these files wholesale**. The approach generates only the _primitive records_ and keeps all derived / runtime / tuple logic hand-authored.
+
+Engine-agnostic: 16-1 (NativeWind → Unistyles) explicitly preserves `shared/theme/` as the token source, so this work survives that migration.
+
+## Acceptance Criteria (draft — refine before dev)
+
+1. `tokens/*.json` (DTCG format) authored for **primitives + semantic color maps only**: `PRIMARY_COLORS`, `NEUTRAL_COLORS`, `CARD_COLORS`, the color members of `LIGHT_THEME`/`DARK_THEME` (excluding `statusBar`), `SPACING`, `TOUCH_TARGET`, `LAYOUT`, and `TYPOGRAPHY`.
+2. A Style Dictionary config generates `shared/theme/tokens.generated.ts` with the exact existing constant names and `as const` shapes. The generated file is **committed** (not gitignored) so Metro / Jest / tsc need no build step.
+3. `colors.ts` / `spacing.ts` / `typography.ts` are refactored to **import primitives** from `tokens.generated.ts` while keeping hand-authored: `BRAND_COLORS`/`getBrandColor`, `statusBar`, all `TAILWIND_*` exports, the typography tuple builder, the spacing interpolation. All **public named exports remain byte-stable**, so `tailwind.config.js`, every `@/shared/theme` consumer, and `colors.contrast.test.ts` work unchanged.
+4. `tokens:build` and `tokens:check` scripts exist; `tokens:check` regenerates to a temp location and `git diff --exit-code`s against the committed file (drift guard), mirroring the existing `check:catalogue-generated` pattern. A CI step runs `tokens:check`.
+5. `yarn typecheck` and `yarn test` pass; the WCAG contrast test (`colors.contrast.test.ts`) is the canary and stays green.
+
+## Tasks / Subtasks (draft)
+
+- [ ] Transcribe current literal values into `tokens/*.json` (DTCG).
+- [ ] Add `style-dictionary` dev-dependency + `style-dictionary.config.mjs` with a custom TS format that reproduces the existing primitive shapes/keys.
+- [ ] Generate `shared/theme/tokens.generated.ts`; `git diff` to confirm byte-for-byte parity with today's values.
+- [ ] Refactor the three theme files to import primitives; keep derived/runtime exports hand-authored.
+- [ ] Add `tokens:build` + `tokens:check` scripts + a CI guard step.
+- [ ] Run `yarn typecheck` + `yarn test`; confirm contrast test green.
+
+## Tech Notes
+
+- **MVP** = colors + spacing primitives. The **typography tuple** and `sync-tokens` generation are **nice-to-have** (they need the fiddliest custom formats) — defer.
+- Honest framing: the JSON-canonical layer is what delivers "versioned, PR-able tokens"; the Style Dictionary codegen is the _means_, and its real payoff is **portability** (DTCG is readable by Figma Tokens / other tools), not necessity — the tokens already work in TS today.
+- Do **not** move `BRAND_COLORS`/`getBrandColor`/`statusBar` into JSON; they are catalogue-runtime / non-token data.
+
+## Definition of Ready (before moving to ready-for-dev)
+
+- [ ] Confirm the decision to commit `tokens.generated.ts` (recommended) vs gitignore + build step.
+- [ ] Confirm the MVP token scope (colors + spacing first; typography/sync deferred).
+- [ ] Confirm the DTCG file layout under `tokens/`.

--- a/docs/sprint-artifacts/stories/16-5-component-gallery-storybook-chromatic.md
+++ b/docs/sprint-artifacts/stories/16-5-component-gallery-storybook-chromatic.md
@@ -1,0 +1,54 @@
+# Story 16.5: Component preview gallery — Storybook + Chromatic [Blocked by 16-1]
+
+Status: backlog
+
+Epic: 16 — Platform & Tech Debt
+
+## Story
+
+As a reviewer or design contributor,
+I want a public component gallery with visual-regression review on every PR,
+so that UI/design changes are reviewable without building the app locally or holding a Figma seat.
+
+## Background / Context
+
+The component library lives at `shared/components/ui/` (Button, TextField, ActionRow, BottomSheet, CardShell, ColorPicker, ToggleSwitch) but there is **no Storybook** today. A web-served Storybook (via `react-native-web`) published through **Chromatic** (free for open source) gives every PR a public component preview plus visual-diff review — the closest thing to a git-anchored, account-free "design review surface."
+
+**Dependency — `Blocked by: 16-1`.** Story 16-1 replaces NativeWind with react-native-unistyles and deletes `tailwind.config.js` / `global.css`. The web rendering pipeline for Storybook is styling-engine-specific, so we build it **once, against the final engine** to avoid throwaway plumbing.
+
+> Open decision (resolve at refinement, per maintainer): if 16-1 is deprioritized, build engine-agnostically by theming stories via the existing `ThemeProvider` + inline-style path (preserved by both engines), treating class-based layout as best-effort. This needs a **spike** first: Unistyles-3's native (Nitro/C++, New-Architecture) core rendering under `react-native-web` is unproven.
+
+Components theme via `useTheme()` + inline styles (`className` is mostly layout), which is the safety net: colors/typography render correctly through the ThemeProvider even if class-based styling is imperfect on web.
+
+## Acceptance Criteria (draft — refine before dev)
+
+1. A web Storybook (`react-native-web`, e.g. `@storybook/react-native-web-vite`) renders the `shared/components/ui` primitives in **light and dark** via a `ThemeProvider` decorator that mocks `core/settings` (the `Button` test's `jest.mock('@/shared/theme')` shows the isolation pattern); i18n is initialized and stories are wrapped in `SafeAreaProvider` so `ColorPicker`/`BottomSheet` render.
+2. Stories exist for the 7 primitives. **MVP:** Button / TextField / ToggleSwitch / CardShell (no i18n/icon/portal deps); then ActionRow / ColorPicker / BottomSheet (require vector-icon fonts + i18n + Modal-on-web verification).
+3. **Chromatic** (free OSS tier) publishes on PRs via a **separate, path-filtered** `.github/workflows/chromatic.yml` that mirrors `ci-quality-gates.yml` (Node 24, yarn `sdk55` cache, `fetch-depth: 0`) and uses `onlyChanged`/TurboSnap to stay within quota. PRs get a public preview URL + visual diffs; a README badge links the published Storybook. The existing merge gates are **not** slowed.
+4. An ESLint override for `**/*.stories.tsx` disables `i18next/no-literal-string` and exempts `boundaries`, so `yarn lint` (a merge gate) stays green.
+5. `storybook`, `build-storybook`, and `chromatic` scripts are added to `package.json`.
+
+## Tasks / Subtasks (draft)
+
+- [ ] (Gate) Confirm 16-1 done, or take the refinement decision + run the Unistyles-on-web spike.
+- [ ] Add Storybook + `react-native-web` deps; create `.storybook/main.ts` + `preview.tsx` (theme/i18n/SafeArea decorators; reproduce the styling pipeline on web).
+- [ ] Seed the 4 MVP stories; verify the light/dark toggle renders.
+- [ ] Add the 3 dependency-heavier stories (vector-icon fonts, i18n, Modal-on-web).
+- [ ] Add the ESLint stories override.
+- [ ] Create the Chromatic project + `CHROMATIC_PROJECT_TOKEN` secret; add `chromatic.yml` (path-filtered, `onlyChanged`) + README badge.
+
+## Tech Notes
+
+- Biggest risk is the **CSS pipeline on web** (NativeWind-under-Vite pre-16-1, or Unistyles-on-web post-16-1 — both unproven). Safety net: `useTheme()` inline styling renders colors/typography regardless.
+- Reanimated / gesture-handler are **not** used by the `ui/` primitives, so they are not a blocker for the MVP.
+- Keep the Chromatic workflow off the critical merge path; path-filter to UI surfaces only.
+
+## Definition of Ready (before moving to ready-for-dev)
+
+- [ ] 16-1 is `done` — OR a refinement decision to build engine-agnostically, with the Unistyles-on-web spike passed.
+- [ ] Chromatic project created and `CHROMATIC_PROJECT_TOKEN` available as a GitHub secret.
+- [ ] MVP story scope confirmed.
+
+## Blocks
+
+- **Blocked by:** 16-1 (styling engine migration NativeWind → Unistyles).

--- a/docs/sprint-artifacts/stories/16-6-stand-up-penpot-design-space.md
+++ b/docs/sprint-artifacts/stories/16-6-stand-up-penpot-design-space.md
@@ -1,0 +1,60 @@
+# Story 16.6: Stand up an open Penpot design space for visual designers
+
+Status: backlog
+
+Epic: 16 — Platform & Tech Debt
+
+## Story
+
+As a maintainer who wants non-coding visual designers to contribute,
+I want an open, no-seat-limit Penpot instance set up as a shared design space,
+so that designers can explore and propose UI/UX visually without a Figma seat — while the git repo (tokens + Storybook components) remains the single canonical source of truth.
+
+## Background / Context
+
+myLoyaltyCards is moving to a **design-in-code** model (see 16-3): tokens in `shared/theme/*.ts`, components in Storybook (16-5), flows in `docs/ux-designs/` — all versioned in git and reviewed via PR. The repo is canonical.
+
+The legacy design source of truth was **Figma** (file `4PSsX8SyTUU0GCUdBAAEED`), used through the Epic 12/13 design overhaul. Figma is proprietary and seat-limited — a poor fit for a community-driven OSS project, because it gates exactly the contributors we most want: non-coding visual designers who can't or won't edit `shared/theme/*.ts` directly.
+
+**Penpot** is open-source, web-based, and has no per-seat cost — a natural **open ideation/exploration surface**. This is the follow-up explicitly requested when the design-in-code direction was chosen (party mode, 2026-06-08). It is **demand-triggered, not speculative.**
+
+> **The rule this story must preserve:** Penpot = **exploration / ideation**; the repo = **canonical**. A Penpot mock is never "the design" — it becomes real only when it lands in the repo via the design-contribution PR flow (16-3). Penpot replaces Figma as an _open_ place to explore; the source-of-truth role moves to the repo regardless.
+
+## Trigger condition (do NOT start before this)
+
+Start only when **real visual (non-coding) designers actually want to contribute** — e.g. someone opens a 🎨 Design issue/discussion asking for a visual workspace, or a maintainer is actively onboarding a designer. Until then this stays `backlog`. Standing up and maintaining a Penpot instance with no designers using it is wasted effort.
+
+## Acceptance Criteria (draft — refine before dev)
+
+1. The **cloud vs self-host** decision is made and recorded (a short ADR-style note or a section in `docs/design/CONTRIBUTING-DESIGN.md`). Default recommendation: **Penpot cloud** (zero-ops, no seat cost) to start.
+2. An **open, no-seat-limit** Penpot workspace exists, with access open to contributors (open team / invite link, or open registration on a self-hosted instance).
+3. The repo-is-canonical relationship is documented in `docs/design/CONTRIBUTING-DESIGN.md`, including a one-line "how to take a Penpot exploration to a repo PR" path.
+4. **Lightweight seeding:** the current palette / typography / spacing from `shared/theme/*.ts` are represented in Penpot (a starter library or single reference page) so designers explore against the real system. Manual/one-off is fine — **no automated token sync is in scope.**
+5. The Figma deprecation note is updated to point at Penpot as the open exploration surface (coordinate with the 16-3 Figma demotion).
+6. **No change to the canonical pipeline:** tokens, Storybook, and `docs/ux-designs/` remain the source of truth; nothing in the app build depends on Penpot.
+
+## Tasks / Subtasks (draft)
+
+- [ ] Decide self-host vs cloud; record the decision (AC1).
+- [ ] Create the workspace/team; configure open access (AC2).
+- [ ] Seed a starter library/reference page from `shared/theme/*.ts` (AC4).
+- [ ] Document "Penpot = ideation, repo = canonical" + the explore→PR path in `docs/design/CONTRIBUTING-DESIGN.md` (AC3).
+- [ ] Update the Figma deprecation note to mention Penpot (AC5).
+- [ ] (If self-host) document the deploy (Docker Compose), backups, and who operates it.
+
+## Tech Notes
+
+- **Effort:** ~S for Penpot cloud (create team, invite link, seed one page, write docs — ~half a day); ~M for self-host (Docker Compose, domain/TLS, auth, backups, ongoing ops). Start on cloud; self-host only if ownership/scale justify it later.
+- **Out of scope (keep lean):** automated Penpot↔repo token sync, Penpot→code generation, wholesale migration of existing Figma frames. Seeding is a manual reference snapshot only.
+- Does not touch CI, the app build, or quality gates — it is an external collaboration surface, not a repo dependency.
+
+## Definition of Ready (before moving to ready-for-dev)
+
+- [ ] Trigger condition met: a real visual designer wants to contribute.
+- [ ] Self-host vs cloud decided (or deferred to the implementer with a cloud default).
+- [ ] Owner identified for the instance/workspace (especially if self-hosting).
+- [ ] `docs/design/CONTRIBUTING-DESIGN.md` exists (depends on 16-3 landing first).
+
+## Blocks
+
+- **Soft-depends on:** 16-3 (the design-contribution guide it documents the Penpot relationship in).


### PR DESCRIPTION
## Summary

Adds four `backlog` story stubs under **Epic 16 — Platform & Tech Debt** capturing the **design-in-code** initiative: an OSS-friendly, git-versioned way to evolve UX/UI that anyone can contribute to via PRs, replacing the seat-gated Figma source of truth. Drafted collaboratively in party mode (2026-06-08). Specs only — **no implementation**.

| Story | Scope | State |
| --- | --- | --- |
| **16-3** Design-contribution workflow & docs | `CONTRIBUTING-DESIGN.md`, `design` label + issue template, PR-conventions story-exemption, Figma demotion, `docs/design/` home | engine-agnostic |
| **16-4** Design tokens as portable DTCG source | promote `shared/theme` tokens to W3C DTCG JSON + Style Dictionary generating the existing TS | engine-agnostic |
| **16-5** Component gallery: Storybook + Chromatic | public, account-free visual component review on every PR | **Blocked by 16-1** (NativeWind → Unistyles) |
| **16-6** Open Penpot design space | the requested follow-up; open ideation surface, repo stays canonical | trigger-gated |

Plus the four Epic 16 registration lines in `sprint-status.yaml`.

## Related story / issue

N/A — this PR *creates* the backlog stories. It is a `docs:` change, **story-exempt** per `CONTRIBUTING.md` / `scripts/check-pr-conventions.mjs`.

## Type of change

- [x] 📝 `docs` — documentation / specs

## Acceptance criteria

N/A — these are `backlog` stubs. Each carries its own *draft* ACs, to be refined when promoted to `ready-for-dev` via the SM `create-story` workflow.

## Screenshots / screen recordings

- [x] Not a user-visible change (no screenshots needed)

## How was this tested?

- `sprint-status.yaml` validated as parseable YAML (js-yaml); the 4 new Epic 16 keys are present and correctly indented.
- Pre-push gate ran clean: **typecheck + lint + 1463 tests / 150 suites all green** (no `--no-verify`).

## Author checklist

- [x] N/A — `docs:`/backlog (story-exempt); this PR *creates* backlog stories rather than consuming a `ready-for-dev` one
- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally (I did **not** use `--no-verify`)
- [x] N/A — docs only, no new behavior to test
- [x] Follows the layer boundaries & rules in `docs/project_context.md` and `AGENTS.md`
- [x] `docs/sprint-artifacts/sprint-status.yaml` and the story files are updated
- [x] I performed a self-review of my own changes

---

> 🔍 Maintainer review requested — not self-merging.