### PR TITLE
feat(watch): selectable card sort (Story 9.5)

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -264,7 +264,7 @@ development_status:
   9-2-mark-card-as-favorite: done # design signed off 2026-06-07 (Figma frame approved); impl + code review + QA complete; awaiting stakeholder commit approval
   9-3-implement-sorting-algorithm: done
   9-4-sync-sorting-to-watch: done # C3 favourite-badge implemented; code review + QA approved (2026-06-09); story.md at "review" — awaiting stakeholder approval to commit/PR
-  9-5-selectable-watch-sort: ready-for-dev # 2026-06-10: gates cleared — PRD FR75/FR76 added (PM) + UX watch-picker/badge spec merged (#130). Port phone sort modes (frequent/recent/az) to watch; default A-Z; independent persisted pref.
+  9-5-selectable-watch-sort: review # 2026-06-10: impl complete on feature/9-5-selectable-watch-sort; dev-subagent code review (2 rounds → 0 comments) + QA (sonnet) approved. story.md at "review" — awaiting stakeholder approval to commit/PR.
   9-6a-watch-usage-event-adr: done # 2026-06-09: ADR-2026-06-09-001 RATIFIED → Accepted (Architect); 7 read-only refs refined + CARD_USED documented. Story .md at "review" (auto-flips to done on merge). Unblocked 9-6.
   9-6-count-watch-card-opens: ready-for-dev # 2026-06-09: gates cleared — ADR-2026-06-09-001 Accepted + PM scope confirmed. Implement CARD_USED per ADR (transferUserInfo; ms-precision usedAt; dedup "<id>:<usedAt>"). Relates PRD FR76.
   epic-9-retrospective: optional

--- a/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
+++ b/docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md
@@ -1,6 +1,6 @@
 # Story 9.5: Selectable Watch Sort
 
-Status: ready-for-dev
+Status: review
 
 > Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
 > ✅ **Gates cleared 2026-06-10 → `ready-for-dev`:** PRD **FR75/FR76** added (PM) + UX watch-picker & favourite-badge spec merged (PR #130). Depends on Story 9.4 (done). _(FR75 renumbered from the proposal's erroneous "FR25"; see PRD note.)_
@@ -41,21 +41,21 @@ so that the order matches how I think about my cards (not just a fixed algorithm
 
 ### Watch sort model — `targets/watch/`
 
-- [ ] Add a `WatchSortMode` enum (`frequent` / `recent` / `az`) (AC: 1, 2)
-- [ ] Extend the comparator: keep `WatchCard.sortedForDisplay` as `frequent`; add `recent` (createdAt desc, no favourite pin) and `az` (favourite-first → localized name) variants — e.g. `WatchCard.sorted(_ cards:by mode:)` (AC: 2)
-- [ ] Persist the selected mode on the watch (UserDefaults/`@AppStorage`), default `az` (AC: 3, 4)
+- [x] Add a `WatchSortMode` enum (`frequent` / `recent` / `az`) (AC: 1, 2)
+- [x] Extend the comparator: keep `WatchCard.sortedForDisplay` as `frequent`; add `recent` (createdAt desc, no favourite pin) and `az` (favourite-first → localized name) variants — e.g. `WatchCard.sorted(_ cards:by mode:)` (AC: 2)
+- [x] Persist the selected mode on the watch (UserDefaults/`@AppStorage`), default `az` (AC: 3, 4)
 
 ### Watch UI — `targets/watch/CardListView.swift`
 
-- [ ] Add a toolbar button that presents a sort picker (per UX spec) (AC: 1)
-- [ ] Drive `displayCards` from the selected `WatchSortMode` (AC: 2, 5)
-- [ ] Localize the control + mode labels in `en.lproj` + `it.lproj` (AC: 1)
+- [x] Add a toolbar button that presents a sort picker (per UX spec) (AC: 1)
+- [x] Drive `displayCards` from the selected `WatchSortMode` (AC: 2, 5)
+- [x] Localize the control + mode labels in `en.lproj` + `it.lproj` (AC: 1)
 
 ### Tests
 
-- [ ] Unit-test each sort variant's ordering (`recent`, `az`), incl. favourite pinning rules (AC: 2)
-- [ ] Test persistence + `az` default (AC: 3, 4)
-- [ ] Update `targets/watch/__tests__/watch-layout-contract.test.ts` if the row/list layout changes
+- [x] Unit-test each sort variant's ordering (`recent`, `az`), incl. favourite pinning rules (AC: 2)
+- [x] Test persistence + `az` default (AC: 3, 4)
+- [x] Update `targets/watch/__tests__/watch-layout-contract.test.ts` if the row/list layout changes
 
 ## Dev Notes
 
@@ -74,14 +74,41 @@ so that the order matches how I think about my cards (not just a fixed algorithm
 
 ### Agent Model Used
 
+Opus 4.8 (`claude-opus-4-8`) — BMad dev agent (Amelia).
+
 ### Debug Log References
+
+- `yarn watch:build` → **BUILD SUCCEEDED**; `CardListView.swift` is deprecation-warning-clean (watchOS 26.5 SDK). Fixed one pre-existing deprecation while in-file: the deep-link `onChange(of:perform:)` single-param closure → two-param form (deprecated in watchOS 10.0).
+- Watch contract jest (`watch-layout-contract.test.ts`): 11/11 pass (incl. 2 new Story 9.5 specs).
+- `yarn lint` clean · `yarn typecheck` clean.
+- Sort orderings independently validated via a standalone `swift` run of the three comparators against the XCTest data (`.recent`/`.az`/`.frequent` all matched expectations).
 
 ### Completion Notes List
 
+- **AC6 (API currency) — verified against official Apple docs before coding:** `ToolbarItemPlacement.topBarTrailing` (watchOS 10.0+, not deprecated), `sheet(isPresented:onDismiss:content:)` (watchOS 6.0+), `@AppStorage` (watchOS 7.0+, `String`-RawValue enum support) — none deprecated. Deployment target is watchOS 10.0.
+- **Model:** `WatchSortMode` enum (`frequent`/`recent`/`az`) + `WatchCard.sorted(_:by:)` added beside `sortedForDisplay` (single source of truth). `.frequent` reuses `sortedForDisplay`, so the complication "top card" can never drift. `.recent` = `createdAt` desc (no favourite pin); `.az` = favourite-first → locale-aware, case- & diacritic-insensitive name compare. Swift `sorted(by:)` is stable (Swift 5+), matching the phone's stable `Array.sort`.
+- **AC2 A‑Z comparator:** uses `compare(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)` to mirror the phone's `localeCompare(…, {sensitivity:'base'})` exactly — accents don't change ordering (matters for the Italian-first audience). _(Tightened from case-insensitive-only after code review finding #5.)_
+- **AC2 `.frequent` parity fix:** corrected `sortedForDisplay` so a card that has been used outranks one that never has at equal `usageCount` (mixed-`nil` `lastUsedAt`) — the prior both-present-only check fell through to `createdAt`, diverging from the phone's `if (a.lastUsedAt) return -1` rule. Pre-existing (Story 9.4) bug surfaced by AC2's "match exactly"; fix also tightens the shared complication ordering. _(Code review finding #1; covered by a new XCTest.)_
+- **Persistence (AC3/AC4):** `@AppStorage("watch.sortMode")` default `.az`, watch-local under its own key — independent of the phone's `AsyncStorage @myLoyaltyCards/sortPreference`. This is UI state, **not** card data, so the watch read-only rule (ADR-2026-06-09-001) is preserved; no `WatchSessionManager`/complication code touched.
+- **UI (UX spec §5):** top-trailing toolbar button (`arrow.up.arrow.down`, a11y "Sort") → `.sheet` hosting `WatchSortPickerView` (Carbon-black `List` of 3 rows). Active row is double-encoded — semibold `accentColor` label + trailing `checkmark` + VoiceOver `.isSelected` trait (never colour alone). Tap sets the mode and dismisses immediately; `.animation(.default, value: sortMode)` gives the brief re-order. Sort button is hidden on the empty state (nothing to sort). `Color.accentColor` is the app key/tint per spec (watch `AccentColor` asset is intentionally system-default).
+- **Localization:** added `watch.sort.{title,frequent,recent,az}` to `en.lproj` + `it.lproj`. Italian is ASCII (`"Piu usate"`) to match the established watch-target convention — both watch `.strings` bundles are deliberately accent-free (e.g. existing `"…carta fedelta piu usata."`); semantics still mirror the phone (`Più usate`). Did not retro-fit accents elsewhere (out of scope).
+- **Tests:** Swift XCTests (`watch-ios/Tests/CardStoreTests.swift`) for the three orderings, favourite-pin rules, the frequent mixed-`nil` tier, A-Z diacritic-insensitivity, `az` default, `allCases` row order, and `UserDefaults` round-trip — following the repo's existing watch-test pattern (these, like all watch Swift tests, run in Xcode; the watch scheme has no `xcodebuild test` step). All orderings were additionally validated by a standalone `swift` run. CI-enforced TS contract coverage added to `watch-layout-contract.test.ts`.
+- **Scope:** card list only; phone behaviour and sync payloads untouched. `sortedForDisplay` (shared with the complication) was tightened for phone parity (see `.frequent` parity fix above) — strictly more correct, no behavioural regression (existing full-tier test still passes).
+- **Code review:** round 1 (sonnet subagent) → fixed findings #1 (frequent mixed-`nil` parity) and #5 (A-Z diacritics) + added covering tests; round 2 → APPROVED (0 comments). Findings #4/#7 (pre-existing vacuous `test_readOnly_preventsCardModification` + Italian comments) were initially deferred, then **addressed per stakeholder request**: rewritten as `test_readOnly_localCardEdits_doNotPersistAcrossReload` (proves a local edit never writes back across a store reload) with English comments. Not a 9.5 AC; folded onto this branch as a separate `test:` change. A 3rd review round on that test → APPROVED (0 comments); its 2 NITs (`setUp` clears stray `UITEST_CARDS`; `defer`-guarded sort-mode cleanup) were then applied, along with gating the DEBUG sample-card seeder to the empty state so it no longer crowds the sort button in dev builds.
+
 ### File List
+
+- `targets/watch/CardListView.swift` — `WatchSortMode` enum, `WatchCard.sorted(_:by:)`, `@AppStorage` sort pref, toolbar sort button + `.sheet`, `WatchSortPickerView`, `displayCards` driven by mode, re-order animation; `sortedForDisplay` mixed-`nil` parity fix; pre-existing `onChange` deprecation fix; DEBUG sample-card seeder gated to the empty state (avoids crowding the sort button in dev builds).
+- `targets/watch/en.lproj/Localizable.strings` — `watch.sort.*` keys.
+- `targets/watch/it.lproj/Localizable.strings` — `watch.sort.*` keys.
+- `targets/watch/__tests__/watch-layout-contract.test.ts` — 2 new Story 9.5 contract specs (sort model + sort control).
+- `watch-ios/Tests/CardStoreTests.swift` — 8 new Story 9.5 XCTests (3 mode orderings, frequent mixed-`nil` tier, A-Z diacritic-insensitivity, `az` default, `allCases` order, `UserDefaults` round-trip); plus rewrote the pre-existing `test_readOnly_*` into a meaningful read-only persistence-invariant guard with English comments (stakeholder follow-up; not a 9.5 AC). Test isolation hardened: `setUp` clears any stray `UITEST_CARDS` env; the sort-mode persistence test cleanup is `defer`-guarded.
+- `docs/sprint-artifacts/sprint-status.yaml` — `9-5-selectable-watch-sort` status.
+- `docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md` — status, tasks, this record.
 
 ## Change Log
 
-| Date       | Version | Description                     | Author       |
-| ---------- | ------- | ------------------------------- | ------------ |
-| 2026-06-09 | 0.1     | Drafted via correct-course (C1) | Amelia (dev) |
+| Date       | Version | Description                                                             | Author       |
+| ---------- | ------- | ----------------------------------------------------------------------- | ------------ |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C1)                                         | Amelia (dev) |
+| 2026-06-10 | 0.2     | Implemented selectable watch sort (model, UI, l10n, tests); AC1–AC6 met | Amelia (dev) |

--- a/targets/watch/CardListView.swift
+++ b/targets/watch/CardListView.swift
@@ -122,19 +122,85 @@ struct WatchCard: Identifiable, Codable {
   }()
 }
 
+/// User-selectable ordering for the Watch card list. Cases mirror the phone's
+/// `useCardSort` (`features/cards/hooks/useCardSort.ts`) so the two surfaces share
+/// one vocabulary. The watch persists its own choice — default `.az` — independently
+/// of the phone (decision 2026-06-09). Declaration order is the picker row order.
+enum WatchSortMode: String, CaseIterable, Identifiable {
+  case frequent
+  case recent
+  case az
+
+  var id: String { rawValue }
+
+  /// UserDefaults key backing the watch-local `@AppStorage` preference. Watch-only:
+  /// never written to card data, so the read-only watch rule (ADR-2026-06-09-001) holds.
+  static let storageKey = "watch.sortMode"
+
+  /// Default on a fresh install with no saved preference (AC3).
+  static let defaultMode: WatchSortMode = .az
+
+  /// Localized label key for this mode (resolved via `WatchL10n`).
+  var localizationKey: String {
+    switch self {
+    case .frequent: return "watch.sort.frequent"
+    case .recent: return "watch.sort.recent"
+    case .az: return "watch.sort.az"
+    }
+  }
+}
+
 extension WatchCard {
   /// Shared ordering for every Watch surface that ranks cards (the card list and
   /// the complication "top card"): favourites first → usageCount desc →
   /// lastUsedAt desc → createdAt desc. Single source of truth so the surfaces
-  /// can never drift apart.
+  /// can never drift apart. This is the `.frequent` mode.
   static func sortedForDisplay(_ cards: [WatchCard]) -> [WatchCard] {
     cards.sorted { a, b in
       if a.isFavorite != b.isFavorite { return a.isFavorite }
       if a.usageCount != b.usageCount { return a.usageCount > b.usageCount }
-      if let aLast = a.lastUsedAt, let bLast = b.lastUsedAt, aLast != bLast {
+      // lastUsedAt desc — and a card that has been used outranks one that never has,
+      // even at equal usageCount (mirrors useCardSort.ts: `if (a.lastUsedAt) return -1;
+      // if (b.lastUsedAt) return 1;`). The earlier both-present-only check skipped this.
+      switch (a.lastUsedAt, b.lastUsedAt) {
+      case let (aLast?, bLast?) where aLast != bLast:
         return aLast > bLast
+      case (.some, .none):
+        return true
+      case (.none, .some):
+        return false
+      default:
+        break
       }
       return a.createdAt > b.createdAt
+    }
+  }
+
+  /// Orders `cards` for the user-selected `mode`, mirroring the phone's `useCardSort`
+  /// semantics exactly so the two surfaces never drift:
+  /// - `.frequent`: favourites first → usageCount desc → lastUsedAt desc → createdAt desc
+  /// - `.recent`:   createdAt desc (favourites are **not** pinned)
+  /// - `.az`:       favourites first → name (locale-aware, case- & diacritic-insensitive)
+  ///
+  /// Swift's `sorted(by:)` is stable (Swift 5+), matching the phone's stable `Array.sort`.
+  static func sorted(_ cards: [WatchCard], by mode: WatchSortMode) -> [WatchCard] {
+    switch mode {
+    case .frequent:
+      return sortedForDisplay(cards)
+    case .recent:
+      return cards.sorted { $0.createdAt > $1.createdAt }
+    case .az:
+      return cards.sorted { a, b in
+        if a.isFavorite != b.isFavorite { return a.isFavorite }
+        // Locale-aware, case- AND diacritic-insensitive to mirror the phone's
+        // localeCompare(…, { sensitivity: 'base' }) exactly (Italian-first audience).
+        return a.name.compare(
+          b.name,
+          options: [.caseInsensitive, .diacriticInsensitive],
+          range: nil,
+          locale: .current
+        ) == .orderedAscending
+      }
     }
   }
 }
@@ -358,12 +424,16 @@ struct CardListView: View {
   @StateObject private var store: CardStore
   @State private var navigationPath: [WatchCardRoute] = []
   @State private var pendingDeepLinkCardId: String?
+  // Watch-local, persisted sort preference (default A-Z), independent of the phone (AC3, AC4).
+  @AppStorage(WatchSortMode.storageKey) private var sortMode: WatchSortMode = WatchSortMode.defaultMode
+  @State private var showSortSheet = false
 
   init(store: CardStore = CardStore()) {
     _store = StateObject(wrappedValue: store)
   }
 
-  /// Cards sorted by isFavorite first → usageCount desc → lastUsedAt desc → createdAt desc.
+  /// Cards ordered by the user-selected `sortMode` (default A-Z). Ordering semantics
+  /// mirror the phone's `useCardSort`; see `WatchCard.sorted(_:by:)`.
   private var displayCards: [WatchCard] {
     let entities: [WatchCard]
     if !persistedEntities.isEmpty {
@@ -390,7 +460,7 @@ struct CardListView: View {
     } else {
       entities = store.cards
     }
-    return WatchCard.sortedForDisplay(entities)
+    return WatchCard.sorted(entities, by: sortMode)
   }
 
   var body: some View {
@@ -411,6 +481,7 @@ struct CardListView: View {
             }
             .padding(.horizontal, 2)
             .padding(.vertical, 2)
+            .animation(.default, value: sortMode)
           }
         }
       }
@@ -426,18 +497,35 @@ struct CardListView: View {
             .background(Color.black)
         }
       }
-    }
-    #if DEBUG
       .toolbar {
-        // use a watch-safe placement for the debug import button
-        ToolbarItem(placement: .automatic) {
-          Button(action: importSampleCards) {
-            Text(WatchL10n.string("watch.debug.import_sample_cards"))
+        if !displayCards.isEmpty {
+          ToolbarItem(placement: .topBarTrailing) {
+            Button {
+              showSortSheet = true
+            } label: {
+              Image(systemName: "arrow.up.arrow.down")
+            }
+            .accessibilityLabel(WatchL10n.string("watch.sort.title"))
+            .accessibilityIdentifier("sort-button")
           }
-          .accessibilityIdentifier("import-sample-cards")
         }
+        #if DEBUG
+          // DEBUG-only seeder; shown only on the empty state (its actual purpose) so it never
+          // crowds the sort control once cards are present. Compiled out of Release entirely.
+          if displayCards.isEmpty {
+            ToolbarItem(placement: .topBarLeading) {
+              Button(action: importSampleCards) {
+                Text(WatchL10n.string("watch.debug.import_sample_cards"))
+              }
+              .accessibilityIdentifier("import-sample-cards")
+            }
+          }
+        #endif
       }
-    #endif
+      .sheet(isPresented: $showSortSheet) {
+        WatchSortPickerView(selection: $sortMode)
+      }
+    }
     .background(Color.black)
     .scrollContentBackground(.hidden)
     .onAppear {
@@ -455,7 +543,7 @@ struct CardListView: View {
 
       openCardRouteIfAvailable(cardId)
     }
-    .onChange(of: displayCards.map(\.id)) { _ in
+    .onChange(of: displayCards.map(\.id)) { _, _ in
       guard let pendingDeepLinkCardId else {
         return
       }
@@ -524,6 +612,52 @@ struct CardListView: View {
       WKInterfaceDevice.current().play(.success)
     }
   #endif
+}
+
+/// Compact watch sort picker presented as a sheet from the card list toolbar (Story 9.5,
+/// UX spec §5). A Carbon-styled `List` of the three `WatchSortMode` rows; the active row is
+/// double-encoded — semibold tint label + trailing checkmark + a VoiceOver "selected" trait,
+/// never colour alone. Tapping a row sets the mode and dismisses immediately so the list
+/// re-orders (AC1, AC2, AC5).
+struct WatchSortPickerView: View {
+  @Binding var selection: WatchSortMode
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      List {
+        ForEach(WatchSortMode.allCases) { mode in
+          let isSelected = selection == mode
+          Button {
+            selection = mode
+            dismiss()
+          } label: {
+            HStack(spacing: 8) {
+              Text(WatchL10n.string(mode.localizationKey))
+                .font(.body)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .foregroundStyle(isSelected ? Color.accentColor : Color.white)
+                .lineLimit(1)
+              Spacer()
+              if isSelected {
+                Image(systemName: "checkmark")
+                  .foregroundStyle(Color.accentColor)
+                  .accessibilityHidden(true)
+              }
+            }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+          }
+          .listRowBackground(Color.black)
+          .accessibilityAddTraits(isSelected ? .isSelected : [])
+        }
+      }
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .background(Color.black)
+      .navigationTitle(WatchL10n.string("watch.sort.title"))
+    }
+  }
 }
 
 struct CardListView_Previews: PreviewProvider {

--- a/targets/watch/__tests__/watch-layout-contract.test.ts
+++ b/targets/watch/__tests__/watch-layout-contract.test.ts
@@ -217,4 +217,74 @@ describe('watch layout contract', () => {
     expect(compactRowHeight).toBeGreaterThanOrEqual(44);
     expect(compactVisibleRows).toBeGreaterThanOrEqual(baselineVisibleRows + 1);
   });
+
+  it('exposes a selectable watch sort model with phone-mirrored variants (Story 9.5)', () => {
+    const cardListView = fs.readFileSync(cardListViewPath, 'utf8');
+
+    // The three modes mirror the phone's useCardSort SortOption union.
+    expect(cardListView).toContain('enum WatchSortMode: String, CaseIterable, Identifiable {');
+    expect(cardListView).toContain('case frequent');
+    expect(cardListView).toContain('case recent');
+    expect(cardListView).toContain('case az');
+
+    // Watch-local persistence key + A-Z default (AC3, AC4).
+    expect(cardListView).toContain('static let storageKey = "watch.sortMode"');
+    expect(cardListView).toContain('static let defaultMode: WatchSortMode = .az');
+
+    // A single comparator entry point; `.frequent` reuses the shared sortedForDisplay so the
+    // complication "top card" can never drift from the list (AC2).
+    expect(cardListView).toContain(
+      'static func sorted(_ cards: [WatchCard], by mode: WatchSortMode) -> [WatchCard]'
+    );
+    expect(cardListView).toContain('return sortedForDisplay(cards)');
+    expect(cardListView).toContain('cards.sorted { $0.createdAt > $1.createdAt }');
+    // A-Z mirrors the phone's localeCompare(sensitivity:'base') — case- AND diacritic-insensitive.
+    expect(cardListView).toContain('options: [.caseInsensitive, .diacriticInsensitive]');
+
+    // The list is driven by the selected mode, not the fixed frequent ordering (AC2, AC5).
+    expect(cardListView).toContain('return WatchCard.sorted(entities, by: sortMode)');
+  });
+
+  it('presents a sort control: toolbar button → picker sheet, double-encoded active row (Story 9.5)', () => {
+    const cardListView = fs.readFileSync(cardListViewPath, 'utf8');
+    const enStrings = fs.readFileSync(
+      path.join(repoRoot, 'targets', 'watch', 'en.lproj', 'Localizable.strings'),
+      'utf8'
+    );
+    const itStrings = fs.readFileSync(
+      path.join(repoRoot, 'targets', 'watch', 'it.lproj', 'Localizable.strings'),
+      'utf8'
+    );
+
+    // Watch-local persisted preference, default A-Z (AC3, AC4).
+    expect(cardListView).toContain(
+      '@AppStorage(WatchSortMode.storageKey) private var sortMode: WatchSortMode = WatchSortMode.defaultMode'
+    );
+
+    // Entry point: a top-trailing toolbar button with the sort glyph (UX spec §5, AC1).
+    expect(cardListView).toContain('ToolbarItem(placement: .topBarTrailing)');
+    expect(cardListView).toContain('Image(systemName: "arrow.up.arrow.down")');
+    expect(cardListView).toContain('.accessibilityLabel(WatchL10n.string("watch.sort.title"))');
+
+    // Presentation: a sheet hosting the picker (AC1).
+    expect(cardListView).toContain('.sheet(isPresented: $showSortSheet)');
+    expect(cardListView).toContain('WatchSortPickerView(selection: $sortMode)');
+    expect(cardListView).toContain('struct WatchSortPickerView: View {');
+
+    // Active row is double-encoded: checkmark + VoiceOver "selected" trait, never colour alone.
+    expect(cardListView).toContain('Image(systemName: "checkmark")');
+    expect(cardListView).toContain('.accessibilityAddTraits(isSelected ? .isSelected : [])');
+
+    // Mode labels + control title are localised in BOTH bundles (cross-file coupling).
+    for (const key of [
+      'watch.sort.title',
+      'watch.sort.frequent',
+      'watch.sort.recent',
+      'watch.sort.az'
+    ]) {
+      expect(cardListView).toContain(`"${key}"`);
+      expect(enStrings).toContain(`"${key}" =`);
+      expect(itStrings).toContain(`"${key}" =`);
+    }
+  });
 });

--- a/targets/watch/en.lproj/Localizable.strings
+++ b/targets/watch/en.lproj/Localizable.strings
@@ -5,6 +5,10 @@
 "watch.cards.empty.accessibility" = "No cards yet. Add cards on your iPhone, they sync here automatically.";
 "watch.cards.fallback_name" = "Card";
 "watch.cards.unavailable" = "Card unavailable";
+"watch.sort.title" = "Sort";
+"watch.sort.frequent" = "Frequently used";
+"watch.sort.recent" = "Recently added";
+"watch.sort.az" = "A-Z";
 "watch.card_row.accessibility_format" = "Card, %@";
 "watch.card_row.favorite_accessibility_format" = "Favourite card, %@";
 "watch.debug.import_sample_cards" = "Import sample cards";

--- a/targets/watch/it.lproj/Localizable.strings
+++ b/targets/watch/it.lproj/Localizable.strings
@@ -5,6 +5,10 @@
 "watch.cards.empty.accessibility" = "Nessuna carta. Aggiungi carte sul tuo iPhone, si sincronizzano qui automaticamente.";
 "watch.cards.fallback_name" = "Carta";
 "watch.cards.unavailable" = "Carta non disponibile";
+"watch.sort.title" = "Ordina";
+"watch.sort.frequent" = "Piu usate";
+"watch.sort.recent" = "Aggiunte di recente";
+"watch.sort.az" = "A-Z";
 "watch.card_row.accessibility_format" = "Carta, %@";
 "watch.card_row.favorite_accessibility_format" = "Carta preferita, %@";
 "watch.debug.import_sample_cards" = "Importa carte di esempio";

--- a/watch-ios/Tests/CardStoreTests.swift
+++ b/watch-ios/Tests/CardStoreTests.swift
@@ -7,6 +7,9 @@ final class CardStoreTests: XCTestCase {
   override func setUp() {
     super.setUp()
     UserDefaults.standard.removeObject(forKey: "watch.cards")
+    // Guard against a prior test's UITEST_CARDS env override leaking into UserDefaults-backed
+    // tests (setenv is process-global); every test starts from a clean slate regardless of order.
+    unsetenv("UITEST_CARDS")
   }
 
   private func makeISO8601Formatter() -> ISO8601DateFormatter {
@@ -447,23 +450,164 @@ final class CardStoreTests: XCTestCase {
     XCTAssertEqual(ordered, ["fav", "hiusage", "fresh", "stale", "midcreated", "oldest"])
   }
 
-  func test_readOnly_preventsCardModification() throws {
-    let store = CardStore()
-    let originalCards = [
+  // MARK: - Story 9.5: selectable watch sort (WatchSortMode)
+
+  func test_sorted_byFrequent_matchesSortedForDisplay() throws {
+    // `.frequent` must stay identical to the shared ordering the complication relies on.
+    let formatter = makeISO8601Formatter()
+    let created = try XCTUnwrap(formatter.date(from: "2026-01-01T00:00:00.000Z"))
+    let cards = [
       WatchCard(
-        id: "r1", name: "ReadOnly", brandId: nil, colorHex: "#1e90ff", barcodeValue: nil,
+        id: "a", name: "Beta", brandId: nil, colorHex: "#1", barcodeValue: "1",
+        barcodeFormat: "CODE128", usageCount: 2, lastUsedAt: nil, createdAt: created,
+        isFavorite: false),
+      WatchCard(
+        id: "b", name: "Alpha", brandId: nil, colorHex: "#2", barcodeValue: "2",
+        barcodeFormat: "CODE128", usageCount: 9, lastUsedAt: nil, createdAt: created,
+        isFavorite: false),
+      WatchCard(
+        id: "c", name: "Gamma", brandId: nil, colorHex: "#3", barcodeValue: "3",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: created,
+        isFavorite: true),
+    ]
+
+    XCTAssertEqual(
+      WatchCard.sorted(cards, by: .frequent).map(\.id),
+      WatchCard.sortedForDisplay(cards).map(\.id))
+  }
+
+  func test_sorted_byFrequent_usedCardOutranksNeverUsed_atSameUsageCount() throws {
+    // Mixed-nil lastUsedAt at equal usageCount: a card that has been used must outrank one
+    // that never has, regardless of createdAt — mirrors phone `sortByFrequent` (AC2).
+    let formatter = makeISO8601Formatter()
+    let jan = try XCTUnwrap(formatter.date(from: "2026-01-01T00:00:00.000Z"))
+    let jun = try XCTUnwrap(formatter.date(from: "2026-06-01T00:00:00.000Z"))
+    let cards = [
+      WatchCard(
+        id: "never-used", name: "B", brandId: nil, colorHex: "#1", barcodeValue: "1",
+        barcodeFormat: "CODE128", usageCount: 5, lastUsedAt: nil, createdAt: jun,
+        isFavorite: false),
+      WatchCard(
+        id: "was-used", name: "A", brandId: nil, colorHex: "#2", barcodeValue: "2",
+        barcodeFormat: "CODE128", usageCount: 5, lastUsedAt: jun, createdAt: jan,
+        isFavorite: false),
+    ]
+
+    XCTAssertEqual(WatchCard.sorted(cards, by: .frequent).map(\.id), ["was-used", "never-used"])
+  }
+
+  func test_sorted_byRecent_ordersByCreatedAtDescending_withoutFavouritePin() throws {
+    let formatter = makeISO8601Formatter()
+    let jan = try XCTUnwrap(formatter.date(from: "2026-01-01T00:00:00.000Z"))
+    let feb = try XCTUnwrap(formatter.date(from: "2026-02-01T00:00:00.000Z"))
+    let mar = try XCTUnwrap(formatter.date(from: "2026-03-01T00:00:00.000Z"))
+
+    // A high-usage favourite created earliest must NOT be pinned in `.recent` —
+    // recency is pure createdAt-descending chronology (matches phone `sortByRecent`).
+    let cards = [
+      WatchCard(
+        id: "old-fav", name: "OldFav", brandId: nil, colorHex: "#1", barcodeValue: "1",
+        barcodeFormat: "CODE128", usageCount: 99, lastUsedAt: nil, createdAt: jan,
+        isFavorite: true),
+      WatchCard(
+        id: "mid", name: "Mid", brandId: nil, colorHex: "#2", barcodeValue: "2",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: feb,
+        isFavorite: false),
+      WatchCard(
+        id: "new", name: "New", brandId: nil, colorHex: "#3", barcodeValue: "3",
+        barcodeFormat: "CODE128", usageCount: 0, lastUsedAt: nil, createdAt: mar,
+        isFavorite: false),
+    ]
+
+    XCTAssertEqual(WatchCard.sorted(cards, by: .recent).map(\.id), ["new", "mid", "old-fav"])
+  }
+
+  func test_sorted_byAZ_ordersByNameCaseInsensitive_withFavouritesFirst() throws {
+    let cards = [
+      WatchCard(
+        id: "banana", name: "banana", brandId: nil, colorHex: "#1", barcodeValue: "1",
+        barcodeFormat: "CODE128", isFavorite: false),
+      WatchCard(
+        id: "Apple", name: "Apple", brandId: nil, colorHex: "#2", barcodeValue: "2",
+        barcodeFormat: "CODE128", isFavorite: false),
+      WatchCard(
+        id: "cherry-fav", name: "cherry", brandId: nil, colorHex: "#3", barcodeValue: "3",
+        barcodeFormat: "CODE128", isFavorite: true),
+    ]
+
+    // Favourite "cherry" pins first; remaining names sort case-insensitively (Apple < banana).
+    XCTAssertEqual(WatchCard.sorted(cards, by: .az).map(\.id), ["cherry-fav", "Apple", "banana"])
+  }
+
+  func test_sorted_byAZ_isDiacriticInsensitive_mirroringPhone() throws {
+    // Phone uses localeCompare(sensitivity:'base'): accents do not change ordering.
+    // "Èlite" must sort as if "Elite" — between "Acme" (A) and "Zeta" (Z).
+    let cards = [
+      WatchCard(
+        id: "zeta", name: "Zeta", brandId: nil, colorHex: "#1", barcodeValue: "1",
+        barcodeFormat: "CODE128", isFavorite: false),
+      WatchCard(
+        id: "elite-accent", name: "Èlite", brandId: nil, colorHex: "#2", barcodeValue: "2",
+        barcodeFormat: "CODE128", isFavorite: false),
+      WatchCard(
+        id: "acme", name: "Acme", brandId: nil, colorHex: "#3", barcodeValue: "3",
+        barcodeFormat: "CODE128", isFavorite: false),
+    ]
+
+    XCTAssertEqual(WatchCard.sorted(cards, by: .az).map(\.id), ["acme", "elite-accent", "zeta"])
+  }
+
+  func test_watchSortMode_defaultIsAZ() {
+    // Fresh install with no saved preference → A-Z (AC3).
+    XCTAssertEqual(WatchSortMode.defaultMode, .az)
+  }
+
+  func test_watchSortMode_allCases_matchPickerRowOrder() {
+    // Declaration order is the picker row order (UX spec §5): Frequently used → Recently added → A-Z.
+    XCTAssertEqual(WatchSortMode.allCases, [.frequent, .recent, .az])
+  }
+
+  func test_watchSortMode_persistsRawValueThroughUserDefaults() throws {
+    // Mirrors how @AppStorage(WatchSortMode.storageKey) reads/writes the watch-local
+    // preference (AC4): absent → caller default; a stored rawValue round-trips back.
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: WatchSortMode.storageKey)
+    defer { defaults.removeObject(forKey: WatchSortMode.storageKey) }
+
+    XCTAssertNil(defaults.string(forKey: WatchSortMode.storageKey))
+
+    defaults.set(WatchSortMode.recent.rawValue, forKey: WatchSortMode.storageKey)
+    let restored = defaults.string(forKey: WatchSortMode.storageKey)
+      .flatMap(WatchSortMode.init(rawValue:))
+    XCTAssertEqual(restored, .recent)
+  }
+
+  func test_readOnly_localCardEdits_doNotPersistAcrossReload() throws {
+    // Apple Watch is read-only for card data (ADR-2026-06-09-001): the in-memory store is a
+    // display snapshot of phone-synced data. The store has no write-back path, so a local edit
+    // must not persist — a freshly loaded store still reflects only the synced snapshot.
+    let synced = [
+      WatchCard(
+        id: "r1", name: "Synced", brandId: nil, colorHex: "#1e90ff", barcodeValue: nil,
         barcodeFormat: nil)
     ]
-    store.cards = originalCards
-    // Simula un tentativo di modifica (che dovrebbe essere ignorato)
-    // In una vera app, la UI non espone azioni di modifica, ma qui simuliamo una chiamata diretta
-    // Proviamo a cambiare il nome della card
-    var modified = store.cards
-    modified[0] = WatchCard(
-      id: "r1", name: "MODIFIED", brandId: nil, colorHex: "#1e90ff", barcodeValue: nil,
-      barcodeFormat: nil)
-    // Non aggiorniamo store.cards: la logica read-only è a livello di UI e modello
-    // Verifica che la store rimanga invariata
-    XCTAssertEqual(store.cards[0].name, "ReadOnly")
+    UserDefaults.standard.set(try JSONEncoder().encode(synced), forKey: "watch.cards")
+    defer { UserDefaults.standard.removeObject(forKey: "watch.cards") }
+
+    let store = CardStore()
+    XCTAssertEqual(store.cards.map(\.name), ["Synced"])
+
+    // Simulate a local mutation attempt. The watch UI exposes no edit path; poking the in-memory
+    // array directly proves even that cannot leak into the persistent store.
+    store.cards = [
+      WatchCard(
+        id: "r1", name: "Edited locally", brandId: nil, colorHex: "#1e90ff", barcodeValue: nil,
+        barcodeFormat: nil)
+    ]
+
+    // A brand-new store re-reads persistence: the edit never wrote back, so the snapshot is
+    // unchanged. Were a card-data write-back path ever introduced, this assertion would fail.
+    let reloaded = CardStore()
+    XCTAssertEqual(reloaded.cards.map(\.name), ["Synced"])
   }
 }


### PR DESCRIPTION
## Summary

Adds a user-selectable sort control to the Apple Watch card list, porting the phone's three sort modes (**Frequently used / Recently added / A‑Z**). The watch keeps its **own** persisted preference (default **A‑Z**), independent of the phone.

- Toolbar button (`arrow.up.arrow.down`, top‑trailing) → `.sheet` with a Carbon‑styled `List` of 3 rows; the active row is double‑encoded (semibold tint label + `checkmark` + VoiceOver `selected`), never colour alone.
- `WatchCard.sorted(_:by:)` mirrors the phone's `useCardSort` semantics exactly; `.frequent` reuses the existing `sortedForDisplay` (shared with the complication) so they never drift.
- Preference persisted via `@AppStorage("watch.sortMode")` (watch‑local, default A‑Z), independent of the phone's `AsyncStorage` key.
- Watch **read‑only‑for‑card‑data** rule preserved — the sort preference is UI state; sync/complication code untouched.

## Acceptance criteria
- [x] **AC1** — toolbar button → picker offering Frequently used / Recently added / A‑Z
- [x] **AC2** — ordering matches the phone's `useCardSort` exactly (favourite‑pin rules incl.; A‑Z locale‑aware, case‑ & diacritic‑insensitive)
- [x] **AC3** — fresh install defaults to A‑Z
- [x] **AC4** — choice persists watch‑local, independent of the phone
- [x] **AC5** — list re‑orders immediately on picker close
- [x] **AC6** — current, non‑deprecated watchOS 10 APIs (verified against official Apple docs)

## Tests & checks
- `yarn watch:build` → **BUILD SUCCEEDED** (watchOS 26.5 SDK); `CardListView.swift` deprecation‑clean
- Watch contract jest (`watch-layout-contract.test.ts`): **11/11** (incl. 2 new Story 9.5 specs)
- **8 new Swift XCTests** (`watch-ios/Tests/CardStoreTests.swift`): 3 mode orderings, frequent mixed‑`nil` tier, A‑Z diacritics, default, `allCases` order, persistence round‑trip — orderings also validated via a standalone `swift` run
- `yarn lint` / `yarn typecheck` clean; full phone suite green (1469 tests) via pre‑push
- Note: watch Swift tests run in Xcode (the `watch` scheme has no `xcodebuild test` step); the CI‑enforced layer is the TS contract tests

## Review
- Dev code review (fresh‑context, Sonnet): 2 rounds → **approved, 0 comments** (fixed frequent mixed‑`nil` parity + A‑Z diacritics)
- QA (Sonnet): 2 rounds → **PASS, 0 comments**
- Read‑only test re‑review (Sonnet): **approved, 0 comments**

## Also included (transparency — small, in touched files)
- Fixed a pre‑existing `onChange(of:perform:)` deprecation in `CardListView.swift`
- Gated the `#if DEBUG` sample‑card seeder to the empty state (it crowded the new sort button in dev builds; not shipped)
- Replaced a vacuous watch read‑only unit test with a real persistence‑invariant guard + hardened test isolation

## Story
[`docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md`](docs/sprint-artifacts/stories/9-5-selectable-watch-sort.md)