### PR TITLE
feat(watch): sync favourite ordering + badge to Apple Watch (Story 9.4)

### DIFF
--- a/core/watch-connectivity.test.ts
+++ b/core/watch-connectivity.test.ts
@@ -24,7 +24,8 @@ const expectedCardPayload = {
   barcodeValue: '123',
   barcodeFormat: 'CODE128',
   usageCount: 0,
-  createdAt: '2026-01-01T00:00:00.000Z'
+  createdAt: '2026-01-01T00:00:00.000Z',
+  isFavorite: false
 };
 
 /** Build an EventEmitter-like mock for `watchEvents`. */
@@ -444,6 +445,24 @@ describe('watch-connectivity wrapper', () => {
       expect(payload.usageCount).toBe(0);
       expect(payload).not.toHaveProperty('brandId');
       expect(payload).not.toHaveProperty('lastUsedAt');
+    });
+
+    test('forwards the card isFavorite flag into the watch payload', async () => {
+      const updateApplicationContext = jest.fn();
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock(
+          'react-native-watch-connectivity',
+          () => ({ updateApplicationContext, watchEvents: makeEvents() }),
+          { virtual: true }
+        );
+        mod = require('./watch-connectivity');
+      });
+
+      const favouriteCard = { ...sampleCard, isFavorite: true };
+      await mod.pushCardsToWatch([favouriteCard]);
+      const payload = updateApplicationContext.mock.calls[0]![0].payload[0];
+      expect(payload.isFavorite).toBe(true);
     });
 
     test('pre-renders QR cards to base64 for the watch payload', async () => {

--- a/core/watch-connectivity.ts
+++ b/core/watch-connectivity.ts
@@ -118,6 +118,7 @@ export interface WatchCardPayload {
   usageCount: number;
   lastUsedAt: string | null;
   createdAt: string;
+  isFavorite: boolean;
 }
 
 const WATCH_QR_PIXEL_SIZE = 144;
@@ -190,7 +191,8 @@ function toBaseWatchCardPayload(card: LoyaltyCard): WatchCardPayload {
     barcodeFormat: card.barcodeFormat,
     usageCount: card.usageCount ?? 0,
     lastUsedAt: card.lastUsedAt ?? null,
-    createdAt: card.createdAt
+    createdAt: card.createdAt,
+    isFavorite: card.isFavorite
   };
 }
 

--- a/docs/adr-2026-06-09-watch-usage-events.md
+++ b/docs/adr-2026-06-09-watch-usage-events.md
@@ -1,0 +1,82 @@
+# ADR-2026-06-09-001: Watch usage events (refine "watch read-only")
+
+- **Status:** **Proposed** — pending PM scope confirmation (crosses the "watch read-only **for MVP**" line) and Architect ratification. Deliverable of Story **9.6a**; gates Story **9.6**.
+- **Date:** 2026-06-09
+- **Drivers:** ifero (stakeholder), `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`)
+- **Supersedes wording of:** ARCH-20 ("Watch is READ-ONLY for MVP") — _refines_, does not remove.
+
+---
+
+## Context
+
+Epic 9 promises "most-used cards at the top … on both phone and watch." Card usage (`usageCount`, `lastUsedAt`) is incremented when a card's barcode is **displayed** (Story 9.1) — but **only on the phone**. Opening a card on the Watch displays its barcode yet counts nothing. Because `usageCount`/`lastUsedAt` are a **single shared value** (synced phone↔watch), watch-driven usage is invisible, so the frequency/recency sort (FR21/FR22) is wrong on **both** surfaces for a watch-heavy user.
+
+The blocker is a deliberate invariant: **"Watch is READ-ONLY for MVP (prevents conflicts)"** — qualified everywhere as _"card editing only on phone."_ The rule exists to stop the watch and phone making **conflicting edits to card data** (name, barcode, colour, favourite, deletion).
+
+Key insight: **usage is not card-data editing.** It is an append-only, **commutative** signal. Two increments in any order yield the same result; `lastUsedAt` is a monotonic `max`. So a watch→phone usage channel does **not** create the edit-conflict class the read-only rule guards against.
+
+(The watch is also not strictly "write-nothing" today: it already sends `requestCards` control messages phone-ward via `core/watch-connectivity.ts`.)
+
+## Decision (proposed)
+
+1. **Refine the invariant** from "watch is read-only" to:
+
+   > **The watch is read-only for card _data_** (create/edit/delete/favourite happen only on the phone). The watch **may emit usage events** (card-opened). The phone applies them as **commutative** updates — no card-data edit conflict is introduced.
+
+2. **Add one versioned message, watch → phone:**
+
+   ```jsonc
+   { "version": 1, "type": "CARD_USED", "payload": { "id": "<uuid>", "usedAt": "<ISO-8601 UTC>" } }
+   ```
+
+3. **Phone reconciliation (conflict-free):** on receiving `CARD_USED`, reuse the Story 9.1 usage path:
+   - `usageCount = usageCount + 1`
+   - `lastUsedAt = max(lastUsedAt, usedAt)`
+   - then re-publish the snapshot to the watch (closes the loop with Story 9.4).
+
+4. **Offline + idempotency:** the watch **queues** events locally and **flushes** on reachability. To avoid double-counting on retransmission, each event carries a stable **client event id** (e.g. `"<cardId>:<usedAt>"`); the phone dedupes recently-seen ids within a bounded window. Increment is applied **once per unique event id**.
+
+5. **Wear OS (Epic 10):** the same message shape + reconciliation is adoptable over the Wearable Data Layer — Epic 10 mirrors this (parity scope added 2026-06-09).
+
+## Conflict-safety argument (AC2)
+
+- `usageCount` forms a commutative monoid under `+1` events → order-independent; only **at-least-once** delivery + dedup is required for exactness.
+- `lastUsedAt` under `max` is commutative, associative, idempotent (a CRDT LWW-style register) → order-independent, duplicate-safe.
+- No field the watch writes is a field the **user edits** → disjoint from the phone's edit surface → the original conflict class is untouched.
+
+## Consequences
+
+- **Positive:** FR21/FR22 become accurate across surfaces; the favourite/most-used promise holds on the watch; small, additive protocol change.
+- **Negative / cost:** the watch gains a (telemetry-only) write path — the read-only rule must be **reworded consistently** (below); delivery is best-effort, so dedup + offline queue are required; Wear OS inherits the obligation.
+- **Risk:** low, contingent on the dedup window being sized so legitimately-distinct opens (same card, different second) are not merged — `usedAt` at millisecond precision plus `cardId` makes collisions effectively impossible.
+
+## Docs to update on ratification (Story 9.6 "docs" task)
+
+Reword consistently (data-vs-usage) at all 7 references, and add `CARD_USED` to the documented message types:
+
+| File                      | Line | Current                                                                                   |
+| ------------------------- | ---- | ----------------------------------------------------------------------------------------- |
+| `CONTRIBUTING.md`         | 270  | "Apple Watch is read-only — never add mutation paths to the watch."                       |
+| `docs/project_context.md` | 237  | "Watch is READ-ONLY for MVP (prevents conflicts)"                                         |
+| `docs/project_context.md` | 324  | "Watch is READ-ONLY for MVP"                                                              |
+| `docs/architecture.md`    | 1029 | "Watch is READ-ONLY for MVP"                                                              |
+| `docs/epics.md`           | 266  | "ARCH-20: Watch is READ-ONLY for MVP (editing only happens on phone)"                     |
+| `docs/epics.md`           | 1008 | "Watch is READ-ONLY for MVP (card editing only on phone)"                                 |
+| `docs/epics.md`           | 1922 | "Watch is READ-ONLY (consistent with watchOS behavior)" (Epic 10 — already forward-noted) |
+
+Also add `CARD_USED` to the `SyncMessage` type list in `docs/project_context.md` (§ Message Versioning) and `docs/architecture.md` (sync section).
+
+## Alternatives considered
+
+- **A. Keep watch read-only; accept skewed usage.** Rejected — defeats Epic 9's "both surfaces" goal (the triggering complaint).
+- **B. Watch tracks usage _locally_ only (no phone sync).** Rejected — the counter is shared; a watch-local count diverges and never improves the phone sort, and would itself be overwritten by the next phone→watch snapshot.
+- **C. Full bidirectional card sync (watch can edit data).** Rejected — reintroduces exactly the edit-conflict class the read-only rule prevents; far larger scope/risk.
+
+## API currency (AC6)
+
+Before implementation (Story 9.6), verify current/non-deprecated WatchConnectivity delivery APIs via Context7 / official docs — likely `transferUserInfo` (queued, guaranteed, survives relaunch) over `sendMessage` (requires reachability). Confirm `react-native-watch-connectivity` exposes the receive side on the phone.
+
+## Sign-off
+
+- [ ] **PM** — confirms pulling usage past the "read-only-for-MVP" line is in scope.
+- [ ] **Architect** — ratifies the design; flips Status → Accepted; folds into `architecture.md` as `ADR-2026-06-09-001`.

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -1892,6 +1892,64 @@ _Example brands: Esselunga, Conad, Coop, Carrefour, Lidl, Eurospin, Pam, Despar,
 **When** the watch syncs
 **Then** the watch card list uses the same sort order
 **And** usage data (usageCount, lastUsedAt, isFavorite) syncs to the watch
+**And** favourite cards show a star/pin indicator on the watch _(AC added 2026-06-09 — C3 folded in via correct-course; see `sprint-artifacts/sprint-change-proposal-2026-06-09.md`)_
+
+---
+
+### Story 9.5: Selectable Watch Sort
+
+_Added 2026-06-09 via correct-course (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`)._
+
+**As a** user,
+**I want** to choose how my cards are sorted on the Watch,
+**So that** the order matches how I think about my cards.
+
+**Acceptance Criteria:**
+
+**Given** I am on the Watch card list
+**When** I open the sort control (toolbar button → picker)
+**Then** I can choose Frequently used / Recently added / A‑Z (the same modes as the phone)
+**And** the default is A‑Z
+**And** my choice persists on the Watch across launches, independently of the phone's selected mode
+
+**Dependencies:** Story 9.4. **Needs:** PRD FR25, UX watch-picker spec.
+
+---
+
+### Story 9.6a: Watch Usage-Event Architecture (Spike / ADR) [Enabling]
+
+_Added 2026-06-09 via correct-course. Gates Story 9.6 (spike-first per Sprint 14 retro)._
+
+**As an** architect,
+**I want** a validated design for watch→phone usage events,
+**So that** counting watch card opens never reintroduces edit conflicts.
+
+**Acceptance Criteria:**
+
+**Given** the watch read-only-for-data invariant
+**When** the ADR is produced
+**Then** it specifies a `CARD_USED` (watch → phone) message in the versioned sync protocol
+**And** proves conflict-free reconciliation (commutative usageCount increments; lastUsedAt = max)
+**And** refines the "watch read-only" wording to "read-only for card data; usage events permitted"
+**And** confirms Wear OS (Epic 10) can adopt the same protocol
+
+---
+
+### Story 9.6: Count Card Opens on the Watch
+
+_Added 2026-06-09 via correct-course. Depends on the 9.6a ADR + PM scope confirmation._
+
+**As a** user,
+**I want** opening a card on my Watch to count toward usage,
+**So that** "most used" is accurate on both Watch and phone.
+
+**Acceptance Criteria:**
+
+**Given** I open a card on the Watch
+**When** the phone is (or becomes) reachable
+**Then** the phone increments that card's usageCount and updates lastUsedAt
+**And** events queue offline on the Watch and flush on reachability
+**And** the Watch remains read-only for card data (no create/edit/delete/favourite from the watch)
 
 ---
 
@@ -1919,7 +1977,13 @@ _Example brands: Esselunga, Conad, Coop, Carrefour, Lidl, Eurospin, Pam, Despar,
 **Technical Notes:**
 
 - Same sync protocol as watchOS (versioned messages)
-- Watch is READ-ONLY (consistent with watchOS behavior)
+- Watch is READ-ONLY for card data (consistent with watchOS). A usage-event channel (card-opened → phone) is **proposed** for Epic 9 Story 9.6, pending the Story 9.6a ADR — Wear OS will mirror whatever that ADR ratifies. _(Updated 2026-06-09 via correct-course.)_
+
+**Parity scope added 2026-06-09 (correct-course — mirror the watchOS Epic 9 changes):**
+
+- Per-surface selectable sort (Frequently used / Recently added / A‑Z), persisted independently (mirror Story 9.5)
+- Favourite (pin) indicator on rows (mirror Story 9.4 / C3)
+- Usage-event emission for card opens (mirror Story 9.6, pending the 9.6a ADR)
 
 **Enabling Note:** Stories 10.1–10.2 are enabling tasks required for the Wear OS experience.
 

--- a/docs/sprint-artifacts/sprint-change-proposal-2026-06-09.md
+++ b/docs/sprint-artifacts/sprint-change-proposal-2026-06-09.md
@@ -1,0 +1,247 @@
+# Sprint Change Proposal — Watch Sort Parity (Epic 9)
+
+- **Date:** 2026-06-09
+- **Author:** Amelia (Dev agent) via `correct-course`
+- **Trigger story:** 9.4 — Sync Sorting to Watch (implemented, **held**, unmerged)
+- **Sprint / Epic:** Sprint 15 / Epic 9 — Smart Card Sorting
+- **Working mode:** Incremental
+- **Status:** ✅ APPROVED by ifero — 2026-06-09
+- **Scope classification:** **MAJOR** (PM + Architect + UX gating before new stories are dev-ready)
+
+> **Approved decisions (2026-06-09):**
+>
+> 1. Proposal **approved** as written.
+> 2. **C3 folded into Story 9.4** — 9.4 re-opened to add the watch favourite badge before it ships.
+> 3. Watch sort = **independent watch preference, default A‑Z** (not mirrored from the phone).
+
+---
+
+## Section 1 — Issue Summary
+
+While reviewing Story 9.4 on a real device pair (phone + Apple Watch Ultra), three issues surfaced with the Watch sorting/favourite experience. They are **connected**: the watch in the screenshots runs **pre-9.4 code** (9.4 is held/unmerged and the watch wasn't rebuilt), so it has no favourite tier at all.
+
+**Evidence (device screenshots, 2026-06-09):**
+
+- **Phone** (sort = "Frequently used"): favourites **Tigotà ⭐, Coop ⭐, UniClub ⭐** grouped on top, star-badged.
+- **Watch** ("Carte"): order is **Stroili, Tigotà, Coop, UniClub** — a non-favourite (Stroili) sits on top, favourites are **not** grouped first, and **no star/pin appears anywhere**.
+
+**The three change items:**
+
+- **C1 — User-selectable Watch sort.** The phone already ships a persisted, user-selectable 3-mode sort (`frequent` / `recent` / `az`) via Story 13.2's `useCardSort` + `SortFilterRow`. The watch has no equivalent — it mirrors a single hardcoded order. Request: bring a sort picker to the watch, **default A‑Z**, persisted. _(So C1 is "port an existing phone pattern," not greenfield.)_
+- **C2 — Count card opens on the Watch.** Opening a card on the watch never increments `usageCount`/`lastUsedAt`. Because that counter is shared phone+watch, watch-driven usage is lost — so FR21 (frequency) and FR22 (recency) are under-counted and "most-used at top" is wrong on **both** surfaces for a watch-heavy user.
+- **C3 — Favourite (pin) indicator on the Watch.** Even after 9.4 groups favourites first, the watch shows **no star/pin** — so the user can't tell _why_ cards are ordered that way. Story 9.2's favourite badge is phone-only.
+
+**Why this is correct-course material:** C1 adds a capability beyond Epic 9's "automatic sort" premise (and beyond the PRD's automatic FRs); C2 crosses the deliberate **"watch read-only for MVP"** architecture decision; C3 completes a favourite UX that 9.4 leaves half-delivered.
+
+---
+
+## Section 2 — Impact Analysis
+
+### Epic Impact
+
+- **Epic 9 (Smart Card Sorting):** Its four stories are deliverable, **but its own goal — "most-used at top … applies to both phone and watch" — is only partially met on the watch.** C2 (usage) and C3 (visible favourites) are _gaps in the existing goal_; C1 is a _new capability_. **Recommendation: extend Epic 9** with new stories rather than redefine it or open a new epic. (Placement nuance: the phone selector shipped under Epic 13, and these are watch-app changes that also touch Epic 5 (Apple Watch App) — but the sorting domain + the "both surfaces" promise make Epic 9 the natural home.)
+- **Epic 10 (Wear OS, backlog) — materially impacted.** Its scope says _"Watch is READ-ONLY (consistent with watchOS behavior)"_ and _"same sync protocol as watchOS."_ The C2 read-only refinement and the C1/C3 parity features **set a precedent Wear OS must follow**. Epic 10's scope and read-only note are updated by this proposal (see §4).
+- No epic is invalidated; no brand-new epic required.
+
+### Story Impact
+
+- **9.4 (held):** correct and foundational — **fold C3 (favourite badge) in** so it ships a coherent, complete favourite-on-watch increment rather than "favourites on top but invisible."
+- **New: 9.5** (selectable watch sort / C1), **9.6** (watch usage counting / C2), **9.6a** (architecture spike/ADR gating 9.6).
+- 9.1 / 9.2 / 9.3 — done, unaffected.
+
+### Artifact Conflicts
+
+| Artifact                                   | Impact                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PRD** (`docs/prd.md`)                    | Add **FR25** (selectable sort per surface, persisted) — the phone already does this, so the PRD is already behind reality. Add **FR26** (usage counted on every display surface incl. watch). Note a watch **A‑Z default** intentionally diverges from FR22's "most-recent-first." No PRD conflict for C2 (read-only is not a PRD rule). |
+| **Architecture** (`docs/architecture.md`)  | **C2 (significant):** new watch→phone `CARD_USED` message type; conflict-free reconciliation (commutative increments + `max(lastUsedAt)`); refine the read-only decision. **C1 (minor):** watch-side preference storage.                                                                                                                 |
+| **project_context.md**                     | Update "Watch App Rules" + "Sync Patterns" read-only lines (§237, §324) and the message-type list.                                                                                                                                                                                                                                       |
+| **CONTRIBUTING.md**                        | Refine line 270 ("never add mutation paths") to the data-editing-vs-usage-event distinction.                                                                                                                                                                                                                                             |
+| **epics.md**                               | Epic 9: add 9.5/9.6/9.6a + 9.4 AC. Epic 10: update read-only note (`:1922`) + add parity scope. Refine ARCH-20 (`:266`) and `:1008`.                                                                                                                                                                                                     |
+| **UX** (`docs/ux-design-specification.md`) | Add watch **sort picker** spec (C1) and watch **favourite badge** spec (C3), both in the watch "Carbon Utility" style.                                                                                                                                                                                                                   |
+| **sprint-status.yaml**                     | Add `9-5`, `9-6`, `9-6a` under Epic 9 (applied on approval — §6.4).                                                                                                                                                                                                                                                                      |
+
+### Technical Impact
+
+- **Read-only is enshrined in 7 places across 5 files** (CONTRIBUTING ×1, project_context ×2, architecture ×1, epics ×3). Every reference is qualified as _card-data editing_ on the phone — so C2 is a **refinement, not a reversal**: the watch stays read-only for card data; it gains a _usage-event_ channel that is commutative and conflict-free.
+- C2 touches both phone (event handler + increment) and watch (event emit + offline queue) and the sync protocol (message versioning).
+- C3 and C1 build on 9.4's `isFavorite` sync; C3 is pure watch UI; C1 needs watch-local persistence + a watch picker.
+- Aligns with the **Sprint 14 retro action items** already on record: "Spike-first for Watch/native APIs" and "Mandatory API-currency check before any Apple-platform story" → reflected as story 9.6a + an API-currency AC.
+
+---
+
+## Section 3 — Recommended Approach
+
+**Path: HYBRID — Direct Adjustment (extend Epic 9), with a PM/Architect gate on C2.**
+
+Rollback was rejected (9.1–9.4 are the foundation the changes build on). An MVP review applies only to C2, which crosses the deliberate "read-only **for MVP**" line — handled via a PM scope confirmation + Architect ADR rather than a scope cut.
+
+**Sequenced by effort/risk so value lands early and the risky change is fenced:**
+
+| #   | Story               | Change                                                                            | Effort  | Risk    | Gate                           |
+| --- | ------------------- | --------------------------------------------------------------------------------- | ------- | ------- | ------------------------------ |
+| 1   | **9.4 (+ fold C3)** | favourite sync/sort **+ visible star** on watch                                   | Low add | Low     | none — ship coherent increment |
+| 2   | **9.5**             | selectable watch sort; ports `frequent`/`recent`/`az`; **A‑Z default**; persisted | Medium  | Low‑Med | UX (watch picker) + PRD FR25   |
+| 3   | **9.6a**            | Architect ADR: usage-event channel + read-only refinement + Wear OS consistency   | Low‑Med | —       | spike-first (per retro)        |
+| 4   | **9.6**             | watch→phone `CARD_USED`; phone increments; offline queue                          | High    | Med     | 9.6a ADR + PM scope confirm    |
+
+**Rationale:** preserves all done work; delivers visible value fast (badge + selectable sort) without waiting on C2; isolates the architecture-touching C2 behind a proper decision so the "prevent conflicts" rationale is honoured; keeps everything coherent under Epic 9 while updating Epic 10 for cross-platform consistency.
+
+**Timeline:** 9.4(+C3) and 9.5 fit the current sprint's tail; 9.6a (spike) + 9.6 likely spill to the next sprint (architecture gate).
+
+---
+
+## Section 4 — Detailed Change Proposals
+
+### 4.1 Stories
+
+**MODIFY — Story 9.4 (add AC6 + task):**
+
+```
+Section: Acceptance Criteria
+NEW AC6:
+  Given a synced card has isFavorite = true
+  When I view the Watch card list
+  Then the row shows a favourite indicator (star/pin badge)
+  And it is visually consistent with the phone's star badge
+
+Section: Tasks
+NEW: Add a compact favourite badge to the Watch CardRowView (Carbon Utility style),
+     driven by the already-synced WatchCard.isFavorite. Add a snapshot/render test.
+
+Rationale: 9.4 already syncs + sorts isFavorite; without a visible badge the favourite-first
+order is unexplained (device-verified gap). Folding it in ships one coherent increment.
+```
+
+**NEW — Story 9.5: Selectable Watch Sort**
+
+```
+As a user, I want to choose how cards are sorted on my Watch,
+so the order matches how I think about my cards.
+
+Acceptance Criteria:
+1. The Watch list offers a sort control (toolbar button → picker), themed Carbon Utility.
+2. Modes mirror the phone semantics: Frequently used / Recently added / A‑Z.
+3. Default = A‑Z.
+4. The choice persists on the Watch across launches (watch-local storage).
+5. Changing the mode re-orders the list immediately.
+6. (API currency) Picker uses current SwiftUI APIs — verified via Context7/official docs.
+
+Decided (2026-06-09): INDEPENDENT watch preference (its own persisted choice, default A‑Z).
+Depends on: 9.4. Needs: PRD FR25, UX watch-picker spec.
+```
+
+**NEW — Story 9.6a: Watch Usage-Event Architecture (Spike/ADR)** _(Architect)_
+
+```
+Produce an ADR that:
+- Designs a watch→phone usage-event channel (e.g. message type CARD_USED { id, usedAt }).
+- Proves conflict-free reconciliation (usageCount increments are commutative; lastUsedAt = max).
+- Refines the "watch read-only" rule → "read-only for card DATA; usage events permitted."
+- Specifies offline behaviour (queue on watch, flush on reachability).
+- Ensures Wear OS (Epic 10) can adopt the same protocol.
+Output: ADR + the exact doc edits in §4.2–§4.5. Spike-first per Sprint 14 retro.
+```
+
+**NEW — Story 9.6: Count Card Opens on the Watch** _(gated by 9.6a)_
+
+```
+As a user, I want opening a card on my Watch to count toward usage,
+so "most used" is accurate on both Watch and phone.
+
+Acceptance Criteria:
+1. Opening a card on the Watch emits a usage event to the phone.
+2. The phone increments usageCount and sets lastUsedAt (commutative; no edit conflict).
+3. Works offline: events queue on the Watch and flush when the phone is reachable.
+4. The Watch remains read-only for card DATA (no create/edit/delete/favourite from watch).
+5. Re-sync reflects updated usage back to the Watch list ordering.
+Depends on: 9.6a ADR, PM scope confirmation.
+```
+
+### 4.2 PRD (`docs/prd.md`)
+
+```
+ADD under "Smart Card Sorting":
+FR25: Users can select the card sort mode (Frequently used / Recently added / A‑Z)
+      on each surface (phone, watch); the selection persists per surface.
+FR26: Card usage (usageCount, lastUsedAt) is recorded whenever a card's barcode is
+      displayed on any surface, including the watch.
+NOTE: A watch A‑Z default is intentional and diverges from FR22's most-recent-first default.
+```
+
+### 4.3 Architecture (`docs/architecture.md`) + `project_context.md` + `CONTRIBUTING.md`
+
+```
+OLD (architecture.md:1029):           - Watch is READ-ONLY for MVP
+OLD (project_context.md:237):         - **Watch is READ-ONLY** for MVP (prevents conflicts)
+OLD (project_context.md:324):         - Watch is **READ-ONLY** for MVP
+OLD (CONTRIBUTING.md:270):            - **Apple Watch is read-only** — never add mutation paths to the watch.
+
+NEW (consistent wording, all sites):
+  - Watch is READ-ONLY for card DATA — create/edit/delete/favourite happen only on the phone.
+    The watch MAY emit usage events (card-opened); the phone applies them as commutative
+    increments (usageCount += 1, lastUsedAt = max). This preserves the no-edit-conflict guarantee.
+
+ALSO (architecture.md sync section + project_context.md message versioning):
+  ADD message type: CARD_USED (watch → phone) to the versioned SyncMessage union.
+```
+
+### 4.4 Epic 9 (`docs/epics.md`)
+
+```
+- Add stories 9.5, 9.6a, 9.6 (as drafted in §4.1).
+- Update Story 9.4 AC (favourite badge).
+- Clarify Epic 9 scope line: "Sorting applies to both phone and watch, including visible
+  favourites, watch-side usage counting, and a per-surface user-selectable sort mode."
+- Refine ARCH-20 (epics.md:266) and :1008 to the data-vs-usage wording from §4.3.
+```
+
+### 4.5 Epic 10 — Wear OS (`docs/epics.md:~1898–1924`) ← _explicit stakeholder ask_
+
+```
+OLD (epics.md:1922): - Watch is READ-ONLY (consistent with watchOS behavior)
+NEW:                 - Watch is READ-ONLY for card data (consistent with watchOS); usage
+                       events (card-opened) are emitted to the phone via the shared protocol.
+
+ADD to Epic 10 scope (parity with watchOS):
+  - Per-surface selectable sort (frequent / recent / A‑Z), persisted (mirror Story 9.5).
+  - Favourite (pin) indicator on rows (mirror Story 9.4/C3).
+  - Usage-event emission (mirror Story 9.6).
+```
+
+### 4.6 UX (`docs/ux-design-specification.md`)
+
+```
+ADD:
+- Watch sort control: toolbar/overlay button → compact picker list (frequent/recent/az),
+  Carbon Utility styling, legible at 49mm and smaller.
+- Watch favourite badge: compact star/pin on the card row, consistent with the phone star,
+  non-intrusive on the small screen.
+```
+
+---
+
+## Section 5 — Implementation Handoff
+
+**Scope: MAJOR** — planning gates precede dev.
+
+| Role             | Responsibility                                                                                      | Deliverable                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **PM**           | Approve FR25/FR26; confirm C2 is pulled past the "read-only-for-MVP" line                           | PRD edits (§4.2)                                                |
+| **Architect**    | Story 9.6a ADR: usage-event channel, conflict-free proof, read-only refinement, Wear OS consistency | ADR + arch/project_context/CONTRIBUTING/epics edits (§4.3–§4.5) |
+| **UX**           | Watch sort picker + watch favourite badge specs                                                     | UX edits (§4.6)                                                 |
+| **SM**           | Draft stories 9.5, 9.6a, 9.6; add to `sprint-status.yaml`                                           | Story files + board entries                                     |
+| **Dev (Amelia)** | Fold C3 into 9.4; implement 9.5 then 9.6 after specs land                                           | Code + tests, per-story                                         |
+
+**Success criteria:**
+
+- 9.4: favourites visibly badged on the watch; existing 9.4 ACs still pass.
+- 9.5: A‑Z default; mode persists; phone↔watch behave consistently per the chosen mirror/independent decision.
+- 9.6: watch opens reflected in `usageCount`/`lastUsedAt` on both surfaces; offline-safe; no card-edit conflicts; read-only-for-data preserved.
+- Epic 10 + all 7 read-only references updated consistently.
+
+**Immediate next steps after approval:**
+
+1. Update `sprint-status.yaml` (add 9-5, 9-6a, 9-6 under Epic 9). _(This workflow performs this step.)_
+2. Decide the disposition of held Story 9.4: ship as-is now, or re-open to fold in C3 first.
+3. Route the ADR (9.6a) and PRD/UX edits to the Architect/PM/UX agents.

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -263,7 +263,10 @@ development_status:
   9-1-track-card-usage: done
   9-2-mark-card-as-favorite: done # design signed off 2026-06-07 (Figma frame approved); impl + code review + QA complete; awaiting stakeholder commit approval
   9-3-implement-sorting-algorithm: done
-  9-4-sync-sorting-to-watch: ready-for-dev
+  9-4-sync-sorting-to-watch: in-progress # C3 favourite-badge implemented; code review + QA approved (2026-06-09); story.md at "review" — awaiting stakeholder approval to commit/PR
+  9-5-selectable-watch-sort: drafted # correct-course 2026-06-09 — port phone sort modes (frequent/recent/az) to watch, default A-Z, independent persisted pref; gates: PRD FR25 + UX picker
+  9-6a-watch-usage-event-adr: drafted # correct-course 2026-06-09 — Architect ADR: watch→phone usage-event channel + read-only refinement; gates 9-6; ADR produced 2026-06-09
+  9-6-count-watch-card-opens: drafted # correct-course 2026-06-09 — watch card open increments usageCount/lastUsedAt (commutative); depends on 9-6a ADR + PM scope confirm
   epic-9-retrospective: optional
 
   # Epic 10: Wear OS App

--- a/docs/sprint-artifacts/stories/9-4-sync-sorting-to-watch.md
+++ b/docs/sprint-artifacts/stories/9-4-sync-sorting-to-watch.md
@@ -1,6 +1,6 @@
 # Story 9.4: Sync Sorting to Watch
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -30,23 +30,28 @@ so that my most-used and favourite cards are on top there too.
    **When** an incoming payload sets `isFavorite: true`
    **Then** the stored `WatchCardEntity.isFavorite` is updated to `true`
 
+6. **Given** a synced card has `isFavorite: true`
+   **When** I view the Watch card list
+   **Then** the row shows a favourite indicator (star/pin badge), visually consistent with the phone's star
+   _(Added 2026-06-09 via correct-course — C3 folded into 9.4)_
+
 ## Tasks / Subtasks
 
 ### Phone side — `core/watch-connectivity.ts`
 
-- [ ] Add `isFavorite: boolean` to the `WatchCardPayload` interface (AC: 1, 3)
-- [ ] Include `isFavorite: card.isFavorite` in `toBaseWatchCardPayload()` (AC: 1, 3)
-- [ ] Update `watch-connectivity.test.ts` to assert `isFavorite` is present in the serialized payload
+- [x] Add `isFavorite: boolean` to the `WatchCardPayload` interface (AC: 1, 3)
+- [x] Include `isFavorite: card.isFavorite` in `toBaseWatchCardPayload()` (AC: 1, 3)
+- [x] Update `watch-connectivity.test.ts` to assert `isFavorite` is present in the serialized payload
 
 ### Watch side — `targets/watch/CardListView.swift`
 
-- [ ] Add `var isFavorite: Bool = false` to `WatchCard` struct (AC: 3, 4)
-- [ ] Add `isFavorite` to `WatchCard.CodingKeys` enum
-- [ ] Decode: `isFavorite = try container.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false` in `init(from decoder:)` (AC: 4)
-- [ ] Encode: `try container.encode(isFavorite, forKey: .isFavorite)` in `encode(to encoder:)` (AC: 3)
-- [ ] Add `isFavorite` parameter to `WatchCard.init(...)` with default `false`
-- [ ] Update `migrateUserDefaults`: use `isFavorite: c.isFavorite` instead of `isFavorite: false` when creating `WatchCardEntity`
-- [ ] Update `displayCards` computed var sort closure to add `isFavorite` as top tier (AC: 1, 2):
+- [x] Add `var isFavorite: Bool = false` to `WatchCard` struct (AC: 3, 4)
+- [x] Add `isFavorite` to `WatchCard.CodingKeys` enum
+- [x] Decode: `isFavorite = try container.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false` in `init(from decoder:)` (AC: 4)
+- [x] Encode: `try container.encode(isFavorite, forKey: .isFavorite)` in `encode(to encoder:)` (AC: 3)
+- [x] Add `isFavorite` parameter to `WatchCard.init(...)` with default `false`
+- [x] Update `migrateUserDefaults`: use `isFavorite: c.isFavorite` instead of `isFavorite: false` when creating `WatchCardEntity`
+- [x] Update `displayCards` computed var sort closure to add `isFavorite` as top tier (AC: 1, 2):
   ```swift
   return entities.sorted { a, b in
     if a.isFavorite != b.isFavorite { return a.isFavorite }
@@ -57,18 +62,24 @@ so that my most-used and favourite cards are on top there too.
     return a.createdAt > b.createdAt
   }
   ```
-- [ ] Update the matching sort in `migrateUserDefaults` (the `topCardName` calculation) to also include `isFavorite` tier
+- [x] Update the matching sort in `migrateUserDefaults` (the `topCardName` calculation) to also include `isFavorite` tier
 
 ### Watch side — `targets/watch/WatchSessionManager.swift`
 
-- [ ] In `upsert()` update-existing-entity branch: add `entity.isFavorite = card.isFavorite` (AC: 5)
-- [ ] In `upsert()` insert-new-entity branch: use `isFavorite: card.isFavorite` instead of `isFavorite: false` (AC: 3)
+- [x] In `upsert()` update-existing-entity branch: add `entity.isFavorite = card.isFavorite` (AC: 5)
+- [x] In `upsert()` insert-new-entity branch: use `isFavorite: card.isFavorite` instead of `isFavorite: false` (AC: 3)
 
 ### Tests — `watch-ios/Tests/CardStoreTests.swift`
 
-- [ ] Add test: `WatchCard` decodes `isFavorite: true` from payload correctly
-- [ ] Add test: `WatchCard` defaults `isFavorite` to `false` when field is absent (backward compat)
-- [ ] Add test: `upsert` updates `entity.isFavorite` when payload changes it
+- [x] Add test: `WatchCard` decodes `isFavorite: true` from payload correctly
+- [x] Add test: `WatchCard` defaults `isFavorite` to `false` when field is absent (backward compat)
+- [x] Add test: `upsert` updates `entity.isFavorite` when payload changes it
+
+### Watch favourite indicator — `targets/watch/CardListView.swift` (C3 — folded in 2026-06-09)
+
+- [x] Add a compact favourite badge (`star.fill`) to `CardRowView`, shown when `card.isFavorite` is true — trailing edge, legible at 49mm and below (AC: 6)
+- [x] Favourite-aware accessibility label via `cardRowAccessibilityKey(isFavorite:)` + new `watch.card_row.favorite_accessibility_format` key (en + it); unit-tested in `CardRowHelpersTests` (no SwiftUI snapshot harness on the watch target — the badge is driven 1:1 by the same `card.isFavorite`)
+- [x] Re-run dev + QA review after the badge lands — Sonnet code review APPROVED (0 comments) + QA APPROVED (0 comments), 2026-06-09
 
 ## Dev Notes
 
@@ -236,10 +247,88 @@ Apply the same change to the `topCardName` sort in `migrateUserDefaults` (same f
 
 ### Agent Model Used
 
-_to be filled by dev agent_
+claude-opus-4-8 (Amelia / dev-story workflow)
 
 ### Debug Log References
 
+- TS: `jest core/watch-connectivity.test.ts` — drove red→green for the payload mapper.
+- Full TS suite: 150 suites / 1469 tests pass (rebased on main incl. Story 9.3); `tsc --noEmit` clean; `eslint` clean on changed files.
+- Swift: `swiftc -parse` clean on all modified `.swift` files (syntax). The watchOS Swift XCTest
+  bundle (`watch-ios/Tests`) is not locally executable here (no `ios/` workspace) **and is not run
+  in CI either** — `watch:build:ci` does `xcodebuild build` (not `test`), per Story 11-6. So these
+  Swift XCTests are syntax-checked via `swiftc -parse` here and run in Xcode / `yarn test:all`
+  locally. The watch **contract tests** (TS, `targets/watch/__tests__`) DO run in CI
+  (`watchos-tests.yml`) and pass (32/32).
+
 ### Completion Notes List
 
+Implemented `isFavorite` end-to-end so the Watch mirrors the phone's favourite-first ordering.
+
+- **AC1/AC2** — Added `isFavorite` as the top sort tier (`favourites → usageCount desc →
+lastUsedAt desc → createdAt desc`) in `CardListView.displayCards`.
+- **AC3** — Phone payload now carries `isFavorite` (`WatchCardPayload` + `toBaseWatchCardPayload`);
+  Watch `WatchCard` struct decodes/encodes it via `CodingKeys`.
+- **AC4** — Watch decode uses `decodeIfPresent(...) ?? false`, so pre-9.4 payloads (no
+  `isFavorite`) decode without crashing and default to `false`.
+- **AC5** — `WatchSessionManager.upsert()` now writes `entity.isFavorite = card.isFavorite` on the
+  update-existing branch and `isFavorite: card.isFavorite` on insert.
+
+**Additions beyond the literal task list (same story intent):**
+
+1. Extracted the 4-tier sort comparator into a single `WatchCard.sortedForDisplay(_:)` (one source
+   of truth) and routed all three surfaces through it: `CardListView.displayCards`,
+   `migrateUserDefaults` topCardName, and `WatchSessionManager.upsert` topCardName. Previously the
+   comparator was duplicated three times (a drift risk); the story explicitly updated two copies, so
+   the third (the primary runtime path that drives the complication "top card") had to match — and
+   centralising removes the duplication entirely and makes the ordering directly unit-testable.
+2. `CardListView.displayCards` entity→`WatchCard` fallback mapping — added `isFavorite: e.isFavorite`
+   so the sort still honours the persisted entity's favourite flag when `rawPayload` is
+   missing/undecodable (otherwise the fallback path would always sort as non-favourite).
+
+**Test coverage:** TS — payload asserts `isFavorite` (existing exact-match tests) + a dedicated
+`isFavorite: true` forwarding test. Swift — decode `true` (AC3), decode-absent default `false` (AC4),
+encode round-trip (AC3), `upsert` sets favourite true→ and clears true→false on an existing entity
+(AC5), migration carries `isFavorite` through `migrateUserDefaults`, an integration check that the
+upsert path persists the favourite as the complication top card, and a direct full-tier ordering
+test on `sortedForDisplay` covering all four tiers (AC1/AC2).
+
+**C3 round (favourite badge, 2026-06-09):** added a `star.fill` badge to `CardRowView` (trailing,
+shown when `card.isFavorite`) + a favourite-aware accessibility label via the testable
+`cardRowAccessibilityKey(isFavorite:)` helper + new `watch.card_row.favorite_accessibility_format`
+key (en + it), unit-tested in `CardRowHelpersTests`. **Caught a CI gap:** the
+`targets/watch/__tests__/` contract suite (run by `watchos-tests.yml`; excluded by the default
+`yarn test` config) asserted the old a11y-label literal — updated it + added a C3 badge/i18n
+contract, and migrated three stale inline sort tests to the shared `WatchCard.sortedForDisplay`.
+Verified: watch contract suite 32/32, main jest 1469, `tsc` + `eslint` clean, `swiftc -parse` clean.
+Also marked one DEBUG "Import sample cards" card + one SwiftUI Preview card `isFavorite: true` so the
+badge is demonstrable without a live phone sync (DEBUG/preview-only; no production impact).
+
 ### File List
+
+- `core/watch-connectivity.ts` — add `isFavorite` to `WatchCardPayload` + `toBaseWatchCardPayload`
+- `core/watch-connectivity.test.ts` — assert `isFavorite` in serialized payload (+ forwarding test)
+- `targets/watch/CardListView.swift` — `WatchCard` struct/init/CodingKeys/decode/encode; new
+  `WatchCard.sortedForDisplay(_:)` (favourite-first comparator, shared by all surfaces) used by
+  `displayCards` + `migrateUserDefaults` topCardName; entity→card fallback mapping carries
+  `isFavorite`; `migrateUserDefaults` entity uses `c.isFavorite`
+- `targets/watch/WatchSessionManager.swift` — `upsert()` maps `isFavorite` (update + insert);
+  topCardName calc uses the shared `sortedForDisplay`
+- `watch-ios/Tests/CardStoreTests.swift` — 7 new tests + strengthened migration test (decode true /
+  default false / encode / upsert true→ / upsert →false / full-tier ordering / top-card integration)
+- `targets/watch/CardListView.swift` — (C3) `cardRowAccessibilityKey(isFavorite:)` helper + `star.fill`
+  badge on favourite rows + favourite-aware accessibility label
+- `targets/watch/en.lproj/Localizable.strings`, `it.lproj/Localizable.strings` — (C3) new
+  `watch.card_row.favorite_accessibility_format` key
+- `watch-ios/Tests/CardRowHelpersTests.swift` — (C3) `cardRowAccessibilityKey` tests; migrated 3 sort
+  tests to `WatchCard.sortedForDisplay`
+- `targets/watch/__tests__/watch-layout-contract.test.ts` — (C3) updated a11y-label assertion + added
+  favourite badge/i18n contract
+
+## Change Log
+
+| Date       | Version | Description                                                                                                                                        | Author       |
+| ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| 2026-06-08 | 0.1     | Implemented isFavorite sync to Watch (payload, decode, sort, upsert) + tests; status → review                                                      | Amelia (dev) |
+| 2026-06-08 | 0.2     | QA round: centralised sort into `WatchCard.sortedForDisplay`; added full-tier ordering, un-favourite, encode, and migration `isFavorite` tests     | Amelia (dev) |
+| 2026-06-09 | 0.3     | correct-course: C3 (watch favourite badge) folded into 9.4 — added AC6 + tasks; status review → in-progress (badge impl + re-review pending)       | Amelia (dev) |
+| 2026-06-09 | 0.4     | Implemented C3: favourite badge + a11y label + helper + tests; fixed stale watch contract test (CI gap) + migrated sort tests; dev review approved | Amelia (dev) |

--- a/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
+++ b/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
@@ -1,0 +1,87 @@
+# Story 9.5: Selectable Watch Sort
+
+Status: drafted
+
+> Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
+> **Gates before `ready-for-dev`:** PRD **FR25** (PM) + UX watch-picker spec (UX). Depends on Story 9.4.
+
+## Story
+
+As a user,
+I want to choose how my cards are sorted on the Watch,
+so that the order matches how I think about my cards (not just a fixed algorithm).
+
+## Acceptance Criteria
+
+1. **Given** I am on the Watch card list
+   **When** I open the sort control (a toolbar button → picker)
+   **Then** I can choose between **Frequently used**, **Recently added**, and **A‑Z**
+
+2. **Given** the watch sort modes
+   **Then** their ordering semantics match the phone's `useCardSort`:
+   - Frequently used → `isFavorite` first → `usageCount` desc → `lastUsedAt` desc → `createdAt` desc
+   - Recently added → `createdAt` desc (favourites **not** pinned)
+   - A‑Z → `isFavorite` first → name (locale-aware, case-insensitive)
+
+3. **Given** a fresh install (no saved preference)
+   **When** the Watch list first renders
+   **Then** the default sort is **A‑Z**
+
+4. **Given** I pick a sort mode on the Watch
+   **When** I relaunch the Watch app
+   **Then** my choice persists (watch-local), **independently** of the phone's selected mode
+
+5. **Given** I change the sort mode
+   **When** the picker closes
+   **Then** the list re-orders immediately
+
+6. **(API currency)** The picker uses current, non-deprecated SwiftUI/watchOS APIs — verified via Context7 / official docs before implementation (Sprint 14 retro action item).
+
+## Tasks / Subtasks
+
+### Watch sort model — `targets/watch/`
+
+- [ ] Add a `WatchSortMode` enum (`frequent` / `recent` / `az`) (AC: 1, 2)
+- [ ] Extend the comparator: keep `WatchCard.sortedForDisplay` as `frequent`; add `recent` (createdAt desc, no favourite pin) and `az` (favourite-first → localized name) variants — e.g. `WatchCard.sorted(_ cards:by mode:)` (AC: 2)
+- [ ] Persist the selected mode on the watch (UserDefaults/`@AppStorage`), default `az` (AC: 3, 4)
+
+### Watch UI — `targets/watch/CardListView.swift`
+
+- [ ] Add a toolbar button that presents a sort picker (per UX spec) (AC: 1)
+- [ ] Drive `displayCards` from the selected `WatchSortMode` (AC: 2, 5)
+- [ ] Localize the control + mode labels in `en.lproj` + `it.lproj` (AC: 1)
+
+### Tests
+
+- [ ] Unit-test each sort variant's ordering (`recent`, `az`), incl. favourite pinning rules (AC: 2)
+- [ ] Test persistence + `az` default (AC: 3, 4)
+- [ ] Update `targets/watch/__tests__/watch-layout-contract.test.ts` if the row/list layout changes
+
+## Dev Notes
+
+- **Phone reference (do not re-invent):** `features/cards/hooks/useCardSort.ts` (Story 13.2) defines the three modes, their comparators, and persisted-preference pattern (`AsyncStorage` key `@myLoyaltyCards/sortPreference`, default `frequent`). Mirror the _semantics_; the watch keeps its **own** preference with an **A‑Z** default (decision 2026-06-09).
+- **Reuse:** `WatchCard.sortedForDisplay(_:)` already implements `frequent`. Add the other two variants beside it so all watch surfaces share one source of truth.
+- **Watch contract tests** (`targets/watch/__tests__/`) run in CI via `watchos-tests.yml` and are **excluded** by the default `yarn test` — run them with `jest --testPathPattern='targets/watch/__tests__' --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/node_modules/'`.
+- **Open product input:** exact picker affordance (sheet vs inline list vs Digital Crown) → UX. PRD FR25 must land first.
+
+### References
+
+- Proposal: [sprint-change-proposal-2026-06-09.md](../sprint-change-proposal-2026-06-09.md)
+- Phone sort: [features/cards/hooks/useCardSort.ts](../../../features/cards/hooks/useCardSort.ts), [features/cards/components/SortFilterRow.tsx](../../../features/cards/components/SortFilterRow.tsx)
+- Watch sort: [targets/watch/CardListView.swift](../../../targets/watch/CardListView.swift) — `WatchCard.sortedForDisplay`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+
+## Change Log
+
+| Date       | Version | Description                     | Author       |
+| ---------- | ------- | ------------------------------- | ------------ |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C1) | Amelia (dev) |

--- a/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
+++ b/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
@@ -1,0 +1,84 @@
+# Story 9.6: Count Card Opens on the Watch
+
+Status: drafted
+
+> Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
+> **Gates before `ready-for-dev`:** Story **9.6a ADR** accepted + **PM** confirmation that this is in scope (it crosses the "watch read-only **for MVP**" line). Depends on Story 9.4.
+
+## Story
+
+As a user,
+I want opening a card on my Watch to count toward its usage,
+so that "most used / recently used" sorting is accurate on both the Watch and the phone (the `usageCount`/`lastUsedAt` counters are shared).
+
+## Acceptance Criteria
+
+1. **Given** I open a card's barcode on the Watch
+   **When** the phone is (or later becomes) reachable
+   **Then** the phone increments that card's `usageCount` by 1 and updates `lastUsedAt` to the open time
+
+2. **Given** multiple/duplicate usage events (per the 9.6a ADR)
+   **Then** reconciliation is conflict-free — increments are commutative, `lastUsedAt = max` — and no card-data edit conflict occurs
+
+3. **Given** the phone is unreachable when I open a card on the Watch
+   **When** reachability is restored
+   **Then** the queued usage event(s) flush and apply (offline-safe), without double-counting
+
+4. **Given** this feature
+   **Then** the Watch remains **read-only for card data** — no create/edit/delete/favourite is initiated from the Watch
+
+5. **Given** usage has been applied on the phone
+   **When** the next snapshot syncs to the Watch
+   **Then** the Watch list ordering reflects the updated usage (closes the loop with Story 9.4 sync)
+
+## Tasks / Subtasks
+
+### Watch — emit usage events
+
+- [ ] Emit a `CARD_USED` event (per 9.6a ADR) when a card's barcode is displayed on the Watch (AC: 1)
+- [ ] Queue events when the phone is unreachable; flush on reachability; dedup/idempotency (AC: 3)
+
+### Phone — apply usage events
+
+- [ ] Handle inbound `CARD_USED` in `core/watch-connectivity.ts`; apply commutative increment + `lastUsedAt = max` via the Story 9.1 usage path (AC: 1, 2)
+- [ ] Re-sync the updated snapshot to the Watch (AC: 5)
+
+### Docs / rules (per 9.6a ADR)
+
+- [ ] Apply the refined read-only wording across the 7 references (CONTRIBUTING, project_context ×2, architecture, epics ×3) + add `CARD_USED` to the documented message types
+
+### Tests
+
+- [ ] Phone: inbound `CARD_USED` increments correctly; commutative under duplicates/out-of-order (AC: 1, 2)
+- [ ] Watch: offline queue + flush, no double-count (AC: 3)
+- [ ] Watch stays read-only for card data — no mutation path added (AC: 4)
+
+## Dev Notes
+
+- **Do not start before 9.6a is accepted** — the message shape, conflict strategy, and offline/idempotency rules come from the ADR.
+- **Reuse the phone usage path** from Story 9.1 (done) for the actual increment so phone and watch opens are counted identically.
+- **Shared counter is the whole point:** because `usageCount`/`lastUsedAt` are shared, fixing the watch gap also corrects the phone's frequency/recency sort (the original observation that triggered this work).
+- **Wear OS (Epic 10):** mirror the same protocol once built (parity scope added to Epic 10 on 2026-06-09).
+
+### References
+
+- Proposal: [sprint-change-proposal-2026-06-09.md](../sprint-change-proposal-2026-06-09.md)
+- ADR gate: [9-6a-watch-usage-event-adr.md](./9-6a-watch-usage-event-adr.md)
+- Usage tracking (phone): Story 9.1 (`features/cards`)
+- Watch connectivity: [core/watch-connectivity.ts](../../../core/watch-connectivity.ts)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+
+## Change Log
+
+| Date       | Version | Description                     | Author       |
+| ---------- | ------- | ------------------------------- | ------------ |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C2) | Amelia (dev) |

--- a/docs/sprint-artifacts/stories/9-6a-watch-usage-event-adr.md
+++ b/docs/sprint-artifacts/stories/9-6a-watch-usage-event-adr.md
@@ -1,0 +1,77 @@
+# Story 9.6a: Watch Usage-Event Architecture (Spike / ADR) [Enabling]
+
+Status: drafted
+
+> Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
+> **Owner:** Architect. **Gates:** none to start; its output gates Story 9.6.
+> Honours Sprint 14 retro: "Spike-first for Watch/native APIs" + "Mandatory API-currency check."
+
+## Story
+
+As an architect,
+I want a validated design for watch→phone usage events,
+so that counting watch card opens (Story 9.6) never reintroduces the card-edit conflicts the "watch read-only for MVP" rule was created to prevent.
+
+## Acceptance Criteria
+
+1. **Given** the current watch architecture (phone→watch snapshots only; watch is read-only for card data)
+   **When** the ADR is produced
+   **Then** it specifies a **`CARD_USED` (watch → phone)** message in the versioned `SyncMessage` protocol (with `version`, `id`, `usedAt`)
+
+2. **Given** concurrent/duplicate usage events
+   **Then** the ADR proves **conflict-free reconciliation** — `usageCount` increments are commutative; `lastUsedAt = max(existing, incoming)` — so no card-data edit conflict is introduced
+
+3. **Given** the watch may be offline / phone unreachable
+   **Then** the ADR defines **offline behaviour** (queue on watch, flush on reachability, idempotency/dedup strategy)
+
+4. **Given** the "watch read-only" rule lives in 7 places (CONTRIBUTING, project_context ×2, architecture, epics ×3)
+   **Then** the ADR specifies the exact refined wording — _"read-only for card data; usage events permitted"_ — and lists every file/line to update
+
+5. **Given** Epic 10 (Wear OS) must stay consistent
+   **Then** the ADR confirms the same protocol/strategy is adoptable on Wear OS (Wearable Data Layer)
+
+6. **(API currency)** Any WatchConnectivity APIs used (e.g. `transferUserInfo`, `sendMessage`, application context) are verified current/non-deprecated via Context7 / official docs.
+
+## Tasks / Subtasks
+
+- [ ] Review current `react-native-watch-connectivity` + WatchConnectivity capabilities for watch→phone delivery (guaranteed vs best-effort); verify API currency (AC: 1, 6)
+- [ ] Design the `CARD_USED` message + the phone-side handler that applies commutative increments (AC: 1, 2)
+- [ ] Define offline queue + flush + dedup/idempotency (AC: 3)
+- [ ] Specify the read-only wording refinement + the exact edit list across the 7 references (AC: 4)
+- [ ] Confirm Wear OS adoptability (AC: 5)
+- [ ] Write the ADR to `docs/architecture/adr/` (or `docs/`); get **PM** confirmation that pulling usage past the "read-only-for-MVP" line is in scope
+- [ ] On acceptance, mark 9.6 `ready-for-dev`
+
+## Dev Notes
+
+- **Why this is a spike:** Story 9.6 reverses a _deliberate_ MVP simplification. The risk is sync conflicts — but usage is **near-commutative** (increment + max-timestamp), which is the key insight that likely keeps it conflict-free. The ADR must validate this, not assume it.
+- **Existing channel:** `core/watch-connectivity.ts` already does phone→watch `applicationContext` snapshots + a `requestCards` ping watch→phone. A `CARD_USED` event extends the watch→phone direction that already exists for `requestCards` — so the watch is not "read-only" in the strict sense today (it already sends control messages); the refinement clarifies _data_ vs _signal_.
+- **Phone increment source of truth:** Story 9.1 (`features/cards`) already increments `usageCount`/`lastUsedAt` on phone display — reuse that path for incoming watch events.
+
+### References
+
+- Proposal: [sprint-change-proposal-2026-06-09.md](../sprint-change-proposal-2026-06-09.md)
+- Sync rules: [docs/project_context.md](../../project_context.md) (§ Sync Patterns / Watch App Rules), [docs/architecture.md](../../architecture.md)
+- Watch connectivity: [core/watch-connectivity.ts](../../../core/watch-connectivity.ts)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8 (Amelia) — initial ADR draft via correct-course
+
+### Debug Log References
+
+### Completion Notes List
+
+- **ADR draft produced 2026-06-09** → [`docs/adr-2026-06-09-watch-usage-events.md`](../../adr-2026-06-09-watch-usage-events.md), Status **Proposed**. Covers the `CARD_USED` message, the commutative conflict-safety argument, offline/dedup, the read-only refinement + exact 7-reference edit list, Wear OS consistency, and an API-currency note. **Awaiting PM scope confirmation + Architect ratification** before 9.6 goes `ready-for-dev`.
+
+### File List
+
+- `docs/adr-2026-06-09-watch-usage-events.md` (new — Proposed ADR)
+
+## Change Log
+
+| Date       | Version | Description                          | Author       |
+| ---------- | ------- | ------------------------------------ | ------------ |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C2 gate) | Amelia (dev) |

--- a/targets/watch/CardListView.swift
+++ b/targets/watch/CardListView.swift
@@ -17,6 +17,7 @@ struct WatchCard: Identifiable, Codable {
   var usageCount: Int = 0
   var lastUsedAt: Date? = nil
   var createdAt: Date = Date()
+  var isFavorite: Bool = false
 
   init(
     id: String,
@@ -28,7 +29,8 @@ struct WatchCard: Identifiable, Codable {
     barcodeImageBase64: String? = nil,
     usageCount: Int = 0,
     lastUsedAt: Date? = nil,
-    createdAt: Date = Date()
+    createdAt: Date = Date(),
+    isFavorite: Bool = false
   ) {
     self.id = id
     self.name = name
@@ -40,11 +42,12 @@ struct WatchCard: Identifiable, Codable {
     self.usageCount = usageCount
     self.lastUsedAt = lastUsedAt
     self.createdAt = createdAt
+    self.isFavorite = isFavorite
   }
 
   enum CodingKeys: String, CodingKey {
     case id, name, brandId, colorHex, barcodeValue, barcodeFormat, barcodeImageBase64, usageCount, lastUsedAt,
-      createdAt
+      createdAt, isFavorite
   }
 
   init(from decoder: Decoder) throws {
@@ -59,6 +62,7 @@ struct WatchCard: Identifiable, Codable {
     usageCount = try container.decodeIfPresent(Int.self, forKey: .usageCount) ?? 0
     lastUsedAt = try Self.decodeDateIfPresent(from: container, forKey: .lastUsedAt)
     createdAt = try Self.decodeDateIfPresent(from: container, forKey: .createdAt) ?? Date()
+    isFavorite = try container.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
   }
 
   func encode(to encoder: Encoder) throws {
@@ -75,6 +79,7 @@ struct WatchCard: Identifiable, Codable {
       try container.encode(Self.encodeDate(lastUsedAt), forKey: .lastUsedAt)
     }
     try container.encode(Self.encodeDate(createdAt), forKey: .createdAt)
+    try container.encode(isFavorite, forKey: .isFavorite)
   }
 
   private static func decodeDateIfPresent(
@@ -115,6 +120,23 @@ struct WatchCard: Identifiable, Codable {
     formatter.formatOptions = [.withInternetDateTime]
     return formatter
   }()
+}
+
+extension WatchCard {
+  /// Shared ordering for every Watch surface that ranks cards (the card list and
+  /// the complication "top card"): favourites first → usageCount desc →
+  /// lastUsedAt desc → createdAt desc. Single source of truth so the surfaces
+  /// can never drift apart.
+  static func sortedForDisplay(_ cards: [WatchCard]) -> [WatchCard] {
+    cards.sorted { a, b in
+      if a.isFavorite != b.isFavorite { return a.isFavorite }
+      if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
+      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
+        return aLast > bLast
+      }
+      return a.createdAt > b.createdAt
+    }
+  }
 }
 
 final class CardStore: ObservableObject {
@@ -163,7 +185,7 @@ final class CardStore: ObservableObject {
         barcodeFormat: c.barcodeFormat ?? "CODE128",
         brandId: c.brandId,
         color: c.colorHex ?? "grey",
-        isFavorite: false,
+        isFavorite: c.isFavorite,
         lastUsedAt: c.lastUsedAt,
         usageCount: c.usageCount,
         createdAt: c.createdAt,
@@ -177,16 +199,7 @@ final class CardStore: ObservableObject {
     UserDefaults.standard.removeObject(forKey: "watch.cards")
     ComplicationSharedState.persistCards(decoded)
 
-    let topCardName = decoded
-      .sorted {
-        if $0.usageCount != $1.usageCount { return $0.usageCount > $1.usageCount }
-        if let lhsLast = $0.lastUsedAt, let rhsLast = $1.lastUsedAt, lhsLast != rhsLast {
-          return lhsLast > rhsLast
-        }
-        return $0.createdAt > $1.createdAt
-      }
-      .first?
-      .name
+    let topCardName = WatchCard.sortedForDisplay(decoded).first?.name
 
     ComplicationSharedState.persistTopCardName(topCardName)
 
@@ -197,6 +210,15 @@ final class CardStore: ObservableObject {
 // MARK: - Helpers moved to ColorHelpers.swift
 // initials(from:), mapColor(hex:), parseHexColor(_:), contrast helpers
 // are now in ColorHelpers.swift for reusability and testability.
+
+/// Localization key for a card row's accessibility label. Favourites get a
+/// distinct key so VoiceOver announces the pinned state. Extracted so the
+/// favourite-vs-not branch is unit-testable without rendering the SwiftUI view.
+func cardRowAccessibilityKey(isFavorite: Bool) -> String {
+  isFavorite
+    ? "watch.card_row.favorite_accessibility_format"
+    : "watch.card_row.accessibility_format"
+}
 
 struct CardRowView: View {
   let card: WatchCard
@@ -255,6 +277,13 @@ struct CardRowView: View {
         .layoutPriority(1)
 
       Spacer()
+
+      if card.isFavorite {
+        Image(systemName: "star.fill")
+          .font(.system(size: 13))
+          .foregroundColor(.yellow)
+          .accessibilityHidden(true)
+      }
     }
     .padding(.horizontal, metrics.horizontalPadding)
     .padding(.vertical, metrics.verticalPadding)
@@ -268,7 +297,7 @@ struct CardRowView: View {
         .stroke(isNearBlack(hex: resolvedColorHex) ? Color.white.opacity(0.15) : Color.clear, lineWidth: 1)
     )
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(WatchL10n.format("watch.card_row.accessibility_format", card.name))
+    .accessibilityLabel(WatchL10n.format(cardRowAccessibilityKey(isFavorite: card.isFavorite), card.name))
   }
 
   @ViewBuilder
@@ -334,7 +363,7 @@ struct CardListView: View {
     _store = StateObject(wrappedValue: store)
   }
 
-  /// Cards sorted by usageCount desc → lastUsedAt desc → createdAt desc.
+  /// Cards sorted by isFavorite first → usageCount desc → lastUsedAt desc → createdAt desc.
   private var displayCards: [WatchCard] {
     let entities: [WatchCard]
     if !persistedEntities.isEmpty {
@@ -354,19 +383,14 @@ struct CardListView: View {
           barcodeFormat: e.barcodeFormat,
           usageCount: e.usageCount,
           lastUsedAt: e.lastUsedAt,
-          createdAt: e.createdAt
+          createdAt: e.createdAt,
+          isFavorite: e.isFavorite
         )
       }
     } else {
       entities = store.cards
     }
-    return entities.sorted { a, b in
-      if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
-      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
-        return aLast > bLast
-      }
-      return a.createdAt > b.createdAt
-    }
+    return WatchCard.sortedForDisplay(entities)
   }
 
   var body: some View {
@@ -482,7 +506,7 @@ struct CardListView: View {
       let sample: [WatchCard] = [
         WatchCard(
           id: "1", name: "Esselunga", brandId: "brand-special", colorHex: "#1e90ff",
-          barcodeValue: "5901234123457", barcodeFormat: "EAN13"),
+          barcodeValue: "5901234123457", barcodeFormat: "EAN13", isFavorite: true),
         WatchCard(
           id: "2", name: "Local Bakery", brandId: nil, colorHex: "#ff6b6b",
           barcodeValue: "012345678905", barcodeFormat: "UPCA"),
@@ -519,7 +543,7 @@ struct CardListView_Previews: PreviewProvider {
       CardListViewMock(cards: [
         WatchCard(
           id: "1", name: "Esselunga", brandId: "brand-special", colorHex: "#1e90ff",
-          barcodeValue: "5901234123457", barcodeFormat: "EAN13"),
+          barcodeValue: "5901234123457", barcodeFormat: "EAN13", isFavorite: true),
         WatchCard(
           id: "2", name: "Local Bakery", brandId: nil, colorHex: "#ff6b6b",
           barcodeValue: "012345678905", barcodeFormat: "UPCA"),

--- a/targets/watch/WatchSessionManager.swift
+++ b/targets/watch/WatchSessionManager.swift
@@ -187,6 +187,7 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
         entity.usageCount = card.usageCount
         entity.lastUsedAt = card.lastUsedAt
         entity.createdAt = card.createdAt
+        entity.isFavorite = card.isFavorite
         entity.updatedAt = Date()
         entity.rawPayload = raw
       } else {
@@ -197,7 +198,7 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
           barcodeFormat: card.barcodeFormat ?? "CODE128",
           brandId: card.brandId,
           color: card.colorHex ?? "grey",
-          isFavorite: false,
+          isFavorite: card.isFavorite,
           lastUsedAt: card.lastUsedAt,
           usageCount: card.usageCount,
           createdAt: card.createdAt,
@@ -215,16 +216,7 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
     try? context.save()
     ComplicationSharedState.persistCards(cards)
 
-    let topCardName = cards
-      .sorted {
-        if $0.usageCount != $1.usageCount { return $0.usageCount > $1.usageCount }
-        if let lhsLast = $0.lastUsedAt, let rhsLast = $1.lastUsedAt, lhsLast != rhsLast {
-          return lhsLast > rhsLast
-        }
-        return $0.createdAt > $1.createdAt
-      }
-      .first?
-      .name
+    let topCardName = WatchCard.sortedForDisplay(cards).first?.name
 
     ComplicationSharedState.persistTopCardName(topCardName)
     ComplicationReloader.reloadAllActiveComplications()

--- a/targets/watch/__tests__/watch-layout-contract.test.ts
+++ b/targets/watch/__tests__/watch-layout-contract.test.ts
@@ -75,12 +75,36 @@ describe('watch layout contract', () => {
 
     expect(cardListView).toContain('.frame(minHeight: metrics.minimumTapHeight)');
     expect(cardListView).toContain(
-      '.accessibilityLabel(WatchL10n.format("watch.card_row.accessibility_format", card.name))'
+      '.accessibilityLabel(WatchL10n.format(cardRowAccessibilityKey(isFavorite: card.isFavorite), card.name))'
     );
     expect(barcodeView).toContain('.accessibilityIdentifier("barcode-view")');
     expect(barcodeView).toContain(
       '.accessibilityLabel(WatchL10n.format("watch.barcode.accessibility.image_format", titleText))'
     );
+  });
+
+  it('renders a favourite badge on the watch row and announces it to VoiceOver (Story 9.4 / C3)', () => {
+    const cardListView = fs.readFileSync(cardListViewPath, 'utf8');
+    const enStrings = fs.readFileSync(
+      path.join(repoRoot, 'targets', 'watch', 'en.lproj', 'Localizable.strings'),
+      'utf8'
+    );
+    const itStrings = fs.readFileSync(
+      path.join(repoRoot, 'targets', 'watch', 'it.lproj', 'Localizable.strings'),
+      'utf8'
+    );
+
+    // Badge is rendered only for favourites
+    expect(cardListView).toContain('if card.isFavorite {');
+    expect(cardListView).toContain('Image(systemName: "star.fill")');
+
+    // Favourite-aware accessibility label is driven by the testable key helper
+    expect(cardListView).toContain('func cardRowAccessibilityKey(isFavorite: Bool) -> String');
+    expect(cardListView).toContain('"watch.card_row.favorite_accessibility_format"');
+
+    // The favourite label key is localised in BOTH bundles (cross-file coupling)
+    expect(enStrings).toContain('"watch.card_row.favorite_accessibility_format"');
+    expect(itStrings).toContain('"watch.card_row.favorite_accessibility_format"');
   });
 
   it('routes QR cards through the native QR renderer instead of the placeholder path', () => {

--- a/targets/watch/en.lproj/Localizable.strings
+++ b/targets/watch/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "watch.cards.fallback_name" = "Card";
 "watch.cards.unavailable" = "Card unavailable";
 "watch.card_row.accessibility_format" = "Card, %@";
+"watch.card_row.favorite_accessibility_format" = "Favourite card, %@";
 "watch.debug.import_sample_cards" = "Import sample cards";
 "watch.barcode.accessibility.image_format" = "Barcode for %@";
 "watch.barcode.accessibility.value_format" = "Barcode value for %@";

--- a/targets/watch/it.lproj/Localizable.strings
+++ b/targets/watch/it.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "watch.cards.fallback_name" = "Carta";
 "watch.cards.unavailable" = "Carta non disponibile";
 "watch.card_row.accessibility_format" = "Carta, %@";
+"watch.card_row.favorite_accessibility_format" = "Carta preferita, %@";
 "watch.debug.import_sample_cards" = "Importa carte di esempio";
 "watch.barcode.accessibility.image_format" = "Codice a barre per %@";
 "watch.barcode.accessibility.value_format" = "Valore codice a barre per %@";

--- a/watch-ios/Tests/CardRowHelpersTests.swift
+++ b/watch-ios/Tests/CardRowHelpersTests.swift
@@ -159,13 +159,7 @@ final class CardRowHelpersTests: XCTestCase {
       WatchCard(id: "2", name: "High", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 10, lastUsedAt: nil, createdAt: Date()),
       WatchCard(id: "3", name: "Mid", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 5, lastUsedAt: nil, createdAt: Date()),
     ]
-    let sorted = cards.sorted { a, b in
-      if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
-      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
-        return aLast > bLast
-      }
-      return a.createdAt > b.createdAt
-    }
+    let sorted = WatchCard.sortedForDisplay(cards)
     XCTAssertEqual(sorted.map(\.name), ["High", "Mid", "Low"])
   }
 
@@ -176,13 +170,7 @@ final class CardRowHelpersTests: XCTestCase {
       WatchCard(id: "1", name: "Earlier", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 5, lastUsedAt: earlier, createdAt: now),
       WatchCard(id: "2", name: "Later", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 5, lastUsedAt: now, createdAt: earlier),
     ]
-    let sorted = cards.sorted { a, b in
-      if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
-      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
-        return aLast > bLast
-      }
-      return a.createdAt > b.createdAt
-    }
+    let sorted = WatchCard.sortedForDisplay(cards)
     XCTAssertEqual(sorted.map(\.name), ["Later", "Earlier"])
   }
 
@@ -193,13 +181,7 @@ final class CardRowHelpersTests: XCTestCase {
       WatchCard(id: "1", name: "Older", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 0, lastUsedAt: nil, createdAt: earlier),
       WatchCard(id: "2", name: "Newer", brandId: nil, colorHex: nil, barcodeValue: nil, barcodeFormat: nil, usageCount: 0, lastUsedAt: nil, createdAt: now),
     ]
-    let sorted = cards.sorted { a, b in
-      if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
-      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
-        return aLast > bLast
-      }
-      return a.createdAt > b.createdAt
-    }
+    let sorted = WatchCard.sortedForDisplay(cards)
     XCTAssertEqual(sorted.map(\.name), ["Newer", "Older"])
   }
 
@@ -215,5 +197,19 @@ final class CardRowHelpersTests: XCTestCase {
     // Custom card with no brandId should fall back to mapColor from colorHex
     let color = mapColor(hex: "#ff4d4d")
     XCTAssertNotNil(color)
+  }
+
+  // MARK: - Favourite badge accessibility (Story 9.4 / C3)
+
+  func test_cardRowAccessibilityKey_favorite_usesFavouriteKey() throws {
+    XCTAssertEqual(
+      cardRowAccessibilityKey(isFavorite: true),
+      "watch.card_row.favorite_accessibility_format")
+  }
+
+  func test_cardRowAccessibilityKey_nonFavorite_usesDefaultKey() throws {
+    XCTAssertEqual(
+      cardRowAccessibilityKey(isFavorite: false),
+      "watch.card_row.accessibility_format")
   }
 }

--- a/watch-ios/Tests/CardStoreTests.swift
+++ b/watch-ios/Tests/CardStoreTests.swift
@@ -152,7 +152,8 @@ final class CardStoreTests: XCTestCase {
     let cards = [
       WatchCard(
         id: "m1", name: "Migrated", brandId: nil, colorHex: "#ff6b6b", barcodeValue: "12345",
-        barcodeFormat: "QR", usageCount: 6, lastUsedAt: lastUsedAt, createdAt: createdAt)
+        barcodeFormat: "QR", usageCount: 6, lastUsedAt: lastUsedAt, createdAt: createdAt,
+        isFavorite: true)
     ]
     let data = try JSONEncoder().encode(cards)
     UserDefaults.standard.set(data, forKey: "watch.cards")
@@ -173,6 +174,7 @@ final class CardStoreTests: XCTestCase {
     XCTAssertEqual(results.first?.usageCount, 6)
     XCTAssertEqual(results.first?.lastUsedAt, lastUsedAt)
     XCTAssertEqual(results.first?.createdAt, createdAt)
+    XCTAssertTrue(try XCTUnwrap(results.first).isFavorite)
     XCTAssertNil(UserDefaults.standard.data(forKey: "watch.cards"))
   }
 
@@ -230,6 +232,219 @@ final class CardStoreTests: XCTestCase {
     XCTAssertEqual(results.first?.usageCount, 5)
     XCTAssertEqual(results.first?.lastUsedAt, refreshedLastUsedAt)
     XCTAssertEqual(results.first?.createdAt, refreshedCreatedAt)
+  }
+
+  func test_watchCard_decodesIsFavorite_fromPhonePayload() throws {
+    let payload = """
+      {
+        "id": "fav-1",
+        "name": "Favourite Card",
+        "colorHex": "#1e90ff",
+        "barcodeValue": "1234567890",
+        "barcodeFormat": "CODE128",
+        "isFavorite": true
+      }
+      """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(WatchCard.self, from: payload)
+
+    XCTAssertTrue(decoded.isFavorite)
+  }
+
+  func test_watchCard_defaultsIsFavorite_whenAbsent() throws {
+    // Backward compat: payloads minted before Story 9.4 omit isFavorite entirely.
+    let payload = """
+      {
+        "id": "legacy-fav",
+        "name": "Legacy Card",
+        "colorHex": "#ff6b6b",
+        "barcodeValue": "12345",
+        "barcodeFormat": "QR"
+      }
+      """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(WatchCard.self, from: payload)
+
+    XCTAssertFalse(decoded.isFavorite)
+  }
+
+  func test_watchCard_encodesIsFavorite_intoPayload() throws {
+    let card = WatchCard(
+      id: "enc-fav",
+      name: "Encoded Favourite",
+      brandId: nil,
+      colorHex: "#1e90ff",
+      barcodeValue: "1234567890",
+      barcodeFormat: "CODE128",
+      isFavorite: true
+    )
+
+    let data = try JSONEncoder().encode(card)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    XCTAssertEqual(json["isFavorite"] as? Bool, true)
+  }
+
+  @MainActor
+  func test_watchSessionManager_upsert_updatesIsFavorite_onExistingEntity() throws {
+    let container = try ModelContainer(
+      for: WatchCardEntity.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let context = ModelContext(container)
+
+    let existing = WatchCardEntity(
+      id: "fav-upsert-1",
+      name: "Card",
+      barcode: "111111",
+      barcodeFormat: "QR",
+      brandId: nil,
+      color: "#ff0000",
+      isFavorite: false,
+      lastUsedAt: nil,
+      usageCount: 0,
+      createdAt: Date(),
+      updatedAt: Date(),
+      rawPayload: nil
+    )
+    context.insert(existing)
+    try context.save()
+
+    WatchSessionManager.upsert(
+      cards: [
+        WatchCard(
+          id: "fav-upsert-1",
+          name: "Card",
+          brandId: nil,
+          colorHex: "#ff0000",
+          barcodeValue: "111111",
+          barcodeFormat: "QR",
+          isFavorite: true
+        )
+      ],
+      in: context
+    )
+
+    let results = try context.fetch(FetchDescriptor<WatchCardEntity>())
+    XCTAssertEqual(results.count, 1)
+    XCTAssertTrue(try XCTUnwrap(results.first).isFavorite)
+  }
+
+  @MainActor
+  func test_watchSessionManager_upsert_clearsIsFavorite_onExistingEntity() throws {
+    // Un-favouriting on the phone must propagate to the Watch entity (true → false).
+    let container = try ModelContainer(
+      for: WatchCardEntity.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let context = ModelContext(container)
+
+    let existing = WatchCardEntity(
+      id: "unfav-1",
+      name: "Card",
+      barcode: "111111",
+      barcodeFormat: "QR",
+      brandId: nil,
+      color: "#ff0000",
+      isFavorite: true,
+      lastUsedAt: nil,
+      usageCount: 0,
+      createdAt: Date(),
+      updatedAt: Date(),
+      rawPayload: nil
+    )
+    context.insert(existing)
+    try context.save()
+
+    WatchSessionManager.upsert(
+      cards: [
+        WatchCard(
+          id: "unfav-1",
+          name: "Card",
+          brandId: nil,
+          colorHex: "#ff0000",
+          barcodeValue: "111111",
+          barcodeFormat: "QR",
+          isFavorite: false
+        )
+      ],
+      in: context
+    )
+
+    let results = try context.fetch(FetchDescriptor<WatchCardEntity>())
+    XCTAssertEqual(results.count, 1)
+    XCTAssertFalse(try XCTUnwrap(results.first).isFavorite)
+  }
+
+  /// Upserts `cards` into a fresh in-memory store and returns the complication
+  /// "top card" name produced by the shared `sortedForDisplay` ordering.
+  @MainActor
+  private func topCardName(afterUpserting cards: [WatchCard]) throws -> String? {
+    let suite = try XCTUnwrap(UserDefaults(suiteName: ComplicationSharedState.suiteName))
+    suite.removeObject(forKey: ComplicationSharedState.topCardNameKey)
+
+    let container = try ModelContainer(
+      for: WatchCardEntity.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    WatchSessionManager.upsert(cards: cards, in: ModelContext(container))
+
+    return suite.string(forKey: ComplicationSharedState.topCardNameKey)
+  }
+
+  @MainActor
+  func test_watchSessionManager_upsert_topCard_prioritisesFavorite_overUsage() throws {
+    // Integration: the upsert path feeds the shared sort into the complication's
+    // persisted top-card name. A non-favourite with high usage must NOT outrank a
+    // favourite with low usage.
+    let top = try topCardName(afterUpserting: [
+      WatchCard(
+        id: "frequent", name: "Frequent", brandId: nil, colorHex: "#1e90ff",
+        barcodeValue: "111", barcodeFormat: "CODE128", usageCount: 50, isFavorite: false),
+      WatchCard(
+        id: "favourite", name: "Favourite", brandId: nil, colorHex: "#ff6b6b",
+        barcodeValue: "222", barcodeFormat: "CODE128", usageCount: 1, isFavorite: true),
+    ])
+
+    XCTAssertEqual(top, "Favourite")
+  }
+
+  func test_sortedForDisplay_appliesFullTierOrdering() throws {
+    let formatter = makeISO8601Formatter()
+    let oldCreated = try XCTUnwrap(formatter.date(from: "2026-01-01T00:00:00.000Z"))
+    let newCreated = try XCTUnwrap(formatter.date(from: "2026-03-01T00:00:00.000Z"))
+    let oldUsed = try XCTUnwrap(formatter.date(from: "2026-02-01T00:00:00.000Z"))
+    let newUsed = try XCTUnwrap(formatter.date(from: "2026-04-01T00:00:00.000Z"))
+
+    // Deliberately unsorted input that forces every tier to decide at least one pair:
+    //  tier 0 isFavorite: "fav" wins outright (despite usage 0)
+    //  tier 1 usageCount: "hiusage" leads the non-favourites
+    //  tier 2 lastUsedAt:  "fresh" beats "stale" (same usage, more recent use)
+    //  tier 3 createdAt:   "midcreated" beats "oldest" (same usage, no lastUsedAt)
+    let cards = [
+      WatchCard(
+        id: "stale", name: "Stale", brandId: nil, colorHex: "#111", barcodeValue: "1",
+        barcodeFormat: "CODE128", usageCount: 3, lastUsedAt: oldUsed, createdAt: newCreated,
+        isFavorite: false),
+      WatchCard(
+        id: "fav", name: "Fav", brandId: nil, colorHex: "#222", barcodeValue: "2",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: oldCreated,
+        isFavorite: true),
+      WatchCard(
+        id: "fresh", name: "Fresh", brandId: nil, colorHex: "#333", barcodeValue: "3",
+        barcodeFormat: "CODE128", usageCount: 3, lastUsedAt: newUsed, createdAt: oldCreated,
+        isFavorite: false),
+      WatchCard(
+        id: "oldest", name: "Oldest", brandId: nil, colorHex: "#444", barcodeValue: "4",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: oldCreated,
+        isFavorite: false),
+      WatchCard(
+        id: "midcreated", name: "MidCreated", brandId: nil, colorHex: "#555", barcodeValue: "5",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: newCreated,
+        isFavorite: false),
+      WatchCard(
+        id: "hiusage", name: "HiUsage", brandId: nil, colorHex: "#666", barcodeValue: "6",
+        barcodeFormat: "CODE128", usageCount: 10, lastUsedAt: nil, createdAt: newCreated,
+        isFavorite: false),
+    ]
+
+    let ordered = WatchCard.sortedForDisplay(cards).map(\.id)
+
+    XCTAssertEqual(ordered, ["fav", "hiusage", "fresh", "stale", "midcreated", "oldest"])
   }
 
   func test_readOnly_preventsCardModification() throws {


### PR DESCRIPTION
## Summary

Syncs the phone's favourite-first ordering to the Apple Watch and makes favourites visible there.

**Story 9.4 — Sync Sorting to Watch** (`docs/sprint-artifacts/stories/9-4-sync-sorting-to-watch.md`)

- Phone payload now carries `isFavorite` (`WatchCardPayload` + `toBaseWatchCardPayload`).
- Watch `WatchCard` decodes/encodes `isFavorite`; the 4-tier sort is centralised in `WatchCard.sortedForDisplay` (favourites → `usageCount` desc → `lastUsedAt` desc → `createdAt` desc) and used by both the card list and the complication top-card.
- `WatchSessionManager.upsert` maps `isFavorite` on insert **and** update.
- **Favourite badge (C3):** favourite rows show a `star.fill` + a favourite-aware VoiceOver label, localised (en + it).

## Acceptance criteria

- [x] **AC1** — a favourited card appears at the top of the watch list
- [x] **AC2** — order: favourites → `usageCount` desc → `lastUsedAt` desc → `createdAt` desc
- [x] **AC3** — a payload that includes `isFavorite` decodes/applies without crashing
- [x] **AC4** — a legacy payload (no `isFavorite`) defaults to `false`, no crash / no data loss
- [x] **AC5** — `upsert` updates the stored `WatchCardEntity.isFavorite`
- [x] **AC6** — favourite rows show a star/pin badge

## Tests

- **TS:** main Jest suite **1469 passed** (150 suites); `tsc --noEmit` + ESLint clean.
- **Watch contract suite** (`targets/watch/__tests__`, run in CI by `watchos-tests.yml`): **32 passed** — updated for the new a11y label + added badge/i18n contract coverage.
- **Swift XCTest** (`watch-ios/Tests`): added decode / encode / upsert (true→/→false) / full-tier ordering / migration / a11y-key tests; `swiftc -parse` clean. _(Watch XCTests are syntax-checked locally; CI builds the watch via `xcodebuild build`.)_
- Badge is demonstrable via the Xcode "With cards" preview, the DEBUG "Import sample cards" action, or a full phone→watch sync.

## Reviews

- **Code review** (fresh-context, Sonnet): **APPROVED — 0 comments** (a re-review also caught & fixed a stale watch contract test before it could fail CI).
- **QA** (fresh-context, Sonnet): **APPROVED — 0 comments**; AC1–AC6 fully covered.

## Also in this branch — `docs(epic-9)` commit (no production code)

A mid-sprint **correct-course** ran during 9.4 (two follow-on needs + a favourite-visibility gap surfaced). This branch also lands the planning artifacts:

- `docs/sprint-artifacts/sprint-change-proposal-2026-06-09.md`
- `docs/adr-2026-06-09-watch-usage-events.md` — **Proposed** ADR (watch usage events; refines "watch read-only" to *read-only for card data*)
- Draft stories **9.5** (selectable watch sort), **9.6a** (usage-event ADR), **9.6** (count watch card opens)
- `docs/epics.md`: Epic 9 new stories + **Epic 10 (Wear OS)** read-only refinement + parity scope
- `sprint-status.yaml`: 9-4 status + add 9-5 / 9-6a / 9-6 (drafted)

These follow-ups are gated (PM FR25, UX picker spec, Architect ADR ratification) and are **not** implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
