### PR TITLE
docs(arch): ratify watch usage-event ADR + refine watch read-only rule (Story 9.6a)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ The authoritative rules are in [`docs/project_context.md`](docs/project_context.
 - **Client-side UUIDs**, **ISO-8601 UTC** date strings, **all JSON fields present** (`null`, never omitted).
 - **Transactional DB writes** (`withTransactionAsync`); use the `logger` wrapper, not `console.log`.
 - **Tests co-located** with source; cross-platform fixtures live in `test-fixtures/`.
-- **Apple Watch is read-only** — never add mutation paths to the watch.
+- **Apple Watch is read-only for card _data_** — never add card create/edit/delete/favourite paths to the watch. (It MAY emit `CARD_USED` usage events, which the phone applies commutatively — usage telemetry is not a card-data mutation. See ADR-2026-06-09-001.)
 - **UI:** respect safe-area insets for edge controls; avoid `Pressable` `style={({pressed}) => …}` callbacks (use `onPressIn`/`onPressOut` + state) — see `AGENTS.md` for the rationale.
 
 Run `yarn lint` and `yarn typecheck` to catch most violations automatically.

--- a/docs/adr-2026-06-09-watch-usage-events.md
+++ b/docs/adr-2026-06-09-watch-usage-events.md
@@ -1,6 +1,6 @@
 # ADR-2026-06-09-001: Watch usage events (refine "watch read-only")
 
-- **Status:** **Proposed** — pending PM scope confirmation (crosses the "watch read-only **for MVP**" line) and Architect ratification. Deliverable of Story **9.6a**; gates Story **9.6**.
+- **Status:** **Accepted** — ratified 2026-06-09 by Winston (Architect); PM scope confirmed 2026-06-09 (ifero). Folded into `architecture.md` as `ADR-2026-06-09-001`. Deliverable of Story **9.6a**; **unblocks** Story **9.6**.
 - **Date:** 2026-06-09
 - **Drivers:** ifero (stakeholder), `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`)
 - **Supersedes wording of:** ARCH-20 ("Watch is READ-ONLY for MVP") — _refines_, does not remove.
@@ -26,8 +26,14 @@ Key insight: **usage is not card-data editing.** It is an append-only, **commuta
 2. **Add one versioned message, watch → phone:**
 
    ```jsonc
-   { "version": 1, "type": "CARD_USED", "payload": { "id": "<uuid>", "usedAt": "<ISO-8601 UTC>" } }
+   {
+     "version": 1,
+     "type": "CARD_USED",
+     "payload": { "id": "<uuid>", "usedAt": "<ISO-8601 UTC, millisecond precision>" }
+   }
    ```
+
+   > **Ratification note (precision, 2026-06-09):** `usedAt` MUST carry **millisecond** precision (e.g. `2026-06-09T12:34:56.789Z`). The dedup event id (Decision 4) is `"<cardId>:<usedAt>"`, so sub-second resolution is precisely what guarantees two genuinely-distinct opens of the same card cannot collapse into one. Second-resolution timestamps are non-conformant.
 
 3. **Phone reconciliation (conflict-free):** on receiving `CARD_USED`, reuse the Story 9.1 usage path:
    - `usageCount = usageCount + 1`
@@ -51,6 +57,8 @@ Key insight: **usage is not card-data editing.** It is an append-only, **commuta
 - **Risk:** low, contingent on the dedup window being sized so legitimately-distinct opens (same card, different second) are not merged — `usedAt` at millisecond precision plus `cardId` makes collisions effectively impossible.
 
 ## Docs to update on ratification (Story 9.6 "docs" task)
+
+> ✅ **Applied 2026-06-09 at ratification** (Architect) — all 7 references reworded + `CARD_USED` added to both documented `SyncMessage` unions (architecture.md & project_context.md). The code-level `sync.ts` schema change remains Story 9.6's implementation task. The `epics.md:1922` row had already advanced to ~line 1980 via the correct-course and is now flipped from "proposed" to "ratified."
 
 Reword consistently (data-vs-usage) at all 7 references, and add `CARD_USED` to the documented message types:
 
@@ -76,7 +84,13 @@ Also add `CARD_USED` to the `SyncMessage` type list in `docs/project_context.md`
 
 Before implementation (Story 9.6), verify current/non-deprecated WatchConnectivity delivery APIs via Context7 / official docs — likely `transferUserInfo` (queued, guaranteed, survives relaunch) over `sendMessage` (requires reachability). Confirm `react-native-watch-connectivity` exposes the receive side on the phone.
 
+**Verified at ratification (2026-06-09, Architect):**
+
+- ✅ **`WCSession.transferUserInfo(_:)` is current / non-deprecated** ([Apple docs](https://developer.apple.com/documentation/watchconnectivity/wcsession/1615671-transferuserinfo)). Queues dictionaries, delivers FIFO, and **continues even if the app is suspended — queued until the counterpart launches**; received via `session(_:didReceiveUserInfo:)`. Correct primitive for the offline-queue requirement. `sendMessage` (reachability-gated) and `updateApplicationContext` (latest-state-only, would lose discrete counts) are correctly rejected.
+- ✅ **`react-native-watch-connectivity` v2.0.0** (current) exposes the phone-side receive as `watchEvents.on('user-info', cb)`, emitting an **array that includes user-info received before the RN app initialised** — relaunch-queued events arrive as a batch; the handler MUST iterate and dedup by event id.
+- ⚠️ **Implementation constraint (Story 9.6):** the **watchOS Simulator does not support `transferUserInfo(_:)`** — this path MUST be validated on a **physical phone+watch pair** (reinforces the Sprint 14 retro "spike-first on device"). Story 9.6 AC6 stays binding for the precise version check at build time.
+
 ## Sign-off
 
-- [ ] **PM** — confirms pulling usage past the "read-only-for-MVP" line is in scope.
-- [ ] **Architect** — ratifies the design; flips Status → Accepted; folds into `architecture.md` as `ADR-2026-06-09-001`.
+- [x] **PM** — confirmed 2026-06-09 (ifero): pulling usage past the "read-only-for-MVP" line is in scope.
+- [x] **Architect** — ratified 2026-06-09 (Winston): design validated (commutativity + dedup + offline + API currency); `usedAt` tightened to ms precision; Status → Accepted; folded into `architecture.md` as `ADR-2026-06-09-001`; read-only wording refined across all 7 references.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1015,21 +1015,33 @@ async function syncWithWatch(cards: LoyaltyCard[]) {
 ```typescript
 type SyncMessage = {
   version: number;
-  type: 'CARDS_UPDATED' | 'CARD_ADDED' | 'CARD_DELETED' | 'REQUEST_FULL_SYNC' | 'SYNC_COMPLETE';
+  // All phone → watch, EXCEPT CARD_USED which is watch → phone (usage telemetry). See ADR-2026-06-09-001.
+  type:
+    | 'CARDS_UPDATED'
+    | 'CARD_ADDED'
+    | 'CARD_DELETED'
+    | 'REQUEST_FULL_SYNC'
+    | 'SYNC_COMPLETE'
+    | 'CARD_USED';
   payload: unknown;
 };
+
+// CARD_USED (watch → phone) — usage event, NOT a card-data edit (ADR-2026-06-09-001):
+//   payload: { id: string; usedAt: string /* ISO-8601 UTC, millisecond precision */ }
+//   Phone applies commutatively: usageCount += 1; lastUsedAt = max(lastUsedAt, usedAt).
+//   Dedup by stable event id "<id>:<usedAt>". Delivered via transferUserInfo (queued). Implemented in Story 9.6.
 
 // Watch MUST handle unknown versions gracefully:
 // - If version > supported: Log warning, ignore, request full sync
 // - Never crash on unknown message format
 ```
 
-**Watch App Editing Policy (MVP):**
+**Watch App Editing Policy** _(refined by [ADR-2026-06-09-001](adr-2026-06-09-watch-usage-events.md), 2026-06-09):_
 
-- Watch is READ-ONLY for MVP
-- Card editing only happens on phone
-- Prevents sync conflicts entirely
-- Add field-level merge in v2 if user feedback requires it
+- Watch is **READ-ONLY for card _data_** — create/edit/delete/favourite happen only on the phone.
+- The watch **MAY emit usage events** (`CARD_USED`, card-opened); the phone applies them as **commutative** updates (`usageCount += 1`, `lastUsedAt = max`), so no card-data edit conflict is introduced.
+- This preserves the original "prevents sync conflicts" guarantee: usage is an append-only commutative signal, disjoint from the user-editable card-data surface.
+- Add field-level merge for card _data_ in v2 only if user feedback requires it.
 
 ### Error & Loading Patterns
 

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -263,7 +263,7 @@ This document provides the complete epic and story breakdown for myLoyaltyCards,
 - ARCH-17: iOS ↔ watchOS sync via WatchConnectivity framework (no throttling)
 - ARCH-18: Android ↔ Wear OS sync via Wearable Data Layer API (Phase 2)
 - ARCH-19: Sync Message Protocol with version field and typed messages (CARDS_UPDATED, CARD_ADDED, etc.)
-- ARCH-20: Watch is READ-ONLY for MVP (editing only happens on phone)
+- ARCH-20: Watch is READ-ONLY for card data (create/edit/delete/favourite only on phone); usage events (`CARD_USED`, card-opened) are permitted and applied commutatively on the phone — refined by ADR-2026-06-09-001 (2026-06-09)
 
 **From Architecture - Infrastructure:**
 
@@ -1005,7 +1005,7 @@ _Example brands: Esselunga, Conad, Coop, Carrefour, Lidl, Eurospin, Pam, Despar,
 
 **Technical Notes:**
 
-- Watch is READ-ONLY for MVP (card editing only on phone)
+- Watch is READ-ONLY for card data (card editing only on phone); usage events permitted, applied commutatively on phone (ADR-2026-06-09-001)
 - Card list order matches phone (newest first / alphabetical)
 - Sync protocol uses versioned messages (CARDS_UPDATED, CARD_ADDED, etc.)
 
@@ -1977,13 +1977,13 @@ _Added 2026-06-09 via correct-course. Depends on the 9.6a ADR + PM scope confirm
 **Technical Notes:**
 
 - Same sync protocol as watchOS (versioned messages)
-- Watch is READ-ONLY for card data (consistent with watchOS). A usage-event channel (card-opened → phone) is **proposed** for Epic 9 Story 9.6, pending the Story 9.6a ADR — Wear OS will mirror whatever that ADR ratifies. _(Updated 2026-06-09 via correct-course.)_
+- Watch is READ-ONLY for card data (consistent with watchOS). A usage-event channel (`CARD_USED`, card-opened → phone) is **ratified** for Epic 9 Story 9.6 by **ADR-2026-06-09-001** (Accepted 2026-06-09) — Wear OS mirrors it via the Wearable Data Layer (`MessageClient`/`DataClient`): same `{ id, usedAt }` payload + commutative reconciliation (`usageCount += 1`, `lastUsedAt = max`). _(Updated 2026-06-09 via correct-course; ratified 2026-06-09.)_
 
 **Parity scope added 2026-06-09 (correct-course — mirror the watchOS Epic 9 changes):**
 
 - Per-surface selectable sort (Frequently used / Recently added / A‑Z), persisted independently (mirror Story 9.5)
 - Favourite (pin) indicator on rows (mirror Story 9.4 / C3)
-- Usage-event emission for card opens (mirror Story 9.6, pending the 9.6a ADR)
+- Usage-event emission for card opens (mirror Story 9.6, per ADR-2026-06-09-001 — Accepted)
 
 **Enabling Note:** Stories 10.1–10.2 are enabling tasks required for the Wear OS experience.
 

--- a/docs/project_context.md
+++ b/docs/project_context.md
@@ -234,16 +234,19 @@ if (currentVersion === 0) {
 
 - **No throttling:** Immediate sync on changes
 - **Retry:** 3 attempts with exponential backoff
-- **Watch is READ-ONLY** for MVP (prevents conflicts)
+- **Watch is READ-ONLY for card _data_** (create/edit/delete/favourite only on phone); it MAY emit `CARD_USED` usage events, applied commutatively on the phone — no edit conflict (ADR-2026-06-09-001)
 
 ### Message Versioning
 
 ```typescript
 type SyncMessage = {
   version: number; // Always include
-  type: 'CARDS_UPDATED' | 'CARD_ADDED' | 'CARD_DELETED' | 'REQUEST_FULL_SYNC';
+  // CARD_USED is watch → phone (usage telemetry); all others phone → watch. See ADR-2026-06-09-001.
+  type: 'CARDS_UPDATED' | 'CARD_ADDED' | 'CARD_DELETED' | 'REQUEST_FULL_SYNC' | 'CARD_USED';
   payload: unknown;
 };
+// CARD_USED payload: { id: string; usedAt: string /* ISO-8601 UTC, ms precision */ }; phone applies
+// usageCount += 1, lastUsedAt = max; dedup by "<id>:<usedAt>". Implemented in Story 9.6.
 ```
 
 ---
@@ -321,7 +324,7 @@ test-fixtures/
 
 ### Watch App Rules
 
-- Watch is **READ-ONLY** for MVP
+- Watch is **READ-ONLY for card _data_** — usage events (`CARD_USED`) permitted, applied commutatively on phone (ADR-2026-06-09-001)
 - Handle unknown message versions gracefully (request full sync)
 - Store dates as strings, parse only for display
 

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-01-03
-# updated: 2026-06-04
+# updated: 2026-06-09
 # project: myLoyaltyCards
 # tracking_system: file-system
 # story_location: docs/sprint-artifacts
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-01-03
-updated: 2026-06-04
+updated: 2026-06-09
 project: myLoyaltyCards
 tracking_system: file-system
 story_location: docs/sprint-artifacts
@@ -264,9 +264,9 @@ development_status:
   9-2-mark-card-as-favorite: done # design signed off 2026-06-07 (Figma frame approved); impl + code review + QA complete; awaiting stakeholder commit approval
   9-3-implement-sorting-algorithm: done
   9-4-sync-sorting-to-watch: done # C3 favourite-badge implemented; code review + QA approved (2026-06-09); story.md at "review" — awaiting stakeholder approval to commit/PR
-  9-5-selectable-watch-sort: drafted # correct-course 2026-06-09 — port phone sort modes (frequent/recent/az) to watch, default A-Z, independent persisted pref; gates: PRD FR25 + UX picker
-  9-6a-watch-usage-event-adr: drafted # correct-course 2026-06-09 — Architect ADR: watch→phone usage-event channel + read-only refinement; gates 9-6; ADR produced 2026-06-09
-  9-6-count-watch-card-opens: drafted # correct-course 2026-06-09 — watch card open increments usageCount/lastUsedAt (commutative); depends on 9-6a ADR + PM scope confirm
+  9-5-selectable-watch-sort: drafted # correct-course 2026-06-09 — port phone sort modes (frequent/recent/az) to watch, default A-Z, independent persisted pref; gates: PRD FR75 (proposed; was erroneously "FR25") + UX watch-picker spec
+  9-6a-watch-usage-event-adr: ready-for-dev # 2026-06-09: ADR-2026-06-09-001 RATIFIED → Accepted (Architect); 7 read-only refs refined + CARD_USED documented. Story .md at "review" (auto-flips to done on merge). Unblocked 9-6.
+  9-6-count-watch-card-opens: ready-for-dev # 2026-06-09: gates cleared — ADR-2026-06-09-001 Accepted + PM scope confirmed. Implement CARD_USED per ADR (transferUserInfo; ms-precision usedAt; dedup "<id>:<usedAt>"). Relates PRD FR76.
   epic-9-retrospective: optional
 
   # Epic 10: Wear OS App

--- a/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
+++ b/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
@@ -3,7 +3,7 @@
 Status: drafted
 
 > Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
-> **Gates before `ready-for-dev`:** PRD **FR25** (PM) + UX watch-picker spec (UX). Depends on Story 9.4.
+> **Gates before `ready-for-dev`:** PRD **FR75** (PM — _renumbered from the proposal's erroneous "FR25", which is already "guest mode"; PRD currently runs to FR74_) + UX watch-picker spec (UX). Depends on Story 9.4.
 
 ## Story
 
@@ -62,7 +62,7 @@ so that the order matches how I think about my cards (not just a fixed algorithm
 - **Phone reference (do not re-invent):** `features/cards/hooks/useCardSort.ts` (Story 13.2) defines the three modes, their comparators, and persisted-preference pattern (`AsyncStorage` key `@myLoyaltyCards/sortPreference`, default `frequent`). Mirror the _semantics_; the watch keeps its **own** preference with an **A‑Z** default (decision 2026-06-09).
 - **Reuse:** `WatchCard.sortedForDisplay(_:)` already implements `frequent`. Add the other two variants beside it so all watch surfaces share one source of truth.
 - **Watch contract tests** (`targets/watch/__tests__/`) run in CI via `watchos-tests.yml` and are **excluded** by the default `yarn test` — run them with `jest --testPathPattern='targets/watch/__tests__' --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/node_modules/'`.
-- **Open product input:** exact picker affordance (sheet vs inline list vs Digital Crown) → UX. PRD FR25 must land first.
+- **Open product input:** exact picker affordance (sheet vs inline list vs Digital Crown) → UX. PRD **FR75** (selectable per-surface sort, persisted) must land first.
 
 ### References
 

--- a/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
+++ b/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
@@ -1,9 +1,9 @@
 # Story 9.6: Count Card Opens on the Watch
 
-Status: drafted
+Status: ready-for-dev
 
 > Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
-> **Gates before `ready-for-dev`:** Story **9.6a ADR** accepted + **PM** confirmation that this is in scope (it crosses the "watch read-only **for MVP**" line). Depends on Story 9.4.
+> ✅ **Gates cleared 2026-06-09 → `ready-for-dev`:** [ADR-2026-06-09-001](../../adr-2026-06-09-watch-usage-events.md) **Accepted** (Architect) + PM scope confirmed (ifero). Depends on Story 9.4 (done). Relates to PRD **FR76** (usage recorded on every display surface, incl. watch).
 
 ## Story
 
@@ -55,7 +55,12 @@ so that "most used / recently used" sorting is accurate on both the Watch and th
 
 ## Dev Notes
 
-- **Do not start before 9.6a is accepted** — the message shape, conflict strategy, and offline/idempotency rules come from the ADR.
+- **9.6a ADR is now Accepted** ([ADR-2026-06-09-001](../../adr-2026-06-09-watch-usage-events.md)) — implement to its finalized contract:
+  - **Message:** `{ version: 1, type: "CARD_USED", payload: { id, usedAt } }`, watch → phone. `usedAt` = ISO-8601 UTC at **millisecond** precision (required for dedup correctness).
+  - **Dedup event id** `"<cardId>:<usedAt>"`; phone applies each unique id **once**: `usageCount += 1`, `lastUsedAt = max(lastUsedAt, usedAt)`.
+  - **Transport:** `transferUserInfo` (queued / guaranteed / survives relaunch) — **not** `sendMessage` (reachability-gated). Phone receives via `watchEvents.on('user-info', …)`, which delivers a **batch** (incl. pre-launch events) → iterate + dedup; size/persist the dedup window so a late retransmit can't slip past it.
+  - **⚠️ Validate on a physical phone+watch pair** — the watchOS Simulator does **not** support `transferUserInfo` (satisfies AC6 / Sprint 14 retro at build time).
+- **Watch→phone channel already exists** (`requestCards` in `core/watch-connectivity.ts`) — `CARD_USED` extends that direction; no new transport plumbing class.
 - **Reuse the phone usage path** from Story 9.1 (done) for the actual increment so phone and watch opens are counted identically.
 - **Shared counter is the whole point:** because `usageCount`/`lastUsedAt` are shared, fixing the watch gap also corrects the phone's frequency/recency sort (the original observation that triggered this work).
 - **Wear OS (Epic 10):** mirror the same protocol once built (parity scope added to Epic 10 on 2026-06-09).

--- a/docs/sprint-artifacts/stories/9-6a-watch-usage-event-adr.md
+++ b/docs/sprint-artifacts/stories/9-6a-watch-usage-event-adr.md
@@ -1,10 +1,11 @@
 # Story 9.6a: Watch Usage-Event Architecture (Spike / ADR) [Enabling]
 
-Status: drafted
+Status: review
 
 > Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
 > **Owner:** Architect. **Gates:** none to start; its output gates Story 9.6.
 > Honours Sprint 14 retro: "Spike-first for Watch/native APIs" + "Mandatory API-currency check."
+> **PM scope confirmed 2026-06-09 (ifero)** — usage-counting (C2) is in scope; watch stays read-only for card data. Status → `ready-for-dev`; ready for the **Architect** to ratify the Proposed ADR (flip → Accepted), fold into `architecture.md` as `ADR-2026-06-09-001`, and apply the read-only wording refinement across the 7 references.
 
 ## Story
 
@@ -24,8 +25,8 @@ so that counting watch card opens (Story 9.6) never reintroduces the card-edit c
 3. **Given** the watch may be offline / phone unreachable
    **Then** the ADR defines **offline behaviour** (queue on watch, flush on reachability, idempotency/dedup strategy)
 
-4. **Given** the "watch read-only" rule lives in 7 places (CONTRIBUTING, project_context ×2, architecture, epics ×3)
-   **Then** the ADR specifies the exact refined wording — _"read-only for card data; usage events permitted"_ — and lists every file/line to update
+4. **Given** the "watch read-only" rule lives in 7 places (CONTRIBUTING, project*context ×2, architecture, epics ×3)
+   **Then** the ADR specifies the exact refined wording — *"read-only for card data; usage events permitted"\_ — and lists every file/line to update
 
 5. **Given** Epic 10 (Wear OS) must stay consistent
    **Then** the ADR confirms the same protocol/strategy is adoptable on Wear OS (Wearable Data Layer)
@@ -34,13 +35,13 @@ so that counting watch card opens (Story 9.6) never reintroduces the card-edit c
 
 ## Tasks / Subtasks
 
-- [ ] Review current `react-native-watch-connectivity` + WatchConnectivity capabilities for watch→phone delivery (guaranteed vs best-effort); verify API currency (AC: 1, 6)
-- [ ] Design the `CARD_USED` message + the phone-side handler that applies commutative increments (AC: 1, 2)
-- [ ] Define offline queue + flush + dedup/idempotency (AC: 3)
-- [ ] Specify the read-only wording refinement + the exact edit list across the 7 references (AC: 4)
-- [ ] Confirm Wear OS adoptability (AC: 5)
-- [ ] Write the ADR to `docs/architecture/adr/` (or `docs/`); get **PM** confirmation that pulling usage past the "read-only-for-MVP" line is in scope
-- [ ] On acceptance, mark 9.6 `ready-for-dev`
+- [x] Review current `react-native-watch-connectivity` + WatchConnectivity capabilities for watch→phone delivery (guaranteed vs best-effort); verify API currency (AC: 1, 6) — ✅ `transferUserInfo` (queued, survives relaunch); RN `watchEvents.on('user-info')` batch receive; Simulator-unsupported
+- [x] Design the `CARD_USED` message + the phone-side handler that applies commutative increments (AC: 1, 2)
+- [x] Define offline queue + flush + dedup/idempotency (AC: 3) — dedup id `"<cardId>:<usedAt>"`, ms-precision `usedAt`
+- [x] Specify the read-only wording refinement + the exact edit list across the 7 references (AC: 4) — ✅ all 7 applied 2026-06-09
+- [x] Confirm Wear OS adoptability (AC: 5) — ✅ Wearable Data Layer (`MessageClient`/`DataClient`), same shape + reconciliation
+- [x] Write the ADR to `docs/architecture/adr/` (or `docs/`); get **PM** confirmation that pulling usage past the "read-only-for-MVP" line is in scope — ✅ ADR ratified; PM confirmed 2026-06-09
+- [x] On acceptance, mark 9.6 `ready-for-dev` — ✅ done 2026-06-09
 
 ## Dev Notes
 
@@ -64,14 +65,22 @@ claude-opus-4-8 (Amelia) — initial ADR draft via correct-course
 
 ### Completion Notes List
 
-- **ADR draft produced 2026-06-09** → [`docs/adr-2026-06-09-watch-usage-events.md`](../../adr-2026-06-09-watch-usage-events.md), Status **Proposed**. Covers the `CARD_USED` message, the commutative conflict-safety argument, offline/dedup, the read-only refinement + exact 7-reference edit list, Wear OS consistency, and an API-currency note. **Awaiting PM scope confirmation + Architect ratification** before 9.6 goes `ready-for-dev`.
+- **ADR draft produced 2026-06-09** → [`docs/adr-2026-06-09-watch-usage-events.md`](../../adr-2026-06-09-watch-usage-events.md), Status **Proposed**. Covers the `CARD_USED` message, the commutative conflict-safety argument, offline/dedup, the read-only refinement + exact 7-reference edit list, Wear OS consistency, and an API-currency note. **PM scope confirmation received 2026-06-09 (ifero). Awaiting Architect ratification** (Status Proposed → Accepted) before 9.6 goes `ready-for-dev`.
+- **ADR ratified 2026-06-09 (Winston, Architect).** Status → **Accepted**. Validated commutativity + dedup (tightened `usedAt` → ms precision), offline via `transferUserInfo` (verified current; Simulator-unsupported → physical-device test in 9.6), and Wear OS adoptability (Wearable Data Layer). Folded into `architecture.md` as `ADR-2026-06-09-001`; read-only wording refined across all **7 references** (CONTRIBUTING ×1, project_context ×2, architecture ×1, epics ×3); `CARD_USED` added to both documented `SyncMessage` unions. **Story 9.6 unblocked → `ready-for-dev`.**
 
 ### File List
 
-- `docs/adr-2026-06-09-watch-usage-events.md` (new — Proposed ADR)
+- `docs/adr-2026-06-09-watch-usage-events.md` (ADR — now **Accepted**)
+- `docs/architecture.md` (SyncMessage union + `CARD_USED` + Watch Editing Policy → ADR-2026-06-09-001)
+- `docs/project_context.md` (Sync Patterns + Message Versioning + Watch App Rules)
+- `CONTRIBUTING.md` (watch read-only wording)
+- `docs/epics.md` (ARCH-20 + Epic 5 note + Epic 10 Wear OS parity)
+- `docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md` (gate cleared → ready-for-dev + ADR specifics in Dev Notes)
 
 ## Change Log
 
-| Date       | Version | Description                          | Author       |
-| ---------- | ------- | ------------------------------------ | ------------ |
-| 2026-06-09 | 0.1     | Drafted via correct-course (C2 gate) | Amelia (dev) |
+| Date       | Version | Description                                                                                                                             | Author         |
+| ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C2 gate)                                                                                                    | Amelia (dev)   |
+| 2026-06-09 | 0.2     | PM scope confirmed (ifero); status drafted → ready-for-dev; routed to Architect for ADR ratification                                    | Bob (SM)       |
+| 2026-06-09 | 0.3     | ADR ratified → Accepted; folded into architecture.md; 7 read-only refs refined; `CARD_USED` added; 9.6 → ready-for-dev; status → review | Winston (Arch) |


### PR DESCRIPTION
## Summary

Ratifies **ADR-2026-06-09-001** (watch→phone usage events, Story 9.6a) and propagates it across the docs. Refines the deliberate "watch read-only for MVP" invariant to **"read-only for card _data_; usage events permitted"** — a refinement, not a reversal: usage is an append-only commutative signal disjoint from the user-editable card surface, so the no-edit-conflict guarantee is preserved.

**Architect validation (not a rubber-stamp):**
- ✅ Commutativity backbone sound (`usageCount` is a monoid under `+1`; `lastUsedAt` = `max`, a CRDT LWW-register).
- 🔧 Tightened `usedAt` → **millisecond precision** so the dedup id `"<cardId>:<usedAt>"` can't merge two genuinely-distinct opens.
- ✅ **API currency verified against official docs:** `transferUserInfo` is current (queued, survives relaunch) — correct over reachability-gated `sendMessage`. ⚠️ watchOS Simulator does **not** support it → Story 9.6 must validate on a physical device pair.
- ✅ Wear OS adoptability confirmed (Wearable Data Layer).

## Changes
- **ADR** → Status **Accepted**; sign-offs ticked; ms-precision + API-currency findings folded in.
- **`CARD_USED` (watch→phone)** added to the documented `SyncMessage` unions in `architecture.md` + `project_context.md`.
- **Read-only wording refined across all 7 live references:** CONTRIBUTING ×1, project_context ×2, architecture ×1, epics ×3.
- **Board:** 9.6a → `review` (auto-flips to `done` on merge); **9.6 → `ready-for-dev`** (gates cleared; ADR specifics baked into Dev Notes); 9.5 FR reference corrected (`FR25` → `FR75`).

## Acceptance Criteria (Story 9.6a)
- [x] AC1 — `CARD_USED (watch → phone)` specified in the versioned `SyncMessage` protocol.
- [x] AC2 — conflict-free reconciliation proven (commutative `+1`; `lastUsedAt = max`).
- [x] AC3 — offline behaviour defined (queue → flush → dedup/idempotency).
- [x] AC4 — exact refined wording + every file/line listed and applied (all 7 refs).
- [x] AC5 — Wear OS adoptability confirmed (Wearable Data Layer).
- [x] AC6 — WatchConnectivity API currency verified (`transferUserInfo` current; Simulator caveat noted).

## Test results
**Documentation-only** — no application code, tests, or generated artifacts touched. Code quality gates N/A; pre-commit `prettier` and pre-push checks passed.

## Links
- ADR: `docs/adr-2026-06-09-watch-usage-events.md` (Accepted)
- Story: `docs/sprint-artifacts/stories/9-6a-watch-usage-event-adr.md`
- Origin: `docs/sprint-artifacts/sprint-change-proposal-2026-06-09.md` (approved by ifero, 2026-06-09)

> Note: per CONTRIBUTING, the author does not merge — over to a maintainer. On merge, the `mark-story-done` automation flips Story 9.6a → `done`.