### PR TITLE
feat(cards): favourites-first smart sort + persist list scroll (Story 9.3)

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -262,7 +262,7 @@ development_status:
   epic-9: in-progress
   9-1-track-card-usage: done
   9-2-mark-card-as-favorite: done # design signed off 2026-06-07 (Figma frame approved); impl + code review + QA complete; awaiting stakeholder commit approval
-  9-3-implement-sorting-algorithm: ready-for-dev
+  9-3-implement-sorting-algorithm: review
   9-4-sync-sorting-to-watch: ready-for-dev
   epic-9-retrospective: optional
 

--- a/docs/sprint-artifacts/stories/9-3-implement-sorting-algorithm.md
+++ b/docs/sprint-artifacts/stories/9-3-implement-sorting-algorithm.md
@@ -1,6 +1,6 @@
 # Story 9.3: Implement Sorting Algorithm
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -26,26 +26,43 @@ so that the right card is near the top when I need it.
    **When** I visit my usual store
    **Then** the correct card appears in the top 3 positions at least 95% of the time
 
-4. **Given** I change the sort option to "A-Z" or "Recently Added"
-   **When** I view the card list
-   **Then** the favourite-first rule does NOT apply (user explicitly chose a different order)
+4. **Given** I change the sort option:
+   - **"A-Z"** → favourites remain pinned to the top, then names sort alphabetically within the favourite and non-favourite groups
+   - **"Recently Added"** → the favourite-first rule does NOT apply (user explicitly chose chronological order)
 
 5. **Given** the "Frequently Used" sort label
    **When** it is displayed in `SortFilterRow`
    **Then** the label reads as the smart sort option (existing i18n key `cards.sort.frequent` — no label change required unless Ifero requests it)
 
+6. **Given** I have scrolled down the card list and open a card's details
+   **When** I navigate back to the list
+   **Then** the list preserves my scroll position (it does NOT jump back to the top)
+   _(Added 2026-06-08, stakeholder-directed: folded into 9.3 — see Dev Notes.)_
+
 ## Tasks / Subtasks
 
-- [ ] Update `sortByFrequent` in `features/cards/hooks/useCardSort.ts` (AC: 1, 2, 4)
-  - [ ] Add `isFavorite` as the top-tier: if `a.isFavorite !== b.isFavorite`, favourites win (`return a.isFavorite ? -1 : 1`)
-  - [ ] Keep the remaining tiers unchanged: `usageCount desc → lastUsedAt desc → createdAt desc`
-  - [ ] Do NOT change `sortByRecent` or `sortByAZ` (AC: 4)
-- [ ] Update `useCardSort.test.ts` to cover new sort tier (AC: 1, 2, 4)
-  - [ ] Test: favourite card sorts above higher-usageCount non-favourite
-  - [ ] Test: two favourite cards are then sorted by usageCount
-  - [ ] Test: `sortByRecent` and `sortByAZ` are unaffected by `isFavorite`
+- [x] Update `sortByFrequent` in `features/cards/hooks/useCardSort.ts` (AC: 1, 2)
+  - [x] Add `isFavorite` as the top-tier: if `a.isFavorite !== b.isFavorite`, favourites win (`return a.isFavorite ? -1 : 1`)
+  - [x] Keep the remaining tiers unchanged: `usageCount desc → lastUsedAt desc → createdAt desc`
+- [x] Apply favourite pinning per corrected AC4 (AC: 4)
+  - [x] Extract a shared `compareFavoriteFirst` helper (reused by `sortByFrequent` and `sortByAZ`)
+  - [x] Pin favourites first in `sortByAZ`, then alphabetical within each group
+  - [x] Do NOT pin favourites in `sortByRecent` (chronological order preserved)
+- [x] Update `useCardSort.test.ts` to cover new sort behavior (AC: 1, 2, 3, 4)
+  - [x] Test: favourite card sorts above higher-usageCount non-favourite
+  - [x] Test: mixed list orders favourites block (by usageCount) ahead of non-favourites block
+  - [x] Test: favourite "usual store" card lands in the top 3 of a 10-card list (AC: 3)
+  - [x] Test: `sortByAZ` pins favourites first, then alphabetical within each group (AC: 4)
+  - [x] Test: `sortByRecent` is unaffected by `isFavorite` (AC: 4)
+- [x] Preserve card-list scroll position on back-navigation (AC: 6)
+  - [x] `useCards`: only drive `isLoading` on the initial load, not on focus refetches, so `CardList` keeps its `FlashList` mounted (no remount → scroll preserved)
+  - [x] Update `useCards.test.ts`: a refetch keeps `isLoading` false (initial load still sets it true)
 
 ## Dev Notes
+
+> ⚠️ **Requirement update (2026-06-08, stakeholder-directed):** AC4 was corrected — favourite pinning **also applies to the "A-Z" sort** (favourites pinned to the top, then alphabetical within each group), but **not** to "Recently Added". The original notes below (including the "do NOT touch `sortByAZ`" guidance and the `sortByAZ ignores isFavorite` test sketch) predate this change and are retained for historical context only; the authoritative behavior is the updated AC4 above. Implementation extracts a shared `compareFavoriteFirst` helper reused by both `sortByFrequent` and `sortByAZ`.
+
+> ➕ **Scope addition (2026-06-08, stakeholder-directed):** AC6 (card-list scroll persistence) was folded into this story. **Root cause:** `CardList` refetches on focus (`useFocusEffect` → `refetch()`), and `useCards.fetchCards()` set `isLoading = true` on _every_ call; `CardList` renders a full-screen spinner whenever `isLoading` is true (`if (isLoading) return <ActivityIndicator/>`), so the focus refetch unmounted and remounted the `FlashList`, resetting scroll to the top. **Fix:** `useCards` only sets `isLoading` on the initial load (guarded by `hasLoadedRef`); focus refetches update data in place so the `FlashList` stays mounted and scroll is preserved. Viewing a card still bumps `usageCount`/`lastUsedAt` (Story 9.1), so the "Frequently used" order may legitimately change on return — but the scroll offset is retained, not reset.
 
 ### The change is minimal — one insertion into an existing comparator
 
@@ -134,10 +151,38 @@ it('sortByAZ ignores isFavorite', () => {
 
 ### Agent Model Used
 
-_to be filled by dev agent_
+claude-opus-4-8 (Amelia — Developer Agent, BMM dev-story workflow)
 
 ### Debug Log References
 
+- Full test suite: 150 suites / 1468 tests passing.
+- `useCards` suite: 10/10 passing (focus refetch no longer flips `isLoading`; initial-load spinner preserved — AC6).
+- `useCardSort` suite: 16/16 passing (TDD red→green confirmed — favourites-first test failed against the pre-change comparator, passed after the Tier 0 insertion). The mixed-list, AC3 top-3, and A-Z favourite-pinning tests also fail against the pre-change comparators, confirming they guard the new behavior.
+- `yarn typecheck` clean; `yarn lint` clean; target files Prettier-compliant.
+
 ### Completion Notes List
 
+- **AC1, AC2 (favourites-first):** Added Tier 0 to `sortByFrequent` — `if (a.isFavorite !== b.isFavorite) return a.isFavorite ? -1 : 1;` — so favourites sort above all non-favourites regardless of `usageCount`. Existing tiers (usageCount desc → lastUsedAt desc → createdAt desc) are unchanged and now apply within each favourite/non-favourite group.
+- **AC4 (corrected — A-Z pins favourites, Recently Added does not):** Per stakeholder direction (2026-06-08), favourite pinning now also applies to "A-Z" (favourites pinned to the top, then alphabetical within each group) via the shared `compareFavoriteFirst` helper; "Recently Added" remains pure chronological (favourites NOT pinned). Tests assert the A-Z pinning order and that `recent` is unaffected by `isFavorite`.
+- **AC3 (right card in top 3 ≥95%):** Covered by a deterministic 10-card test asserting the favourite "usual store" card lands in the top 3 even with only moderate usage — the tier ordering (favourites → frequency → recency) delivers this outcome. No separate code path required; the frequency/recency tiers were already in place from earlier stories and are preserved.
+- **QA follow-up (2026-06-08):** Added an integrated mixed favourites/non-favourites test and the AC3 top-3 test, and replaced the redundant "two favourites by usageCount" test (which did not exercise the new tier) — both new tests are verified to fail against the pre-change comparator.
+- **AC5 (label):** No change required — existing i18n key `cards.sort.frequent` ("Frequently used") is retained per story note.
+- **AC6 (scroll persistence — folded in per stakeholder direction):** Fixed `useCards` so a focus refetch no longer flips `isLoading` to `true` (guarded by `hasLoadedRef`); `CardList` keeps its `FlashList` mounted on back-navigation instead of remounting at the top. `CardList` is the only consumer of `useCards().isLoading`, so the blast radius is contained. Updated the `useCards` refetch test to assert the corrected behaviour (initial load still shows the spinner).
+- Updated the hook JSDoc to document favourite pinning in both "Frequently used" and "A-Z", and that "Recently added" is not pinned.
+- No new dependencies; change is contained to the `features/cards` layer (no layer-boundary impact).
+
 ### File List
+
+- `features/cards/hooks/useCardSort.ts` — Modified: added `compareFavoriteFirst` helper; favourites tier in `sortByFrequent` and `sortByAZ`; `sortByRecent` unchanged; updated JSDoc.
+- `features/cards/hooks/useCardSort.test.ts` — Modified: added favourites-tier tests (AC1, AC2), AC3 top-3 test, A-Z favourite-pinning test, and the `recent` not-pinned guard (AC4).
+- `features/cards/hooks/useCards.ts` — Modified: only set `isLoading` on the initial load (added `hasLoadedRef`) so focus refetches don't unmount `CardList`'s list (AC6 scroll persistence).
+- `features/cards/hooks/useCards.test.ts` — Modified: updated the refetch test to assert `isLoading` stays `false` on a refetch (AC6).
+
+## Change Log
+
+| Date       | Description                                                                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-08 | Implemented favourites-first tier in `sortByFrequent` (Story 9.3, AC1/AC2/AC4); added tests.                                                                                            |
+| 2026-06-08 | QA follow-up: added integrated mixed-list test + AC3 top-3 test; removed redundant two-favourites test.                                                                                 |
+| 2026-06-08 | Stakeholder-directed AC4 correction: favourite pinning now applies to "A-Z" (not "Recently Added"); extracted `compareFavoriteFirst` helper; updated tests + JSDoc.                     |
+| 2026-06-08 | Stakeholder-directed AC6 fold-in: card-list scroll persistence — `useCards` keeps `isLoading` false on focus refetches so `CardList` doesn't remount the list; updated `useCards` test. |

--- a/features/cards/hooks/useCardSort.test.ts
+++ b/features/cards/hooks/useCardSort.test.ts
@@ -138,6 +138,63 @@ describe('useCardSort', () => {
     });
   });
 
+  describe('sortCards — favourites tier (Story 9.3)', () => {
+    it('sorts favourites above non-favourites regardless of usageCount (AC1, AC2)', () => {
+      const favCards = [
+        makeCard({ id: '1', name: 'Alpha', isFavorite: false, usageCount: 100 }),
+        makeCard({ id: '2', name: 'Beta', isFavorite: true, usageCount: 0 })
+      ];
+
+      const { result } = renderHook(() => useCardSort());
+      const sorted = result.current.sortCards(favCards);
+
+      // Beta is favourite → wins despite zero usage vs Alpha's 100
+      expect(sorted.map((c) => c.id)).toEqual(['2', '1']);
+    });
+
+    it('orders the favourites block (by usageCount) ahead of the non-favourites block in a mixed list (AC1, AC2)', () => {
+      const mixed = [
+        makeCard({ id: 'nf-hi', isFavorite: false, usageCount: 100 }),
+        makeCard({ id: 'fav-lo', isFavorite: true, usageCount: 1 }),
+        makeCard({ id: 'nf-lo', isFavorite: false, usageCount: 5 }),
+        makeCard({ id: 'fav-hi', isFavorite: true, usageCount: 9 })
+      ];
+
+      const { result } = renderHook(() => useCardSort());
+      const sorted = result.current.sortCards(mixed);
+
+      // Favourites first, ordered by usageCount (9 > 1), then non-favourites by usageCount
+      // (100 > 5). The favourite with usageCount 1 still outranks the non-favourite with 100.
+      expect(sorted.map((c) => c.id)).toEqual(['fav-hi', 'fav-lo', 'nf-hi', 'nf-lo']);
+    });
+
+    it('keeps the favourite "usual store" card in the top 3 of a 10-card list (AC3)', () => {
+      const tenCards = [
+        // User-designated favourite with only moderate usage — must still surface near the top.
+        makeCard({ id: 'primary', isFavorite: true, usageCount: 12 }),
+        makeCard({ id: 'c2', usageCount: 30 }),
+        makeCard({ id: 'c3', usageCount: 25 }),
+        makeCard({ id: 'c4', usageCount: 20 }),
+        makeCard({ id: 'c5', usageCount: 15 }),
+        makeCard({ id: 'c6', usageCount: 10 }),
+        makeCard({ id: 'c7', usageCount: 8 }),
+        makeCard({ id: 'c8', usageCount: 5 }),
+        makeCard({ id: 'c9', usageCount: 2 }),
+        makeCard({ id: 'c10', usageCount: 0 })
+      ];
+
+      const { result } = renderHook(() => useCardSort());
+      const top3 = result.current
+        .sortCards(tenCards)
+        .slice(0, 3)
+        .map((c) => c.id);
+
+      // AC3: the relevant card (the favourite "usual store" card) lands in the top 3 — the
+      // favourite leads via Tier 0, then the two highest-usage non-favourites follow.
+      expect(top3).toEqual(['primary', 'c2', 'c3']);
+    });
+  });
+
   describe('sortCards — recent', () => {
     it('sorts by createdAt descending', () => {
       const { result } = renderHook(() => useCardSort());
@@ -148,6 +205,33 @@ describe('useCardSort', () => {
 
       const sorted = result.current.sortCards(cards);
       expect(sorted.map((c) => c.name)).toEqual(['Delta', 'Charlie', 'Bravo', 'Alpha']);
+    });
+
+    it('ignores isFavorite — favourite-first rule does not apply (AC4)', () => {
+      const recentCards = [
+        makeCard({
+          id: '1',
+          name: 'Old',
+          isFavorite: true,
+          createdAt: '2026-01-01T00:00:00Z'
+        }),
+        makeCard({
+          id: '2',
+          name: 'New',
+          isFavorite: false,
+          createdAt: '2026-02-01T00:00:00Z'
+        })
+      ];
+
+      const { result } = renderHook(() => useCardSort());
+
+      act(() => {
+        result.current.setSortOption('recent');
+      });
+
+      const sorted = result.current.sortCards(recentCards);
+      // New created later → first, despite Old being favourite
+      expect(sorted.map((c) => c.name)).toEqual(['New', 'Old']);
     });
   });
 
@@ -161,6 +245,25 @@ describe('useCardSort', () => {
 
       const sorted = result.current.sortCards(cards);
       expect(sorted.map((c) => c.name)).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta']);
+    });
+
+    it('pins favourites to the top, then sorts alphabetically within each group (AC4)', () => {
+      const azCards = [
+        makeCard({ id: '1', name: 'Apple', isFavorite: false }),
+        makeCard({ id: '2', name: 'Zebra', isFavorite: true }),
+        makeCard({ id: '3', name: 'Mango', isFavorite: true }),
+        makeCard({ id: '4', name: 'Banana', isFavorite: false })
+      ];
+
+      const { result } = renderHook(() => useCardSort());
+
+      act(() => {
+        result.current.setSortOption('az');
+      });
+
+      const sorted = result.current.sortCards(azCards);
+      // Favourites first, alphabetical (Mango, Zebra); then non-favourites, alphabetical (Apple, Banana)
+      expect(sorted.map((c) => c.name)).toEqual(['Mango', 'Zebra', 'Apple', 'Banana']);
     });
   });
 

--- a/features/cards/hooks/useCardSort.ts
+++ b/features/cards/hooks/useCardSort.ts
@@ -29,29 +29,44 @@ interface UseCardSortResult {
   sortLabels: Record<SortOption, string>;
 }
 
+/**
+ * Pins favourites above non-favourites. Returns 0 when both cards share the same
+ * favourite state, letting the caller fall through to its own ordering.
+ */
+const compareFavoriteFirst = (a: LoyaltyCard, b: LoyaltyCard): number =>
+  a.isFavorite === b.isFavorite ? 0 : a.isFavorite ? -1 : 1;
+
 const sortByFrequent = (a: LoyaltyCard, b: LoyaltyCard): number => {
-  // Primary: usageCount descending
+  // Tier 0: favourites always first
+  const favorite = compareFavoriteFirst(a, b);
+  if (favorite !== 0) return favorite;
+  // Tier 1: usageCount descending
   if (a.usageCount !== b.usageCount) return b.usageCount - a.usageCount;
-  // Tiebreaker: lastUsedAt descending (most recent first)
+  // Tier 2: lastUsedAt descending (most recent first)
   if (a.lastUsedAt && b.lastUsedAt) return b.lastUsedAt.localeCompare(a.lastUsedAt);
   if (a.lastUsedAt) return -1;
   if (b.lastUsedAt) return 1;
-  // Final fallback: recently added
+  // Tier 3: createdAt descending (fallback)
   return b.createdAt.localeCompare(a.createdAt);
 };
 
+// "Recently added" is an explicit chronological order — favourites are NOT pinned.
 const sortByRecent = (a: LoyaltyCard, b: LoyaltyCard): number =>
   b.createdAt.localeCompare(a.createdAt);
 
-const sortByAZ = (a: LoyaltyCard, b: LoyaltyCard): number =>
-  a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+const sortByAZ = (a: LoyaltyCard, b: LoyaltyCard): number => {
+  // Favourites stay pinned to the top, then names sort alphabetically within each group
+  const favorite = compareFavoriteFirst(a, b);
+  if (favorite !== 0) return favorite;
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+};
 
 /**
  * Hook for sorting loyalty cards with persistent preference.
  *
- * - "Frequently used": sorts by usageCount desc → lastUsedAt desc → createdAt desc
- * - "Recently added": sorts by createdAt desc
- * - "A-Z": sorts by name (locale-aware, case-insensitive)
+ * - "Frequently used": sorts by isFavorite first → usageCount desc → lastUsedAt desc → createdAt desc
+ * - "Recently added": sorts by createdAt desc (favourites are NOT pinned)
+ * - "A-Z": sorts by isFavorite first → name (locale-aware, case-insensitive)
  */
 export const useCardSort = (): UseCardSortResult => {
   const [sortOption, setSortOptionState] = useState<SortOption>('frequent');

--- a/features/cards/hooks/useCards.test.ts
+++ b/features/cards/hooks/useCards.test.ts
@@ -157,7 +157,7 @@ describe('useCards', () => {
       expect(result.current.cards).toEqual([mockCards[0]]);
     });
 
-    it('sets loading state during refetch', async () => {
+    it('keeps isLoading false during a refetch so the list is not unmounted (Story 9.3, AC6)', async () => {
       (cardRepository.getAllCards as jest.Mock).mockResolvedValue(mockCards);
 
       const { result } = renderHook(() => useCards());
@@ -166,7 +166,7 @@ describe('useCards', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      // Mock delayed response
+      // Mock delayed response for the refetch
       let resolvePromise: (value: LoyaltyCard[]) => void;
       const delayedPromise = new Promise<LoyaltyCard[]>((resolve) => {
         resolvePromise = resolve;
@@ -177,17 +177,17 @@ describe('useCards', () => {
         result.current.refetch();
       });
 
-      // Should be loading during refetch
-      expect(result.current.isLoading).toBe(true);
+      // After the initial load, a focus refetch must NOT flip isLoading back to
+      // true — otherwise CardList swaps the FlashList for a spinner, remounts it,
+      // and the scroll position resets to the top. Data updates in place instead.
+      expect(result.current.isLoading).toBe(false);
 
       await act(async () => {
         resolvePromise!(mockCards);
         await delayedPromise;
       });
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
+      expect(result.current.isLoading).toBe(false);
     });
 
     it('clears error on successful refetch', async () => {

--- a/features/cards/hooks/useCards.ts
+++ b/features/cards/hooks/useCards.ts
@@ -6,7 +6,7 @@
  * Orders cards by creation date (newest first) per AC3.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { getAllCards } from '@/core/database';
 import { LoyaltyCard } from '@/core/schemas';
@@ -36,10 +36,17 @@ export function useCards(): UseCardsResult {
   const [cards, setCards] = useState<LoyaltyCard[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const hasLoadedRef = useRef(false);
 
   const fetchCards = useCallback(async () => {
     try {
-      setIsLoading(true);
+      // Only drive the full-screen loading state on the FIRST load. Subsequent
+      // refetches (e.g. CardList's useFocusEffect on back-navigation) update the
+      // data in place, so CardList keeps its FlashList mounted and preserves the
+      // user's scroll position instead of remounting at the top. (Story 9.3, AC6)
+      if (!hasLoadedRef.current) {
+        setIsLoading(true);
+      }
       setError(null);
       // getAllCards returns cards ordered by createdAt DESC (newest first) per AC3
       const fetchedCards = await getAllCards();
@@ -47,6 +54,7 @@ export function useCards(): UseCardsResult {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load cards');
     } finally {
+      hasLoadedRef.current = true;
       setIsLoading(false);
     }
   }, []);
@@ -59,7 +67,6 @@ export function useCards(): UseCardsResult {
     cards,
     isLoading,
     error,
-    refetch: fetchCards,
+    refetch: fetchCards
   };
 }
-


### PR DESCRIPTION
## Summary

Implements **Story 9.3 — smart card sorting**. The default **Frequently used** sort now pins favourites to the top (then `usageCount` desc → `lastUsedAt` desc → `createdAt` desc), and the **A-Z** sort also pins favourites first (then alphabetical within each group). **Recently added** stays purely chronological. Also fixes a card-list scroll-reset bug folded into this story at the product owner's request (AC6).

## Related story / issue

- Story: `docs/sprint-artifacts/stories/9-3-implement-sorting-algorithm.md` (Story 9.3)

## Type of change

- [x] ✨ `feat` — new feature (smart sort)
- [x] 🐛 `fix` — bug fix (card-list scroll persistence, AC6)

## Acceptance criteria

- [x] **AC1** — default sort: favourites → `usageCount` desc → `lastUsedAt` desc → `createdAt` desc
- [x] **AC2** — a favourite appears above all non-favourites regardless of usage count
- [x] **AC3** — with 10 cards, the relevant (favourite) card lands in the top 3 (deterministic test)
- [x] **AC4** — **A-Z** pins favourites then sorts alphabetically within groups; **Recently added** does NOT pin (chronological)
- [x] **AC5** — sort label unchanged (`cards.sort.frequent` = "Frequently used")
- [x] **AC6** — card list preserves scroll position when returning from a card's details (no `FlashList` remount on focus refetch)

## Changes

- `features/cards/hooks/useCardSort.ts` — shared `compareFavoriteFirst` helper; favourite pinning in `sortByFrequent` and `sortByAZ`; `sortByRecent` unchanged; JSDoc updated.
- `features/cards/hooks/useCards.ts` — only drive `isLoading` on the initial load (`hasLoadedRef`); focus refetches update data in place so `CardList` keeps its list mounted and scroll is preserved.
- Tests extended/updated for both hooks; story spec updated (AC4 corrected, AC6 added — see the story's Dev Notes banners + Change Log).

## Test results

- `useCardSort` 16/16 · `useCards` 10/10 · **full suite 1468/1468** · `yarn typecheck`, `yarn lint`, Prettier — all clean.
- The new/updated tests provably fail against the pre-change comparators and the unconditional `setIsLoading` (regression-guard verified).

## Review / QA

- Code review (fresh-context subagent): **APPROVED — 0 comments**.
- QA (fresh-context subagent): **PASS — 0 comments** (incl. revert experiments confirming each new test guards its behaviour).

## Notes

- AC4 was corrected and AC6 folded into this story mid-development at the product owner's direction; both are documented in the story file.
- Non-blocking follow-up: `useCards` remains an `export function` declaration (pre-existing, Story 2.1) vs. the `const`-arrow convention — intentionally out of scope here.

> Please review & merge per CONTRIBUTING — I'm not merging my own PR. The `mark-story-done` workflow will flip Story 9.3 to `done` on merge.
