### PR TITLE
feat(watch): count watch card opens toward shared usage (Story 9.6)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,11 +11,14 @@ import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 
 import { getOrCreateGuestSessionId } from '@/core/auth/guest-session-repository';
 import { initializeDatabase } from '@/core/database';
-import { getAllCards } from '@/core/database/card-repository';
+import { applyWatchUsageEvents, getAllCards } from '@/core/database/card-repository';
 import {
+  parseWatchUsageEvent,
   pushCardsToWatch,
   subscribeToWatchMessages,
-  WatchMessage
+  subscribeToWatchUserInfo,
+  WatchMessage,
+  WatchUsageEvent
 } from '@/core/watch-connectivity';
 
 import { getSupabaseClient } from '@/shared/supabase/client';
@@ -311,6 +314,7 @@ const RootLayout = () => {
     };
 
     let unsubscribe: (() => void) | undefined;
+    let unsubscribeUserInfo: (() => void) | undefined;
 
     initializeApp().then(() => {
       // Push an initial snapshot so the watch converges on launch, even if no
@@ -334,9 +338,31 @@ const RootLayout = () => {
       } catch {
         // ignore if native module missing
       }
+
+      try {
+        // Watch CARD_USED usage events (Story 9.6, ADR-2026-06-09-001).
+        // Subscribed after initializeApp so the DB is ready even for the
+        // batch of events the OS queued while the app wasn't running.
+        // applyWatchUsageEvents dedups and re-syncs the snapshot itself.
+        unsubscribeUserInfo = subscribeToWatchUserInfo(async (events) => {
+          try {
+            const usageEvents = events
+              .map(parseWatchUsageEvent)
+              .filter((event): event is WatchUsageEvent => event !== null);
+            if (usageEvents.length > 0) {
+              await applyWatchUsageEvents(usageEvents);
+            }
+          } catch (e) {
+            console.warn('Watch usage event handler error:', e);
+          }
+        });
+      } catch {
+        // ignore if native module missing
+      }
     });
     return () => {
       if (typeof unsubscribe === 'function') unsubscribe();
+      if (typeof unsubscribeUserInfo === 'function') unsubscribeUserInfo();
     };
   }, []);
 

--- a/core/database/card-repository.integration.test.ts
+++ b/core/database/card-repository.integration.test.ts
@@ -13,7 +13,13 @@
 import Database from 'better-sqlite3';
 import { SQLiteDatabase } from 'expo-sqlite';
 
-import { getCardById, incrementUsageCount, insertCard, toggleFavorite } from './card-repository';
+import {
+  applyWatchUsageEvents,
+  getCardById,
+  incrementUsageCount,
+  insertCard,
+  toggleFavorite
+} from './card-repository';
 import { runMigrations } from './migrations';
 import { LoyaltyCard } from '../schemas';
 
@@ -21,6 +27,11 @@ import { LoyaltyCard } from '../schemas';
 jest.mock('../watch-connectivity', () => ({
   pushCardsToWatch: jest.fn().mockResolvedValue(undefined)
 }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { pushCardsToWatch } = require('../watch-connectivity') as {
+  pushCardsToWatch: jest.Mock;
+};
 
 /**
  * Adapt a synchronous better-sqlite3 instance to the async expo-sqlite
@@ -150,5 +161,169 @@ describe('card-repository integration (real SQLite)', () => {
     const card = await getCardById('c1', db);
     expect(card?.isFavorite).toBe(true);
     expect(card?.updatedAt).toBe('2020-01-01T00:00:00.000Z'); // unchanged
+  });
+
+  // Story 9.6 (ADR-2026-06-09-001): watch CARD_USED events applied on the phone.
+  // These run the REAL SQL — the CASE-WHEN max() logic, INSERT OR IGNORE dedup,
+  // and pruning are exactly what AC2/AC3 hinge on.
+  describe('applyWatchUsageEvents', () => {
+    const event = (id: string, usedAt: string) => ({ id, usedAt });
+
+    test('increments usageCount and stamps lastUsedAt from the event time (AC1)', async () => {
+      await insertCard(
+        makeCard({
+          id: 'c1',
+          usageCount: 0,
+          lastUsedAt: null,
+          updatedAt: '2020-01-01T00:00:00.000Z'
+        }),
+        db
+      );
+
+      const applied = await applyWatchUsageEvents([event('c1', '2026-06-09T10:00:00.123Z')], db);
+
+      expect(applied).toBe(1);
+      const card = await getCardById('c1', db);
+      expect(card?.usageCount).toBe(1);
+      expect(card?.lastUsedAt).toBe('2026-06-09T10:00:00.123Z'); // event time, not apply time
+      expect(card?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(card?.updatedAt).not.toBe('2020-01-01T00:00:00.000Z'); // delta sync pickup
+    });
+
+    test('is commutative — applying events in any order converges (AC2)', async () => {
+      const e1 = event('c1', '2026-06-09T10:00:00.000Z');
+      const e2 = event('c1', '2026-06-09T11:30:00.500Z');
+
+      const forward = makeRealDb();
+      const reverse = makeRealDb();
+      try {
+        for (const { db: target } of [forward, reverse]) {
+          await runMigrations(target);
+          await insertCard(makeCard({ id: 'c1', usageCount: 0, lastUsedAt: null }), target);
+        }
+
+        await applyWatchUsageEvents([e1], forward.db);
+        await applyWatchUsageEvents([e2], forward.db);
+
+        await applyWatchUsageEvents([e2], reverse.db);
+        await applyWatchUsageEvents([e1], reverse.db);
+
+        const forwardCard = await getCardById('c1', forward.db);
+        const reverseCard = await getCardById('c1', reverse.db);
+        expect(forwardCard?.usageCount).toBe(2);
+        expect(reverseCard?.usageCount).toBe(2);
+        expect(forwardCard?.lastUsedAt).toBe('2026-06-09T11:30:00.500Z'); // max wins
+        expect(reverseCard?.lastUsedAt).toBe('2026-06-09T11:30:00.500Z');
+      } finally {
+        forward.close();
+        reverse.close();
+      }
+    });
+
+    test('keeps lastUsedAt monotonic when an older event arrives late (AC2)', async () => {
+      await insertCard(
+        makeCard({ id: 'c1', usageCount: 5, lastUsedAt: '2026-06-09T12:00:00.000Z' }),
+        db
+      );
+
+      const applied = await applyWatchUsageEvents([event('c1', '2026-06-09T08:00:00.000Z')], db);
+
+      expect(applied).toBe(1);
+      const card = await getCardById('c1', db);
+      expect(card?.usageCount).toBe(6); // the open still counts…
+      expect(card?.lastUsedAt).toBe('2026-06-09T12:00:00.000Z'); // …but max() keeps the newer stamp
+    });
+
+    test('never double-counts a redelivered event — dedup across batches (AC3)', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      const e1 = event('c1', '2026-06-09T10:00:00.123Z');
+
+      expect(await applyWatchUsageEvents([e1], db)).toBe(1);
+      expect(await applyWatchUsageEvents([e1], db)).toBe(0); // retransmit after relaunch
+      expect(await applyWatchUsageEvents([e1, e1], db)).toBe(0);
+
+      expect((await getCardById('c1', db))?.usageCount).toBe(1);
+    });
+
+    test('dedups duplicates inside a single delivered batch (AC3)', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      const e1 = event('c1', '2026-06-09T10:00:00.123Z');
+
+      const applied = await applyWatchUsageEvents([e1, e1, e1], db);
+
+      expect(applied).toBe(1);
+      expect((await getCardById('c1', db))?.usageCount).toBe(1);
+    });
+
+    test('two distinct opens of the same card both count — ms precision keeps ids distinct (AC1, AC3)', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+
+      const applied = await applyWatchUsageEvents(
+        [event('c1', '2026-06-09T10:00:00.123Z'), event('c1', '2026-06-09T10:00:00.456Z')],
+        db
+      );
+
+      expect(applied).toBe(2);
+      expect((await getCardById('c1', db))?.usageCount).toBe(2);
+    });
+
+    test('an event for a deleted/unknown card is recorded but mutates nothing', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      const ghost = event('ghost', '2026-06-09T10:00:00.123Z');
+
+      expect(await applyWatchUsageEvents([ghost], db)).toBe(0);
+      expect(await applyWatchUsageEvents([ghost], db)).toBe(0); // still deduped on retransmit
+
+      expect((await getCardById('c1', db))?.usageCount).toBe(0);
+    });
+
+    test('prunes dedup rows older than the retention window', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      await db.runAsync('INSERT INTO watch_usage_events (event_id, applied_at) VALUES (?, ?)', [
+        'ancient:2020-01-01T00:00:00.000Z',
+        '2020-01-01T00:00:00.000Z'
+      ]);
+
+      await applyWatchUsageEvents([event('c1', '2026-06-09T10:00:00.123Z')], db);
+
+      const remaining = await db.getAllAsync<{ event_id: string }>(
+        'SELECT event_id FROM watch_usage_events'
+      );
+      const ids = remaining.map((row) => row.event_id);
+      expect(ids).not.toContain('ancient:2020-01-01T00:00:00.000Z'); // pruned
+      expect(ids).toContain('c1:2026-06-09T10:00:00.123Z'); // fresh row kept
+    });
+
+    test('re-syncs the snapshot to the watch once per batch with applied events (AC5)', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      pushCardsToWatch.mockClear();
+
+      await applyWatchUsageEvents(
+        [event('c1', '2026-06-09T10:00:00.123Z'), event('c1', '2026-06-09T10:00:01.456Z')],
+        db
+      );
+
+      expect(pushCardsToWatch).toHaveBeenCalledTimes(1); // batched, not per-event
+      const pushedCards = pushCardsToWatch.mock.calls[0]![0];
+      expect(pushedCards).toHaveLength(1);
+      expect(pushedCards[0].usageCount).toBe(2); // snapshot reflects the applied usage
+    });
+
+    test('does not re-sync when every event was a duplicate or unknown', async () => {
+      await insertCard(makeCard({ id: 'c1', usageCount: 0 }), db);
+      const e1 = event('c1', '2026-06-09T10:00:00.123Z');
+      await applyWatchUsageEvents([e1], db);
+      pushCardsToWatch.mockClear();
+
+      await applyWatchUsageEvents([e1, event('ghost', '2026-06-09T11:00:00.000Z')], db);
+
+      expect(pushCardsToWatch).not.toHaveBeenCalled();
+    });
+
+    test('empty batch is a no-op', async () => {
+      pushCardsToWatch.mockClear();
+      expect(await applyWatchUsageEvents([], db)).toBe(0);
+      expect(pushCardsToWatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/core/database/card-repository.test.ts
+++ b/core/database/card-repository.test.ts
@@ -1,6 +1,7 @@
 import { SQLiteDatabase } from 'expo-sqlite';
 
 import {
+  applyWatchUsageEvents,
   getAllCards,
   getCardById,
   insertCard,
@@ -350,5 +351,107 @@ describe('card-repository', () => {
       card.createdAt,
       card.updatedAt
     ]);
+  });
+
+  describe('applyWatchUsageEvents (Story 9.6)', () => {
+    /**
+     * Changes-aware mock: the production code branches on
+     * `runAsync(...).changes` (0 = duplicate event / unknown card), which the
+     * shared makeDb mock (resolves undefined) cannot express.
+     */
+    const makeUsageDb = (changesByCall: number[] = []) => {
+      let call = 0;
+      return {
+        getAllAsync: jest.fn().mockResolvedValue([]),
+        getFirstAsync: jest.fn().mockResolvedValue(null),
+        runAsync: jest.fn().mockImplementation(async () => ({
+          changes: changesByCall[call++] ?? 1,
+          lastInsertRowId: 0
+        })),
+        withTransactionAsync: jest.fn(
+          async (fn: (...args: unknown[]) => Promise<unknown>) => await fn()
+        )
+      } as unknown as SQLiteDatabase;
+    };
+
+    const event = { id: 'c1', usedAt: '2026-06-09T10:00:00.123Z' };
+
+    test('wraps the batch in a transaction (project DB-write rule)', async () => {
+      const db = makeUsageDb();
+      await applyWatchUsageEvents([event], db);
+      expect(db.withTransactionAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('records the event id then applies the commutative update (AC1, AC2)', async () => {
+      const db = makeUsageDb();
+      await applyWatchUsageEvents([event], db);
+
+      const calls = (db.runAsync as jest.Mock).mock.calls;
+      // 1: dedup insert, 2: card update, 3: prune
+      expect(calls).toHaveLength(3);
+
+      const [insertSql, insertParams] = calls[0];
+      expect(insertSql).toContain('INSERT OR IGNORE INTO watch_usage_events');
+      expect(insertParams[0]).toBe('c1:2026-06-09T10:00:00.123Z'); // "<cardId>:<usedAt>"
+
+      const [updateSql, updateParams] = calls[1];
+      expect(updateSql).toContain('usage_count = usage_count + 1');
+      expect(updateSql).toContain('CASE');
+      expect(updateSql).toContain('last_used_at < ?');
+      expect(updateSql).toContain('updated_at = ?');
+      expect(updateParams).toEqual([
+        event.usedAt,
+        event.usedAt,
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+        'c1'
+      ]);
+
+      const [pruneSql] = calls[2];
+      expect(pruneSql).toContain('DELETE FROM watch_usage_events');
+    });
+
+    test('skips the card update when the event id was already seen (AC3)', async () => {
+      const db = makeUsageDb([0]); // dedup insert reports a conflict
+      const applied = await applyWatchUsageEvents([event], db);
+
+      expect(applied).toBe(0);
+      const sqls = (db.runAsync as jest.Mock).mock.calls.map(([sql]) => sql as string);
+      expect(sqls.some((sql) => sql.includes('usage_count'))).toBe(false);
+    });
+
+    test('pushes one snapshot per batch with applied events (AC5)', async () => {
+      const db = makeUsageDb();
+      await applyWatchUsageEvents([event, { id: 'c2', usedAt: '2026-06-09T11:00:00.456Z' }], db);
+      // pushSnapshotToWatch reads all cards exactly once for the whole batch
+      expect(db.getAllAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not push a snapshot when nothing was applied', async () => {
+      const db = makeUsageDb([0]);
+      await applyWatchUsageEvents([event], db);
+      expect(db.getAllAsync).not.toHaveBeenCalled();
+    });
+
+    test('returns 0 and runs no SQL for an empty batch', async () => {
+      const db = makeUsageDb();
+      expect(await applyWatchUsageEvents([], db)).toBe(0);
+      expect(db.runAsync).not.toHaveBeenCalled();
+      expect(db.withTransactionAsync).not.toHaveBeenCalled();
+    });
+
+    test('counts only events that mutated a card row (unknown card → 0)', async () => {
+      // insert succeeds (new event id) but the UPDATE matches no row
+      const db = makeUsageDb([1, 0, 1]);
+      const applied = await applyWatchUsageEvents([{ id: 'ghost', usedAt: event.usedAt }], db);
+      expect(applied).toBe(0);
+    });
+
+    test('uses default getDatabase when no db supplied', async () => {
+      const db = makeUsageDb();
+      const spy = jest.spyOn(databaseModule, 'getDatabase').mockReturnValue(db);
+      await applyWatchUsageEvents([event]);
+      expect(spy).toHaveBeenCalled();
+      expect(db.runAsync).toHaveBeenCalled();
+    });
   });
 });

--- a/core/database/card-repository.ts
+++ b/core/database/card-repository.ts
@@ -9,7 +9,7 @@
 import { SQLiteDatabase } from 'expo-sqlite';
 
 import { LoyaltyCard, BarcodeFormat, CardColor } from '../schemas';
-import { pushCardsToWatch } from '../watch-connectivity';
+import { pushCardsToWatch, type WatchUsageEvent } from '../watch-connectivity';
 import { getDatabase } from './database';
 
 async function pushSnapshotToWatch(db: SQLiteDatabase): Promise<void> {
@@ -288,6 +288,79 @@ export async function toggleFavorite(
     [now, id]
   );
   await pushSnapshotToWatch(db);
+}
+
+/**
+ * How long applied watch-usage event ids are retained for dedup. Retransmits
+ * arrive promptly after the next app launch (the library re-delivers its
+ * native queue on subscribe), so 30 days is generous headroom while keeping
+ * the ledger bounded per ADR-2026-06-09-001.
+ */
+const WATCH_USAGE_EVENT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Apply a batch of watch CARD_USED events (Story 9.6, ADR-2026-06-09-001).
+ *
+ * Delivery is at-least-once (`transferUserInfo` retransmits after relaunch),
+ * so each event id `"<cardId>:<usedAt>"` is applied exactly once: the
+ * INSERT OR IGNORE into the persisted `watch_usage_events` ledger decides
+ * first sight, and only then does the card row change. Reconciliation is
+ * conflict-free by construction — `usage_count += 1` is commutative and
+ * `last_used_at` takes max(current, usedAt), comparing ms-precision ISO-8601
+ * UTC strings (lexicographic order == chronological order). `updated_at` is
+ * bumped so delta sync propagates the change to the cloud, as in
+ * `incrementUsageCount` (Story 9.1) — with one deliberate difference: the
+ * phone path stamps `last_used_at = now`, while watch events take
+ * `max(current, usedAt)` so late or out-of-order delivery stays idempotent.
+ *
+ * Pushes ONE refreshed snapshot to the watch when anything changed (AC5).
+ * Returns the number of events that mutated a card row.
+ */
+export async function applyWatchUsageEvents(
+  events: WatchUsageEvent[],
+  db: SQLiteDatabase = getDatabase()
+): Promise<number> {
+  if (events.length === 0) return 0;
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const pruneBefore = new Date(now.getTime() - WATCH_USAGE_EVENT_RETENTION_MS).toISOString();
+  let appliedCount = 0;
+
+  await db.withTransactionAsync(async () => {
+    for (const event of events) {
+      const eventId = `${event.id}:${event.usedAt}`;
+      const inserted = await db.runAsync(
+        'INSERT OR IGNORE INTO watch_usage_events (event_id, applied_at) VALUES (?, ?)',
+        [eventId, nowIso]
+      );
+      if ((inserted?.changes ?? 0) === 0) {
+        continue; // already applied — duplicate/retransmit (AC3)
+      }
+
+      const updated = await db.runAsync(
+        `UPDATE loyalty_cards
+          SET usage_count = usage_count + 1,
+              last_used_at = CASE
+                WHEN last_used_at IS NULL OR last_used_at < ? THEN ?
+                ELSE last_used_at
+              END,
+              updated_at = ?
+          WHERE id = ?`,
+        [event.usedAt, event.usedAt, nowIso, event.id]
+      );
+      if ((updated?.changes ?? 0) > 0) {
+        appliedCount += 1;
+      }
+    }
+
+    await db.runAsync('DELETE FROM watch_usage_events WHERE applied_at < ?', [pruneBefore]);
+  });
+
+  if (appliedCount > 0) {
+    await pushSnapshotToWatch(db);
+  }
+  return appliedCount;
 }
 
 /**

--- a/core/database/index.ts
+++ b/core/database/index.ts
@@ -23,5 +23,6 @@ export {
   deleteAllCards,
   getCardCount,
   incrementUsageCount,
-  toggleFavorite
+  toggleFavorite,
+  applyWatchUsageEvents
 } from './card-repository';

--- a/core/database/migrations.test.ts
+++ b/core/database/migrations.test.ts
@@ -53,4 +53,29 @@ describe('migrations', () => {
     // Should set DB version at the end
     expect(db.execAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${DB_VERSION}`);
   });
+
+  // Story 9.6: watch_usage_events dedup table (migration v2)
+
+  test('DB_VERSION is 2', () => {
+    expect(DB_VERSION).toBe(2);
+  });
+
+  test('fresh install (version 0) creates the watch_usage_events table', async () => {
+    const db = makeDb(0);
+    await migrations.runMigrations(db as unknown as SQLiteDatabase);
+    const createdDedupTable = db.execAsync.mock.calls.some(
+      (c) => typeof c[0] === 'string' && c[0].includes('watch_usage_events')
+    );
+    expect(createdDedupTable).toBe(true);
+  });
+
+  test('upgrade from v1 creates the watch_usage_events table and bumps version', async () => {
+    const db = makeDb(1);
+    await migrations.runMigrations(db as unknown as SQLiteDatabase);
+    const createdDedupTable = db.execAsync.mock.calls.some(
+      (c) => typeof c[0] === 'string' && c[0].includes('watch_usage_events')
+    );
+    expect(createdDedupTable).toBe(true);
+    expect(db.execAsync).toHaveBeenCalledWith('PRAGMA user_version = 2');
+  });
 });

--- a/core/database/migrations.ts
+++ b/core/database/migrations.ts
@@ -12,7 +12,7 @@ import { SQLiteDatabase } from 'expo-sqlite';
  * Current database version
  * Increment this when adding new migrations
  */
-export const DB_VERSION = 1;
+export const DB_VERSION = 2;
 
 /**
  * Database name
@@ -24,19 +24,14 @@ export const DB_NAME = 'myloyaltycards.db';
  * Returns 0 if not set (fresh install)
  */
 export async function getDbVersion(db: SQLiteDatabase): Promise<number> {
-  const result = await db.getFirstAsync<{ user_version: number }>(
-    'PRAGMA user_version'
-  );
+  const result = await db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
   return result?.user_version ?? 0;
 }
 
 /**
  * Set the database version using user_version pragma
  */
-export async function setDbVersion(
-  db: SQLiteDatabase,
-  version: number
-): Promise<void> {
+export async function setDbVersion(db: SQLiteDatabase, version: number): Promise<void> {
   await db.execAsync(`PRAGMA user_version = ${version}`);
 }
 
@@ -60,12 +55,32 @@ async function createCurrentSchema(db: SQLiteDatabase): Promise<void> {
       updated_at TEXT NOT NULL
     );
     
-    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_created_at 
+    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_created_at
       ON loyalty_cards(created_at);
-    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_usage 
+    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_usage
       ON loyalty_cards(usage_count, last_used_at);
-    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_favorite 
+    CREATE INDEX IF NOT EXISTS idx_loyalty_cards_favorite
       ON loyalty_cards(is_favorite);
+  `);
+  await createWatchUsageEventsTable(db);
+}
+
+/**
+ * Dedup ledger for watch CARD_USED usage events (Story 9.6,
+ * ADR-2026-06-09-001). Each applied event id ("<cardId>:<usedAt>") is
+ * recorded so an at-least-once retransmit — including one delivered after an
+ * app relaunch — can never double-count. Rows are pruned by applied_at to
+ * keep the window bounded.
+ */
+async function createWatchUsageEventsTable(db: SQLiteDatabase): Promise<void> {
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS watch_usage_events (
+      event_id TEXT PRIMARY KEY NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_watch_usage_events_applied_at
+      ON watch_usage_events(applied_at);
   `);
 }
 
@@ -75,6 +90,14 @@ async function createCurrentSchema(db: SQLiteDatabase): Promise<void> {
  */
 async function migrateV0toV1(db: SQLiteDatabase): Promise<void> {
   await createCurrentSchema(db);
+}
+
+/**
+ * Migration from version 1 to version 2
+ * Adds the watch_usage_events dedup table (Story 9.6)
+ */
+async function migrateV1toV2(db: SQLiteDatabase): Promise<void> {
+  await createWatchUsageEventsTable(db);
 }
 
 /**
@@ -96,9 +119,13 @@ export async function runMigrations(db: SQLiteDatabase): Promise<void> {
     await migrateV0toV1(db);
   }
 
+  if (currentVersion < 2) {
+    await migrateV1toV2(db);
+  }
+
   // Add future migrations here:
-  // if (currentVersion < 2) {
-  //   await migrateV1toV2(db);
+  // if (currentVersion < 3) {
+  //   await migrateV2toV3(db);
   // }
 
   await setDbVersion(db, DB_VERSION);

--- a/core/watch-connectivity.test.ts
+++ b/core/watch-connectivity.test.ts
@@ -665,4 +665,186 @@ describe('watch-connectivity wrapper', () => {
       });
     });
   });
+
+  // Story 9.6 (ADR-2026-06-09-001): inbound CARD_USED usage events
+  describe('parseWatchUsageEvent', () => {
+    const loadModule = () => {
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock('react-native-watch-connectivity', () => ({}), { virtual: true });
+        mod = require('./watch-connectivity');
+      });
+      return mod;
+    };
+
+    const validEvent = {
+      version: 1,
+      type: 'CARD_USED',
+      payload: { id: 'card-1', usedAt: '2026-06-09T12:34:56.789Z' }
+    };
+
+    test('accepts a conformant v1 CARD_USED event', () => {
+      const mod = loadModule();
+      expect(mod.parseWatchUsageEvent(validEvent)).toEqual({
+        id: 'card-1',
+        usedAt: '2026-06-09T12:34:56.789Z'
+      });
+    });
+
+    test('rejects unknown message types', () => {
+      const mod = loadModule();
+      expect(mod.parseWatchUsageEvent({ ...validEvent, type: 'CARD_DELETED' })).toBeNull();
+      expect(mod.parseWatchUsageEvent({ ...validEvent, type: 'requestCards' })).toBeNull();
+    });
+
+    test('rejects unknown versions (graceful forward-compat)', () => {
+      const mod = loadModule();
+      expect(mod.parseWatchUsageEvent({ ...validEvent, version: 2 })).toBeNull();
+      expect(mod.parseWatchUsageEvent({ ...validEvent, version: undefined })).toBeNull();
+    });
+
+    test('rejects missing or empty card id', () => {
+      const mod = loadModule();
+      expect(
+        mod.parseWatchUsageEvent({ ...validEvent, payload: { usedAt: validEvent.payload.usedAt } })
+      ).toBeNull();
+      expect(
+        mod.parseWatchUsageEvent({
+          ...validEvent,
+          payload: { id: '', usedAt: validEvent.payload.usedAt }
+        })
+      ).toBeNull();
+    });
+
+    test('rejects second-precision usedAt (ADR requires milliseconds)', () => {
+      const mod = loadModule();
+      expect(
+        mod.parseWatchUsageEvent({
+          ...validEvent,
+          payload: { id: 'card-1', usedAt: '2026-06-09T12:34:56Z' }
+        })
+      ).toBeNull();
+    });
+
+    test('rejects non-UTC offsets and non-date strings', () => {
+      const mod = loadModule();
+      expect(
+        mod.parseWatchUsageEvent({
+          ...validEvent,
+          payload: { id: 'card-1', usedAt: '2026-06-09T12:34:56.789+02:00' }
+        })
+      ).toBeNull();
+      expect(
+        mod.parseWatchUsageEvent({
+          ...validEvent,
+          payload: { id: 'card-1', usedAt: 'not-a-date' }
+        })
+      ).toBeNull();
+    });
+
+    test('rejects calendar-impossible timestamps that pass the shape regex', () => {
+      const mod = loadModule();
+      expect(
+        mod.parseWatchUsageEvent({
+          ...validEvent,
+          payload: { id: 'card-1', usedAt: '2026-13-45T99:99:99.999Z' }
+        })
+      ).toBeNull();
+    });
+
+    test('rejects non-object payloads', () => {
+      const mod = loadModule();
+      expect(mod.parseWatchUsageEvent(null)).toBeNull();
+      expect(mod.parseWatchUsageEvent(undefined)).toBeNull();
+      expect(mod.parseWatchUsageEvent('CARD_USED')).toBeNull();
+      expect(mod.parseWatchUsageEvent(42)).toBeNull();
+    });
+  });
+
+  describe('subscribeToWatchUserInfo', () => {
+    test('returns a noop unsubscribe when the native module is missing', () => {
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock('react-native-watch-connectivity', () => {
+          throw new Error('native module unavailable');
+        });
+        mod = require('./watch-connectivity');
+      });
+      const handler = jest.fn();
+      const off = mod.subscribeToWatchUserInfo(handler);
+      expect(typeof off).toBe('function');
+      expect(() => off()).not.toThrow();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test('delivers user-info batches to the handler', () => {
+      const events = makeEvents();
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock('react-native-watch-connectivity', () => ({ watchEvents: events }), {
+          virtual: true
+        });
+        mod = require('./watch-connectivity');
+      });
+
+      const handler = jest.fn();
+      mod.subscribeToWatchUserInfo(handler);
+
+      const batch = [
+        {
+          version: 1,
+          type: 'CARD_USED',
+          payload: { id: 'c1', usedAt: '2026-06-09T10:00:00.000Z' }
+        },
+        { version: 1, type: 'CARD_USED', payload: { id: 'c2', usedAt: '2026-06-09T10:00:01.000Z' } }
+      ];
+      events.emit('user-info', batch);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(batch);
+    });
+
+    test('wraps a single (non-array) user-info payload into a batch', () => {
+      const events = makeEvents();
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock('react-native-watch-connectivity', () => ({ watchEvents: events }), {
+          virtual: true
+        });
+        mod = require('./watch-connectivity');
+      });
+
+      const handler = jest.fn();
+      mod.subscribeToWatchUserInfo(handler);
+
+      const single = {
+        version: 1,
+        type: 'CARD_USED',
+        payload: { id: 'c1', usedAt: '2026-06-09T10:00:00.000Z' }
+      };
+      events.emit('user-info', single);
+
+      expect(handler).toHaveBeenCalledWith([single]);
+    });
+
+    test('unsubscribe detaches the user-info listener', () => {
+      const events = makeEvents();
+      let mod: any = null;
+      jest.isolateModules(() => {
+        jest.doMock('react-native-watch-connectivity', () => ({ watchEvents: events }), {
+          virtual: true
+        });
+        mod = require('./watch-connectivity');
+      });
+
+      const handler = jest.fn();
+      const off = mod.subscribeToWatchUserInfo(handler);
+      off();
+
+      events.emit('user-info', [
+        { version: 1, type: 'CARD_USED', payload: { id: 'c1', usedAt: '2026-06-09T10:00:00.000Z' } }
+      ]);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/core/watch-connectivity.ts
+++ b/core/watch-connectivity.ts
@@ -28,6 +28,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 
 import { toDataURL, type RenderOptions } from '@bwip-js/react-native';
+import * as z from 'zod';
 
 import type { LoyaltyCard } from './schemas';
 
@@ -101,7 +102,49 @@ export type WatchMessage =
   | { type: 'cards'; payload: WatchCardPayload[] }
   | { type: 'syncCard'; payload: { id: string; cardData: any } }
   | { type: 'ack'; payload?: { id?: string } }
+  | { version: 1; type: 'CARD_USED'; payload: { id: string; usedAt: string } }
   | { type: string; payload?: any };
+
+// ---------------------------------------------------------------------------
+// CARD_USED usage events (Story 9.6, ADR-2026-06-09-001)
+// ---------------------------------------------------------------------------
+
+/**
+ * `usedAt` must be ISO-8601 UTC at millisecond precision: the dedup event id
+ * is `"<cardId>:<usedAt>"`, so sub-second resolution is what guarantees two
+ * genuinely-distinct opens of the same card cannot collapse into one id.
+ * Second-resolution timestamps are non-conformant per the ADR.
+ */
+const MS_PRECISION_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const watchUsageEventMessageSchema = z.object({
+  version: z.literal(1),
+  type: z.literal('CARD_USED'),
+  payload: z.object({
+    id: z.string().min(1),
+    usedAt: z
+      .string()
+      .regex(MS_PRECISION_UTC_TIMESTAMP)
+      .refine((value) => !Number.isNaN(Date.parse(value)))
+  })
+});
+
+export interface WatchUsageEvent {
+  id: string;
+  usedAt: string;
+}
+
+/**
+ * Validate a raw watch → phone user-info item as a v1 CARD_USED event.
+ * Anything non-conformant (unknown type, unknown version, malformed or
+ * second-precision timestamp) returns `null` — unknown messages are ignored
+ * gracefully rather than half-applied, and no card-data mutation can ever be
+ * smuggled through this channel.
+ */
+export function parseWatchUsageEvent(raw: unknown): WatchUsageEvent | null {
+  const result = watchUsageEventMessageSchema.safeParse(raw);
+  return result.success ? result.data.payload : null;
+}
 
 /**
  * Shape sent over the wire to the watch. Field names match the watch-side
@@ -490,6 +533,25 @@ export function subscribeToWatchMessages(handler: (msg: WatchMessage) => void): 
   };
 }
 
+/**
+ * Subscribe to `user-info` deliveries from the watch — the transport that
+ * carries CARD_USED usage events (Story 9.6). `transferUserInfo` payloads are
+ * OS-queued on the watch, so the library delivers them as a *batch* array on
+ * subscription (including events received before the RN app initialised) and
+ * as single-item arrays afterwards. The handler always receives an array;
+ * each item must still be validated via `parseWatchUsageEvent`.
+ */
+export function subscribeToWatchUserInfo(handler: (events: unknown[]) => void): Unsubscribe {
+  const native = getNativeModule();
+  if (!native) return () => {};
+  ensureDiagnostics(native);
+
+  const off = subscribe(native, 'user-info', (payload) => {
+    handler(Array.isArray(payload) ? payload : [payload]);
+  });
+  return off ?? (() => {});
+}
+
 export function requestCardsFromPhone(): Promise<boolean> {
   return sendMessageToWatch({ type: 'requestCards' });
 }
@@ -573,6 +635,8 @@ export default {
   isWatchConnectivityAvailable,
   sendMessageToWatch,
   subscribeToWatchMessages,
+  subscribeToWatchUserInfo,
+  parseWatchUsageEvent,
   requestCardsFromPhone,
   syncCardToWatch,
   pushCardsToWatch,

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -266,7 +266,7 @@ development_status:
   9-4-sync-sorting-to-watch: done # C3 favourite-badge implemented; code review + QA approved (2026-06-09); story.md at "review" — awaiting stakeholder approval to commit/PR
   9-5-selectable-watch-sort: done # 2026-06-10: impl complete on feature/9-5-selectable-watch-sort; dev-subagent code review (2 rounds → 0 comments) + QA (sonnet) approved. story.md at "review" — awaiting stakeholder approval to commit/PR.
   9-6a-watch-usage-event-adr: done # 2026-06-09: ADR-2026-06-09-001 RATIFIED → Accepted (Architect); 7 read-only refs refined + CARD_USED documented. Story .md at "review" (auto-flips to done on merge). Unblocked 9-6.
-  9-6-count-watch-card-opens: ready-for-dev # 2026-06-09: gates cleared — ADR-2026-06-09-001 Accepted + PM scope confirmed. Implement CARD_USED per ADR (transferUserInfo; ms-precision usedAt; dedup "<id>:<usedAt>"). Relates PRD FR76.
+  9-6-count-watch-card-opens: review # 2026-06-10: impl complete on feature/9-6-count-watch-card-opens — CARD_USED per ADR-2026-06-09-001. Code review (opus) + QA (opus) both APPROVED 0 findings round 1. All gates green (1503 tests, coverage ≥80%, watch build OK). Awaiting stakeholder approval to commit/PR. ⚠️ transferUserInfo needs physical-pair validation.
   epic-9-retrospective: optional
 
   # Epic 10: Wear OS App

--- a/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
+++ b/docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md
@@ -1,6 +1,6 @@
 # Story 9.6: Count Card Opens on the Watch
 
-Status: ready-for-dev
+Status: review
 
 > Drafted 2026-06-09 via `correct-course` (`sprint-artifacts/sprint-change-proposal-2026-06-09.md`).
 > ✅ **Gates cleared 2026-06-09 → `ready-for-dev`:** [ADR-2026-06-09-001](../../adr-2026-06-09-watch-usage-events.md) **Accepted** (Architect) + PM scope confirmed (ifero). Depends on Story 9.4 (done). Relates to PRD **FR76** (usage recorded on every display surface, incl. watch).
@@ -35,23 +35,23 @@ so that "most used / recently used" sorting is accurate on both the Watch and th
 
 ### Watch — emit usage events
 
-- [ ] Emit a `CARD_USED` event (per 9.6a ADR) when a card's barcode is displayed on the Watch (AC: 1)
-- [ ] Queue events when the phone is unreachable; flush on reachability; dedup/idempotency (AC: 3)
+- [x] Emit a `CARD_USED` event (per 9.6a ADR) when a card's barcode is displayed on the Watch (AC: 1)
+- [x] Queue events when the phone is unreachable; flush on reachability; dedup/idempotency (AC: 3)
 
 ### Phone — apply usage events
 
-- [ ] Handle inbound `CARD_USED` in `core/watch-connectivity.ts`; apply commutative increment + `lastUsedAt = max` via the Story 9.1 usage path (AC: 1, 2)
-- [ ] Re-sync the updated snapshot to the Watch (AC: 5)
+- [x] Handle inbound `CARD_USED` in `core/watch-connectivity.ts`; apply commutative increment + `lastUsedAt = max` via the Story 9.1 usage path (AC: 1, 2)
+- [x] Re-sync the updated snapshot to the Watch (AC: 5)
 
 ### Docs / rules (per 9.6a ADR)
 
-- [ ] Apply the refined read-only wording across the 7 references (CONTRIBUTING, project_context ×2, architecture, epics ×3) + add `CARD_USED` to the documented message types
+- [x] Apply the refined read-only wording across the 7 references (CONTRIBUTING, project_context ×2, architecture, epics ×3) + add `CARD_USED` to the documented message types
 
 ### Tests
 
-- [ ] Phone: inbound `CARD_USED` increments correctly; commutative under duplicates/out-of-order (AC: 1, 2)
-- [ ] Watch: offline queue + flush, no double-count (AC: 3)
-- [ ] Watch stays read-only for card data — no mutation path added (AC: 4)
+- [x] Phone: inbound `CARD_USED` increments correctly; commutative under duplicates/out-of-order (AC: 1, 2)
+- [x] Watch: offline queue + flush, no double-count (AC: 3)
+- [x] Watch stays read-only for card data — no mutation path added (AC: 4)
 
 ## Dev Notes
 
@@ -76,14 +76,52 @@ so that "most used / recently used" sorting is accurate on both the Watch and th
 
 ### Agent Model Used
 
+claude-fable-5 (Amelia, BMAD dev agent)
+
+### Implementation Plan
+
+- **Watch (Swift):** `WatchSessionManager.recordCardUsed(cardId:)` builds `{version: 1, type: "CARD_USED", payload: {id, usedAt}}` with `usedAt` from a static `ISO8601DateFormatter` (`.withInternetDateTime, .withFractionalSeconds` → ms precision per ADR) and hands it to `WCSession.transferUserInfo` (current, non-deprecated; OS-level FIFO queue survives unreachability and relaunch → AC3 offline queue). Events created before `WCSession` activation completes are buffered in-memory (NSLock-guarded) and flushed in `activationDidCompleteWith`. Emission point: `BarcodeFlashView.task(id: card.id)` — the single surface where a card's barcode is displayed (all navigation paths flow through it).
+- **Phone (TS):** `core/watch-connectivity.ts` gains a zod-validated `CARD_USED` message schema (`version === 1`, ms-precision UTC regex on `usedAt`) + `parseWatchUsageEvent` + `subscribeToWatchUserInfo` ('user-info' events; v1.1.0 lib delivers missed/queued items as a batch on subscribe — verified in `dist/events/subscriptions.js`). New `watch_usage_events` dedup table (migration v2, persisted so a post-relaunch retransmit can't slip past — pruned by `applied_at`, 30-day window). `card-repository.applyWatchUsageEvents` runs in one transaction: `INSERT OR IGNORE` event id `"<cardId>:<usedAt>"` → only on first sight `usage_count += 1`, `last_used_at = max(last_used_at, usedAt)` (CASE WHEN on ms-ISO strings — lexicographic == chronological), `updated_at = now` (cloud delta-sync pickup); single `pushSnapshotToWatch` per batch with ≥1 applied event (AC5). Wiring in `app/_layout.tsx` beside the existing `requestCards` handler; subscription starts after DB init, so pre-launch events held by the lib's native queue land after the DB is ready.
+- **Library version note:** ADR cites `react-native-watch-connectivity` v2.0.0 docs; installed is v1.1.0. Verified the installed version exposes the identical receive surface (`watchEvents.addListener('user-info', cb)` with batch + missed-queue semantics), so no upgrade is needed (tight scope).
+- **Docs task:** all 7 read-only rewords + both documented `SyncMessage` unions were already applied at ADR ratification (verified in CONTRIBUTING.md:270, project_context.md:237/245/327, architecture.md:1018–1042, epics.md:266/1008/1980) — this story verifies and records; the code-level schema work is the `core/watch-connectivity.ts` change above.
+- **Tests:** TDD per task. Watch: new CI-enforced TS contract test (`targets/watch/__tests__/watch-usage-event-contract.test.ts`) — emission shape, ms-precision formatter, transferUserInfo transport, activation buffering, and the AC4 read-only guarantee (outbound watch messages ⊆ {requestCards, CARD_USED}); Swift compile verified via `yarn watch:build`. Phone: migration v2 tests; zod parse + user-info subscription unit tests; `applyWatchUsageEvents` unit tests (SQL-string level) + **integration tests on real SQLite** (better-sqlite3 + real migrations) for increment/max/dedup/commutativity/out-of-order/prune semantics (AC1/AC2/AC3).
+
 ### Debug Log References
 
 ### Completion Notes List
 
+- **Watch emission (AC1):** `BarcodeFlashView.task(id: card.id)` now calls `WatchSessionManager.shared.recordCardUsed(cardId:)` — one event per barcode open, covering every navigation path (list row + any future deep link, since all barcode display flows through this view). Event matches the ADR contract exactly: `{version: 1, type: "CARD_USED", payload: {id, usedAt}}` with `usedAt` from `ISO8601DateFormatter` (`.withInternetDateTime, .withFractionalSeconds`, UTC) → millisecond precision.
+- **Offline queue (AC3, watch side):** transport is `WCSession.transferUserInfo` — the OS queues FIFO while the phone is unreachable, persists across watch app relaunches, and delivers when the counterpart runs (verified current/non-deprecated at ADR ratification). Events recorded before `WCSession` activation completes are buffered in-memory (NSLock-guarded; SwiftUI main thread vs. background delegate callbacks) and flushed from `activationDidCompleteWith`.
+- **Phone apply path (AC1/AC2/AC3):** `applyWatchUsageEvents` (core/database/card-repository.ts) runs one transaction per delivered batch: `INSERT OR IGNORE` into the new persisted `watch_usage_events` ledger (event id `"<cardId>:<usedAt>"`) decides first-sight; only then `usage_count += 1`, `last_used_at = max(current, usedAt)` via CASE WHEN (ms-ISO strings: lexicographic == chronological), `updated_at = now` for cloud delta-sync pickup — mirroring the Story 9.1 `incrementUsageCount` semantics. The persisted ledger (migration v2, `DB_VERSION = 2`) is pruned by `applied_at` (30-day window) so a post-relaunch retransmit can never slip past dedup while the table stays bounded.
+- **Receive wiring (AC1/AC5):** `subscribeToWatchUserInfo` ('user-info' events) added to core/watch-connectivity.ts; v1.1.0 of `react-native-watch-connectivity` delivers OS-queued items as a batch on subscribe (incl. pre-launch events — verified in `dist/events/subscriptions.js`) and single-item arrays afterwards. `app/_layout.tsx` subscribes after DB init, validates each item with the zod `CARD_USED` schema (`parseWatchUsageEvent` — rejects unknown types/versions, second-precision or non-UTC timestamps), and applies the batch. `applyWatchUsageEvents` pushes ONE refreshed snapshot per batch with ≥1 applied event (AC5 — watch ordering converges).
+- **Read-only preserved (AC4):** no mutation path added. Contract test pins: `transferUserInfo` has exactly one call site (the usage-event sender), all `sendMessage` literals are `requestCards`, and no card-mutation verbs travel watch → phone. Phone-side, the user-info handler can only ever apply usage events (zod rejects everything else).
+- **Docs (ADR task):** all 7 read-only rewords + `CARD_USED` in both documented `SyncMessage` unions were applied at ADR ratification — verified at CONTRIBUTING.md:270, project_context.md:237/245/327, architecture.md:1018–1042, epics.md:266/1008/1980. No doc changes needed in this story; the code-level schema (`core/watch-connectivity.ts`) is implemented here.
+- **Library note:** ADR cites `react-native-watch-connectivity` v2.0.0; installed v1.1.0 verified to expose the identical receive surface (`watchEvents.addListener('user-info', cb)` with missed-queue batch semantics). No upgrade needed — kept scope tight.
+- **Validation:** `yarn typecheck` ✓, `yarn lint` ✓, `yarn test` 150 suites / 1503 tests ✓ (incl. 11 new real-SQLite integration tests for commutativity/out-of-order/dedup/prune, 8 new repository unit tests, 12 new watch-connectivity tests, 3 new migration tests), coverage 90.87%/80.74%/86.91%/91.44% (≥80% gate) ✓, watch contract tests 4 suites / 40 tests ✓ (incl. new 6-test usage-event contract), `yarn watch:build` **BUILD SUCCEEDED** ✓.
+- **⚠️ Physical-device validation pending:** the watchOS Simulator does not support `transferUserInfo` — the end-to-end flow (watch open → phone count → re-sync) must be validated on a physical phone+watch pair (per ADR ratification note / Sprint 14 retro). Code-level behavior is fully covered by tests.
+- **Code review:** round 1 (opus subagent, adversarial, fresh context) → **APPROVED (0 findings)**. Non-blocking notes: doc-comment wording on the 9.1-path comparison (tightened in-place to spell out the deliberate `max()` vs `now()` difference); defensive non-array wrap in `subscribeToWatchUserInfo` kept as forward-compat; `console.warn` matches `_layout.tsx` file convention (logger migration is 16-2 territory).
+- **QA review:** round 1 (opus subagent) → **APPROVED (0 findings)**. All 5 ACs traced to asserting tests (AC evidence recorded in review); gates re-run independently: typecheck ✓ lint ✓ 1503/1503 ✓ coverage 90.93/80.8/87.07/91.5 ≥80% ✓; File List verified == `git status`; docs task (7 refs + 2 unions) spot-checked ✓.
+
 ### File List
+
+- `targets/watch/WatchSessionManager.swift` — modified: `recordCardUsed(cardId:at:)`, ms-precision ISO8601 formatter, pre-activation buffer + flush, single `transferUserInfo` call site
+- `targets/watch/BarcodeFlashView.swift` — modified: emit usage event on barcode display
+- `targets/watch/__tests__/watch-usage-event-contract.test.ts` — new: CI-enforced contract tests (shape, ms precision, transport, buffering, AC4 read-only audit)
+- `core/watch-connectivity.ts` — modified: `CARD_USED` in `WatchMessage` union, zod usage-event schema, `parseWatchUsageEvent`, `subscribeToWatchUserInfo`
+- `core/watch-connectivity.test.ts` — modified: 12 new tests (parse validation + user-info subscription)
+- `core/database/migrations.ts` — modified: `DB_VERSION` 1→2, `watch_usage_events` dedup table (fresh-install schema + v1→v2 migration)
+- `core/database/migrations.test.ts` — modified: 3 new migration tests
+- `core/database/card-repository.ts` — modified: `applyWatchUsageEvents` (transactional dedup + commutative apply + bounded prune + single batch re-sync)
+- `core/database/card-repository.test.ts` — modified: 8 new unit tests
+- `core/database/card-repository.integration.test.ts` — modified: 11 new real-SQLite tests (AC1/AC2/AC3/AC5 semantics)
+- `core/database/index.ts` — modified: export `applyWatchUsageEvents`
+- `app/_layout.tsx` — modified: subscribe to watch user-info, validate + apply usage events
+- `docs/sprint-artifacts/sprint-status.yaml` — modified: story status tracking
+- `docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md` — modified: story record
 
 ## Change Log
 
-| Date       | Version | Description                     | Author       |
-| ---------- | ------- | ------------------------------- | ------------ |
-| 2026-06-09 | 0.1     | Drafted via correct-course (C2) | Amelia (dev) |
+| Date       | Version | Description                                                                                                           | Author       |
+| ---------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ------------ |
+| 2026-06-09 | 0.1     | Drafted via correct-course (C2)                                                                                       | Amelia (dev) |
+| 2026-06-10 | 1.0     | Implemented CARD_USED watch→phone usage events per ADR-2026-06-09-001 (emission, dedup apply, re-sync, tests, docs ✓) | Amelia (dev) |

--- a/targets/watch/BarcodeFlashView.swift
+++ b/targets/watch/BarcodeFlashView.swift
@@ -105,6 +105,9 @@ struct BarcodeFlashView: View {
       // focus the view for crown events and play haptic
       isFocused = true
       WKInterfaceDevice.current().play(.success)
+      // Story 9.6 (ADR-2026-06-09-001): a displayed barcode is a card "open" —
+      // emit the usage event so the phone counts it toward shared sorting.
+      WatchSessionManager.shared.recordCardUsed(cardId: card.id)
     }
 
     .task(id: "\(card.id)-\(Int(barcodeTargetSize.width))x\(Int(barcodeTargetSize.height))") {

--- a/targets/watch/WatchSessionManager.swift
+++ b/targets/watch/WatchSessionManager.swift
@@ -16,6 +16,25 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
 
   private var container: ModelContainer?
 
+  /// CARD_USED events recorded before `WCSession` activation completes.
+  /// `transferUserInfo` drops payloads on a non-activated session, so opens
+  /// that race a cold launch are held here and flushed from
+  /// `session(_:activationDidCompleteWith:error:)`. Guarded by
+  /// `pendingUsageEventsLock`: SwiftUI records on the main thread while the
+  /// activation callback arrives on a background queue.
+  private var pendingUsageEvents: [[String: Any]] = []
+  private let pendingUsageEventsLock = NSLock()
+
+  /// `usedAt` MUST carry millisecond precision (ADR-2026-06-09-001): the phone
+  /// dedups by `"<cardId>:<usedAt>"`, so sub-second resolution is what keeps
+  /// two distinct opens of the same card from collapsing into one event id.
+  private static let usageEventTimestampFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    return formatter
+  }()
+
   /// Wire up the persistence container and kick off `WCSession` activation.
   /// Cached `applicationContext` is intentionally NOT read here — the iOS API
   /// only populates `WCSession.default.receivedApplicationContext` after the
@@ -50,6 +69,60 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
     }
   }
 
+  // MARK: - Usage events (Story 9.6, ADR-2026-06-09-001)
+
+  /// Record that a card's barcode was opened on the watch. The event travels
+  /// watch → phone via `transferUserInfo` — the OS queues it FIFO while the
+  /// phone is unreachable and keeps it across relaunches, which is the
+  /// offline-queue behaviour AC3 requires. Usage is telemetry, not a
+  /// card-data edit: the phone applies it commutatively
+  /// (`usageCount += 1`, `lastUsedAt = max`), so the watch stays read-only
+  /// for card data.
+  func recordCardUsed(cardId: String, at date: Date = Date()) {
+    let usedAt = Self.usageEventTimestampFormatter.string(from: date)
+    let event = makeCardUsedEvent(cardId: cardId, usedAt: usedAt)
+
+    guard WCSession.isSupported() else { return }
+    let session = WCSession.default
+
+    pendingUsageEventsLock.lock()
+    pendingUsageEvents.append(event)
+    pendingUsageEventsLock.unlock()
+
+    if session.activationState == .activated {
+      flushPendingUsageEvents(session)
+    } else {
+      log.info("buffering CARD_USED until WCSession activation completes")
+      activateIfNeeded()
+    }
+  }
+
+  private func makeCardUsedEvent(cardId: String, usedAt: String) -> [String: Any] {
+    [
+      "version": 1,
+      "type": "CARD_USED",
+      "payload": ["id": cardId, "usedAt": usedAt]
+    ]
+  }
+
+  private func flushPendingUsageEvents(_ session: WCSession) {
+    guard session.activationState == .activated else { return }
+
+    pendingUsageEventsLock.lock()
+    let events = pendingUsageEvents
+    pendingUsageEvents.removeAll()
+    pendingUsageEventsLock.unlock()
+
+    for event in events {
+      transferUsageEvent(event, via: session)
+    }
+  }
+
+  private func transferUsageEvent(_ event: [String: Any], via session: WCSession) {
+    log.info("transferUserInfo CARD_USED (queued for phone)")
+    _ = session.transferUserInfo(event)
+  }
+
   // MARK: - WCSessionDelegate
 
   func session(
@@ -64,6 +137,7 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
       "activation complete: state=\(activationState.rawValue) reachable=\(session.isReachable)"
     )
     if activationState == .activated {
+      flushPendingUsageEvents(session)
       applyCachedContextIfAvailable()
       // Best-effort ping so the phone can reply with the latest list if it's
       // foregrounded right now. The applicationContext path covers the

--- a/targets/watch/__tests__/watch-usage-event-contract.test.ts
+++ b/targets/watch/__tests__/watch-usage-event-contract.test.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Story 9.6 — Count Card Opens on the Watch (ADR-2026-06-09-001).
+ *
+ * Contract tests pinning the watch-side CARD_USED usage-event emission:
+ *   - message shape `{ version: 1, type: "CARD_USED", payload: { id, usedAt } }`
+ *   - `usedAt` at millisecond precision (`.withFractionalSeconds`) — required
+ *     for dedup-id correctness ("<cardId>:<usedAt>")
+ *   - transport is `transferUserInfo` (OS-queued, survives unreachability and
+ *     relaunch — AC3), NOT reachability-gated `sendMessage`
+ *   - events recorded before WCSession activation are buffered and flushed on
+ *     activation
+ *   - the watch stays read-only for card DATA (AC4): the only outbound
+ *     messages are `requestCards` and `CARD_USED`
+ */
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const watchDir = path.join(repoRoot, 'targets', 'watch');
+const sessionManagerPath = path.join(watchDir, 'WatchSessionManager.swift');
+const barcodeViewPath = path.join(watchDir, 'BarcodeFlashView.swift');
+
+const readSwift = (filePath: string) => fs.readFileSync(filePath, 'utf8');
+
+const listSwiftSources = (dir: string): string[] => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listSwiftSources(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.swift')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+};
+
+describe('watch usage event contract (Story 9.6)', () => {
+  it('builds CARD_USED with the ADR v1 message shape', () => {
+    const sessionManager = readSwift(sessionManagerPath);
+
+    const builderStart = sessionManager.indexOf('func makeCardUsedEvent');
+    expect(builderStart).toBeGreaterThan(-1);
+    const builder = sessionManager.slice(builderStart, builderStart + 600);
+
+    expect(builder).toContain('"version": 1');
+    expect(builder).toContain('"type": "CARD_USED"');
+    expect(builder).toContain('"id": cardId');
+    expect(builder).toContain('"usedAt": usedAt');
+  });
+
+  it('stamps usedAt at millisecond precision in UTC (ISO-8601)', () => {
+    const sessionManager = readSwift(sessionManagerPath);
+
+    expect(sessionManager).toContain('ISO8601DateFormatter');
+    expect(sessionManager).toContain('.withFractionalSeconds');
+    expect(sessionManager).toContain('.withInternetDateTime');
+  });
+
+  it('uses the OS-queued transferUserInfo transport for usage events (AC3)', () => {
+    const sessionManager = readSwift(sessionManagerPath);
+
+    expect(sessionManager).toContain('.transferUserInfo(');
+    // The reachability-gated one-shot channel must not carry usage events.
+    expect(sessionManager).not.toMatch(/sendMessage\([^)]*CARD_USED/s);
+  });
+
+  it('buffers events until WCSession activation completes, then flushes', () => {
+    const sessionManager = readSwift(sessionManagerPath);
+
+    expect(sessionManager).toContain('pendingUsageEvents');
+    expect(sessionManager).toContain('flushPendingUsageEvents');
+    // Flush must be wired into the activation callback so pre-activation
+    // opens (e.g. cold launch straight into a card) are not dropped.
+    const activationCallback = sessionManager.slice(
+      sessionManager.indexOf('activationDidCompleteWith'),
+      sessionManager.indexOf('didReceiveApplicationContext')
+    );
+    expect(activationCallback).toContain('flushPendingUsageEvents');
+  });
+
+  it('records a usage event when the barcode view is displayed (AC1)', () => {
+    const barcodeView = readSwift(barcodeViewPath);
+
+    // Emission rides the same per-appearance task that focuses the view and
+    // plays the haptic — one event per card open.
+    expect(barcodeView).toContain('recordCardUsed(cardId: card.id)');
+    const appearanceTask = barcodeView.slice(
+      barcodeView.indexOf('.task(id: card.id)'),
+      barcodeView.indexOf('.task(id: "\\(card.id)')
+    );
+    expect(appearanceTask).toContain('recordCardUsed');
+  });
+
+  it('keeps the watch read-only for card data — no outbound mutation messages (AC4)', () => {
+    const sourcesByFile = listSwiftSources(watchDir).map((filePath) => ({
+      filePath,
+      source: readSwift(filePath)
+    }));
+
+    // transferUserInfo is invoked from exactly one call site, in the session
+    // manager, and only ever carries the CARD_USED event built by
+    // makeCardUsedEvent.
+    for (const { filePath, source } of sourcesByFile) {
+      if (filePath !== sessionManagerPath) {
+        expect(source).not.toContain('transferUserInfo(');
+      }
+    }
+    const sessionManager = readSwift(sessionManagerPath);
+    const transferCallSites = sessionManager.match(/\.transferUserInfo\(/g) ?? [];
+    expect(transferCallSites).toHaveLength(1);
+    const transferFuncDecl = 'func transferUsageEvent';
+    const funcStart = sessionManager.indexOf(transferFuncDecl);
+    const callSite = sessionManager.indexOf('.transferUserInfo(');
+    expect(funcStart).toBeGreaterThan(-1);
+    expect(callSite).toBeGreaterThan(funcStart);
+    // No other function opens between the declaration and the call — the
+    // single call site lives inside transferUsageEvent.
+    const betweenDeclAndCall = sessionManager.slice(funcStart + transferFuncDecl.length, callSite);
+    expect(betweenDeclAndCall).not.toContain('func ');
+
+    // Every inline sendMessage literal stays a read-only control ping.
+    const allSources = sourcesByFile.map(({ source }) => source).join('\n');
+    const sentMessageTypes = new Set(
+      [...allSources.matchAll(/sendMessage\(\s*\[\s*"type":\s*"([^"]+)"/g)].map((match) => match[1])
+    );
+    expect([...sentMessageTypes]).toEqual(['requestCards']);
+
+    // No card-data mutation verbs travel watch → phone.
+    for (const forbidden of [
+      'createCard',
+      'editCard',
+      'updateCard',
+      'deleteCard',
+      'syncCard',
+      'toggleFavorite'
+    ]) {
+      expect(allSources).not.toMatch(
+        new RegExp(`(?:sendMessage|transferUserInfo)\\([^)]*${forbidden}`, 's')
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Opening a card's barcode on the Apple Watch now counts toward the card's shared usage (`usageCount` / `lastUsedAt`), so most-used / recently-used sorting is accurate on **both** the Watch and the phone. Implements [ADR-2026-06-09-001](docs/adr-2026-06-09-watch-usage-events.md) (PRD FR76).

- **Watch** emits `{version: 1, type: "CARD_USED", payload: {id, usedAt}}` (ms-precision UTC) via `WCSession.transferUserInfo` — OS-queued FIFO while the phone is unreachable, survives relaunch; pre-activation opens are buffered and flushed on activation
- **Phone** validates with a zod schema (rejects unknown versions/types and second-precision timestamps), receives `user-info` batches (incl. pre-launch queue), dedups via the new persisted `watch_usage_events` ledger (migration v2; event id `"<cardId>:<usedAt>"`; 30-day prune), applies commutatively in one transaction (`usage_count += 1`, `last_used_at = max`), and re-syncs one snapshot per applied batch
- **Read-only invariant preserved**: usage telemetry only — pinned by a CI-enforced contract test (single `transferUserInfo` call site; outbound watch messages ⊆ {`requestCards`, `CARD_USED`})
- Docs task (7 read-only rewords + `CARD_USED` in both documented `SyncMessage` unions) was applied at ADR ratification — verified, no further changes needed

## Acceptance criteria

- [x] AC1 — watch open increments `usageCount` by 1 and updates `lastUsedAt` to the open time on the phone
- [x] AC2 — conflict-free reconciliation: commutative increments, `lastUsedAt = max`, no card-data edit conflict
- [x] AC3 — offline queue + flush without double-counting (persisted dedup survives relaunch retransmits)
- [x] AC4 — watch stays read-only for card data (contract-test enforced)
- [x] AC5 — next watch snapshot reflects the updated usage (ordering converges)

## Reviews

- Code review (opus subagent, adversarial, fresh context): **APPROVED — 0 findings** (round 1)
- QA review (opus subagent): **APPROVED — 0 findings** (round 1) — AC-by-AC evidence in the story's Dev Agent Record

## Test results

- `yarn typecheck` / `yarn lint`: clean
- `yarn test`: **150 suites / 1503 tests** passing (40 new: 11 real-SQLite integration, 8 repository unit, 12 watch-connectivity, 3 migration, 6 watch contract)
- Coverage: 90.9% stmts / 80.8% branches / 87.1% funcs / 91.5% lines (≥80% gate)
- Watch contract tests: 4 suites / 40 tests passing; `yarn watch:build`: **BUILD SUCCEEDED**

> ⚠️ **Physical-device validation pending:** the watchOS Simulator does not support `transferUserInfo` — the end-to-end flow (watch open → phone count → re-sync) should be validated on a physical phone+watch pair before considering the feature shippable (flagged per Sprint 14 retro).

## Story

[docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md](docs/sprint-artifacts/stories/9-6-count-watch-card-opens.md)