### PR TITLE
chore(sprint): close Epic 9, plan & refine Sprint 16

### DIFF
--- a/docs/sprint-artifacts/epic-9-retro-2026-06-10.md
+++ b/docs/sprint-artifacts/epic-9-retro-2026-06-10.md
@@ -1,0 +1,156 @@
+# Sprint 15 / Epic 9 Retrospective — Smart Card Sorting
+
+**Date:** 2026-06-10
+**Epic:** 9 — Smart Card Sorting
+**Sprint:** 15 (planned 2026-06-06; delivered 2026-06-06 → 2026-06-10, ahead of the 2026-06-20 window)
+**Facilitator:** Bob (Scrum Master)
+**Participants:** ifero (Project Lead), Amelia (Dev), Quinn (QA), Winston (Architect), John (PM), Sally (UX)
+**Status:** Complete
+
+---
+
+## Sprint Summary
+
+| Metric                    | Value                                                      |
+| ------------------------- | ---------------------------------------------------------- |
+| Stories Planned           | 4                                                          |
+| Stories Delivered         | 7 (+3 added mid-sprint via `correct-course`)               |
+| Stories Completed         | 7 / 7 (100%) — all merged to `main`                        |
+| PRs Merged                | 10 (#123–#132) — 8 story/spec + 2 backlog tickets          |
+| Commits                   | 20                                                         |
+| Files Changed             | 59                                                         |
+| Lines Added / Deleted     | +4,617 / −244 (net +4,373)                                 |
+| Tests                     | 1442 → 1503 jest (+61); watch TS contract suite 32 → 40    |
+| Coverage                  | ≥80% gate held throughout (9.6 final ~90.9% stmts)         |
+| Production Incidents      | 0                                                          |
+| ADRs Produced             | 1 — ADR-2026-06-09-001 (watch usage events)                |
+| PRD Impact                | Activated FR21–24 + FR8; **added FR75 + FR76** mid-sprint  |
+| Follow-up Tickets Created | 16-2 (logger/Sentry #125), 16-3…16-6 (design-in-code #126) |
+
+**Stories Delivered:**
+
+| Story | Title                                | Wave | PR             | Note                                                      |
+| ----- | ------------------------------------ | ---- | -------------- | --------------------------------------------------------- |
+| 9.1   | Track Card Usage                     | 1    | #123           | `usageCount`/`lastUsedAt` on detail-screen focus          |
+| 9.2   | Mark Card as Favorite                | 1    | #124           | `isFavorite` toggle + badge; design re-spin pre-commit    |
+| 9.3   | Implement Sorting Algorithm          | 2    | #127           | Favourites-first; +AC6 scroll persistence folded in       |
+| 9.4   | Sync Sorting to Watch                | 3    | #128           | `isFavorite` end-to-end + watch favourite badge (C3)      |
+| 9.6a  | Watch Usage-Event ADR **[Enabling]** | 4    | #129           | ADR-2026-06-09-001 ratified; gated 9.6                    |
+| 9.5   | Selectable Watch Sort                | 4    | #131 (UX #130) | Watch sort picker (Frequent / Recent / A-Z)               |
+| 9.6   | Count Card Opens on the Watch        | 5    | #132           | `CARD_USED` watch→phone, persisted dedup ledger (mig. v2) |
+
+---
+
+## Successes
+
+1. **Course-correction under load worked.** Scope grew from 4 to 7 stories mid-sprint (9.5, 9.6a, 9.6 added via `correct-course` on 2026-06-09), and every added story shipped through full code-review + QA. Responsive to change without a quality drop.
+
+2. **Sprint 14 retro lessons were demonstrably applied.** The two process action items from the prior retro showed up in the work: **spike-first** (Story 9.6a is an enabling ADR produced _before_ 9.6 touched watch→phone messaging) and **mandatory API-currency checks** (9.5 AC6 and 9.6, via the ADR, verify non-deprecated SwiftUI/WatchConnectivity APIs against official docs). This is cycle-over-cycle improvement, not aspiration.
+
+3. **Epic 2's schema-ahead foundation paid off.** `usageCount`, `lastUsedAt`, and `isFavorite` were added (inactive) back in Epic 2. Story 9.3's core change was a single comparator tier — `if (a.isFavorite !== b.isFavorite) return a.isFavorite ? -1 : 1;` — turning the headline feature into a one-line diff.
+
+4. **Real-SQLite integration testing matured and propagated.** A 9.1 TEA review established `better-sqlite3` integration tests (string-matching unit tests can't catch a column/`WHERE` typo); the pattern was reused through 9.2, 9.4, and 9.6 (11 new real-DB tests in 9.6 alone for commutativity, out-of-order, and dedup).
+
+5. **Single-source comparator discipline prevented drift.** 9.4 collapsed a thrice-duplicated watch sort into `WatchCard.sortedForDisplay(_:)`; 9.5 extended it to `sorted(_:by:)`. 9.5 even caught and fixed a latent `.frequent` mixed-`nil` parity bug carried in from 9.4.
+
+6. **CI-enforced watch TS contract tests earned their keep.** Swift XCTests don't run in CI here, but the `targets/watch/__tests__` contract suite does — it caught a stale a11y-label assertion (9.4) and now audits the AC4 read-only guarantee (outbound watch messages ⊆ `{requestCards, CARD_USED}`) in 9.6.
+
+7. **Cross-functional roles sequenced correctly.** PM (FR75/FR76) → Architect (ADR ratified) → UX (picker/badge specs) → Dev (implementation) → QA (adversarial review). Architecture _finished_ before implementation _started_ on the watch usage-event chain.
+
+8. **Zero production incidents** across 59 files and ~4.6K lines.
+
+---
+
+## Challenges
+
+> Psychological safety: these are systems/process observations, not individual performance.
+
+1. **The sprint record lagged reality.** `correct-course` added 9.5/9.6a/9.6 to the story files and `development_status`, but **not** to `current_sprint.stories`/`waves`. The sprint plan didn't reflect its own scope until reconciled on 2026-06-10 — the gap that opened this session. Same strength (fast pivots), same shadow (drift).
+
+2. **Design validation landed late.** Story 9.2's favourite star passed code-review **and** QA, _then_ a stakeholder design review caught that the gold star is invisible on yellow brand tiles (e.g. Esselunga) and the icon family violated DEC-12.5-004 — forcing a pause + Figma sign-off + rework before commit.
+
+3. **Late requirement folds within stories.** 9.3 absorbed AC6 (scroll persistence) and a corrected AC4 (A-Z favourite pinning) mid-story (both stakeholder-directed 2026-06-08). Good outcomes, but planned scope ≠ shipped scope at the story level.
+
+4. **Physical-device validation debt.** 9.6's `transferUserInfo` (watch→phone usage events) and 9.2's watch snapshot/cloud/header-star paths **cannot** be exercised on the watchOS Simulator. Code is fully unit/contract-tested; the real-hardware loop is unverified.
+
+5. **Recurring logger/Sentry gap.** Flagged in 9.2 and again in 9.6 — `features/` uses `console.*` directly, so production error reporting never fires. Correctly deferred to keep scope tight → backlogged as Story 16-2.
+
+---
+
+## Key Decisions
+
+### DEC-S15-RETRO-001: Watch hardware validation rides the next RC; gates Epic 10
+
+**Context:** `transferUserInfo` and watch favourite sync are unprovable on Simulator. The code is test-covered but the end-to-end loop (watch open → phone count → re-sync) is unverified on real hardware.
+**Decision:** Validate on a physical phone + paired watch as part of the **next RC build**. A solid, validated watch app is a prerequisite for **Epic 10 (Wear OS)**.
+**Owner:** ifero · **Status:** Agreed — not a blocker for Sprint 15 closure; gates Epic 10.
+
+### DEC-S15-RETRO-002: Reconcile the sprint record within `correct-course`
+
+**Context:** Mid-sprint additions updated story files + `development_status` but left `current_sprint.stories`/`waves` stale.
+**Decision:** When `correct-course` adds/changes stories, update `current_sprint.stories` and `waves` in the **same pass**.
+**Owner:** Bob (SM) · **Status:** Approved — effective immediately.
+
+### DEC-S15-RETRO-003: Pull design sign-off ahead of code-review for visible-UI stories
+
+**Context:** 9.2 reached committed quality before a design defect was caught, forcing rework.
+**Decision:** For stories with a visible UI surface, design/Figma sign-off precedes code-review. Fold the lesson into the in-flight **Epic 16-3 (design-contribution-workflow)**.
+**Owner:** Sally (UX) + Bob (SM) · **Status:** Approved.
+
+---
+
+## Previous Retrospective Follow-Through
+
+**From Sprint 14 Retro (2026-06-06):**
+
+| Action Item                                                       | Status           | Outcome                                                                           |
+| ----------------------------------------------------------------- | ---------------- | --------------------------------------------------------------------------------- |
+| Mandatory API-currency check in story ACs (Apple-platform work)   | ✅ Applied       | 9.5 AC6 + 9.6 (via ADR) verify non-deprecated APIs against Context7/official docs |
+| Spike-first for Watch/native APIs (no impl without validated PoC) | ✅ Applied       | Story 9.6a — enabling ADR ratified before 9.6 implementation                      |
+| Backlog Epic 5 follow-up: replace generic complication (from 5.7) | ❌ Not addressed | Out of Epic 9 scope — carried forward as an action item below                     |
+
+2 of 3 prior action items were applied and visibly improved the watch work. The third is carried forward (see Action Item 5).
+
+---
+
+## Action Items
+
+| #   | Action                                                                                                        | Owner            | Category       | Done when                                                       |
+| --- | ------------------------------------------------------------------------------------------------------------- | ---------------- | -------------- | --------------------------------------------------------------- |
+| 1   | Reconcile `current_sprint.stories`/`waves` inside every `correct-course` (not just `development_status`)      | Bob (SM)         | Process        | Next mid-sprint add lands in the sprint record same-day         |
+| 2   | ⭐ Validate watch usage-events + favourite sync on a physical phone+watch pair at next RC — **gates Epic 10** | ifero            | Critical Path  | Watch open → phone `usageCount` increments → re-sync, on device |
+| 3   | Move design sign-off before code-review for visible-UI stories; fold into Epic 16-3                           | Sally (UX) + Bob | Process        | No "passed QA, then reworked for design" loops recur            |
+| 4   | Verify the logger/Sentry call-site migration (16-2) actually fires in production                              | Amelia (Dev)     | Technical      | A logged error reaches Sentry in a prod build                   |
+| 5   | Don't drop Sprint 14 action #3 (Epic 5 specific complication) — draft the story or consciously park it        | Bob (SM)         | Accountability | A story exists or an explicit park decision is recorded         |
+
+---
+
+## Readiness Assessment
+
+| Dimension              | Status                                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| Testing & Quality      | ✅ Strong — 1503 tests, ≥80% coverage, adversarial reviews · ⚠️ except hardware path (Item 2)   |
+| Deployment             | ⏳ Next RC (ifero's cadence)                                                                    |
+| Stakeholder Acceptance | ✅ Stakeholder (ifero) participated; 9.2 design signed off 2026-06-07                           |
+| Technical Health       | ✅ Solid — single-source comparator, persisted dedup ledger, schema-ahead from Epic 2           |
+| Blockers               | ✅ None blocking sprint closure · 1 critical-path item (Item 2) gating Epic 10, not this sprint |
+
+**Verdict:** Epic 9 is complete from a story perspective and functionally accepted. One validation item rides the next RC and gates Wear OS.
+
+---
+
+## Next Sprint — Open Decision
+
+No significant discovery forces a re-plan; if anything, Epic 9 **de-risked** the roadmap (ADR-2026-06-09-001 confirms the usage-event protocol ports to Wear OS via the Wearable Data Layer). The next epic is a genuine choice to make in sprint-planning:
+
+| Candidate                        | Readiness                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Epic 10 — Wear OS**            | De-risked by the ADR, but **gated** on the watch hardware validation (Item 2) landing first |
+| **Epic 14 — Household Collab.**  | Deferred — Phase A needs dedicated UX/UI design before implementation                       |
+| **Epic 16 — Platform/Tech Debt** | 16-1 (NativeWind → Unistyles) drafted; 16-2 (logger) done; 16-3…16-6 design-in-code drafted |
+
+**Recommendation:** Run `sprint-planning` ([SP]) to choose and sequence Sprint 16. ifero's stated direction: a solid, validated watch app before the Android Wear equivalent.
+
+---
+
+Bob (Scrum Master): "Epic 9 was a model of responsive delivery — we grew scope 75% mid-sprint and still shipped 7/7 with the suite green and zero incidents, _and_ we proved the last retro's lessons stuck. The honest edge is hardware: green tests aren't a validated watch. ifero owns that at the next RC, and it gates Wear OS. Great work, team."

--- a/docs/sprint-artifacts/sprint-14-retro-2026-06-06.md
+++ b/docs/sprint-artifacts/sprint-14-retro-2026-06-06.md
@@ -1,0 +1,34 @@
+# Sprint 14 Retrospective — WatchOS Reliability, Italian In-App & Household Planning
+
+**Date:** 2026-06-06
+**Sprint:** 14 (2026-05-13 → 2026-05-26)
+**Epics:** 2, 5, 6, 14, 15
+**Status:** Complete
+**Note:** Archived from `sprint-status.yaml` on 2026-06-11 when Sprint 15 rolled into `last_sprint` (single-slot). Preserved here so the history isn't lost.
+
+---
+
+## Delivery
+
+10/10 stories done across 5 epics (14-1 updated to done post-sprint): 5-7, 5-8, 2-9, 2-10, 5-10, 15-2, 14-1, 6-18a, 11-7, 13-7b.
+
+## What went well
+
+- Strong throughput across a wide scope (Watch, localization, barcode, OTP, infra).
+- Apple Watch epic (Epic 5) fully wrapped: 5-7, 5-8, and 5-10 all landed.
+- Italian localization (15-2) shipped cleanly.
+- Unplanned regression fix (13-7b, added 2026-06-04) absorbed without derailing the sprint.
+
+## What could have gone better
+
+- Story 5-7 (Watch Complication): agent started on deprecated ClockKit instead of current WidgetKit. Had to pivot mid-story, still ended up delivering a generic complication rather than the specific one intended. Rework loop caused significant frustration.
+
+## Action items for Sprint 15
+
+1. **Mandatory API currency check:** before any story touching Apple platform APIs (Watch, WidgetKit, PassKit, etc.), verify the current API via Context7 or official docs. Non-negotiable — goes in story acceptance criteria.
+2. **Spike-first for Watch/native APIs:** no full implementation without a validated proof of concept on device first.
+3. **Backlog a follow-up story in Epic 5** to replace the generic complication with the specific complication originally intended in 5-7.
+
+---
+
+> **Follow-through:** Action items 1 & 2 were applied in Epic 9 (Sprint 15) — the 9.6a spike/ADR before 9.6, and API-currency checks baked into 9.5/9.6 ACs (see [epic-9-retro-2026-06-10.md](epic-9-retro-2026-06-10.md)). Action item 3 (Epic 5 specific complication) remained unaddressed and was carried forward into the Epic 9 retro's action items.

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-01-03
-# updated: 2026-06-09
+# updated: 2026-06-11
 # project: myLoyaltyCards
 # tracking_system: file-system
 # story_location: docs/sprint-artifacts
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-01-03
-updated: 2026-06-09
+updated: 2026-06-11
 project: myLoyaltyCards
 tracking_system: file-system
 story_location: docs/sprint-artifacts
@@ -44,77 +44,14 @@ story_location: docs/sprint-artifacts
 # LAST SPRINT (completed)
 # ============================================
 last_sprint:
-  number: 14
-  name: 'Sprint 14: WatchOS Reliability, Italian In-App, and Household Collaboration Planning'
-  goal: 'Complete Apple Watch reliability work, finish incremental catalogue generation, enable Italian in-app readiness, begin household collaboration discovery, repair the OTP verification regression from Story 6.18, and stage barcode readability bugfix tickets for phone and watch.'
-  status: completed
-  planning_date: 2026-05-03
-  start_date: 2026-05-13
-  end_date: 2026-05-26
-  duration: 2 weeks
-  epics: [5, 15, 14, 6, 2]
-  stories:
-    - 5-7-create-watch-complication
-    - 5-8-incremental-catalogue-generation
-    - 2-9-scan-cards-from-image-screenshot
-    - 2-10-fix-barcode-qr-readability-padding
-    - 5-10-watch-barcode-legibility-list-density
-    - 15-2-italian-language-in-app
-    - 14-1-household-collaboration-scoping
-    - 6-18a-otp-verification-followup
-    - 11-7-contribution-infrastructure
-    - 13-7b-fix-onboarding-welcome-redirect-loop
-  waves:
-    wave_1:
-      stories: [5-7, 5-8, 2-9, 2-10, 5-10, 15-2, 6-18a, 13-7b]
-      note: 'Primary implementation work on Apple Watch reliability, image-based scanning, barcode readability bugfix planning, Italian in-app readiness, and the OTP verification follow-up bugfix.'
-    wave_2:
-      stories: [14-1]
-      note: 'Begin household collaboration discovery and alignment once core sprint capacity is confirmed.'
-    wave_3:
-      stories: [11-7]
-      note: 'Developer-experience follow-up: open-source contribution docs (README, CONTRIBUTING, LICENSE), GitHub PR/issue templates, and merge-time story-status automation. Maps to NFR-M3 and NFR-M5.'
-  notes: |
-    Sprint 14 closed successfully on 2026-05-26. 10/10 stories done (14-1 updated to done post-sprint).
-    Summary:
-      - Delivered a wide-scope sprint spanning Epics 2, 5, 6, 14, and 15.
-      - Apple Watch epic (Epic 5) fully wrapped: 5-7, 5-8, and 5-10 all landed.
-      - Italian localization (15-2) shipped cleanly.
-      - Household collaboration scoping (14-1) completed — Epic 14 Phase A ready to implement.
-      - OTP verification follow-up bugfix (6-18a) resolved the 8-digit OTP + single-field regression.
-      - Unplanned regression fix (13-7b) absorbed without derailing the sprint.
-  retrospective: |
-    Retrospective completed 2026-06-06.
-    Delivery: 10/10 stories done across 5 epics (14-1 updated to done post-sprint).
-    What went well:
-      - Strong throughput across a wide scope (Watch, localization, barcode, OTP, infra).
-      - Apple Watch epic (Epic 5) fully wrapped: 5-7, 5-8, and 5-10 all landed.
-      - Italian localization (15-2) shipped cleanly.
-      - Unplanned regression fix (13-7b, added 2026-06-04) absorbed without derailing the sprint.
-    What could have gone better:
-      - Story 5-7 (Watch Complication): agent started on deprecated ClockKit instead of current
-        WidgetKit. Had to pivot mid-story, still ended up delivering a generic complication rather
-        than the specific one intended. Rework loop caused significant frustration.
-    Action items for Sprint 15:
-      1. Mandatory API currency check: before any story touching Apple platform APIs (Watch,
-         WidgetKit, PassKit, etc.), verify the current API via Context7 or official docs.
-         Non-negotiable — goes in story acceptance criteria.
-      2. Spike-first for Watch/native APIs: no full implementation without a validated proof of
-         concept on device first.
-      3. Backlog a follow-up story in Epic 5 to replace the generic complication with the
-         specific complication originally intended in 5-7.
-
-# ============================================
-# CURRENT SPRINT
-# ============================================
-current_sprint:
   number: 15
   name: 'Sprint 15: Smart Card Sorting'
   goal: 'Complete Epic 9 — activate usage tracking and favourites, implement the smart sorting algorithm, and sync card order to Apple Watch.'
-  status: planning
+  status: completed
   planning_date: 2026-06-06
   start_date: 2026-06-09
   end_date: 2026-06-20
+  completed_date: 2026-06-10
   duration: 2 weeks
   epics: [9]
   stories:
@@ -122,24 +59,88 @@ current_sprint:
     - 9-2-mark-card-as-favorite
     - 9-3-implement-sorting-algorithm
     - 9-4-sync-sorting-to-watch
+    - 9-5-selectable-watch-sort
+    - 9-6a-watch-usage-event-adr
+    - 9-6-count-watch-card-opens
   waves:
     wave_1:
       stories: [9-1, 9-2]
-      note: 'Parallel — independent. Activate usage tracking (usageCount + lastUsedAt on card display) and favourites (isFavorite toggle + visual indicator). Schema fields already exist from Epic 2.'
+      note: 'Usage tracking + favourites (schema fields already in place from Epic 2).'
     wave_2:
       stories: [9-3]
-      note: 'Depends on Wave 1. Implement sorting algorithm: favourites first → frequency → recency → alphabetical. Applies to phone card list.'
+      note: 'Favourites-first smart sort on the phone card list.'
     wave_3:
       stories: [9-4]
-      note: 'Depends on Wave 2. Sync sort order and usage data (usageCount, lastUsedAt, isFavorite) to Apple Watch.'
+      note: 'Sync favourite ordering + usage data to Apple Watch.'
+    wave_4:
+      stories: [9-6a, 9-5]
+      note: 'Mid-sprint via correct-course (2026-06-09): 9-6a enabling ADR (watch→phone CARD_USED, ADR-2026-06-09-001); 9-5 selectable watch sort.'
+    wave_5:
+      stories: [9-6]
+      note: 'Mid-sprint: count watch card opens toward the shared usageCount/lastUsedAt counters (FR76).'
   notes: |
-    Sprint 15 planned on 2026-06-06 following Sprint 14 retrospective.
-    Focus is entirely on Epic 9 (Smart Card Sorting) — a focused single-epic sprint to deliver
-    a high-value UX improvement using schema fields already in place since Epic 2.
-    Epic 14 (Household Collaboration) deferred: Phase A (deeplink sharing + shopping list)
-    requires dedicated UX/UI design work before implementation begins.
-    Decision: Epic 9 first because schema is ready, Watch integration is unblocked (Epic 5 done),
-    and the feature directly improves daily usability for all existing users.
+    Sprint 15 delivered Epic 9 (Smart Card Sorting). Scope grew 4 → 7 mid-sprint via
+    correct-course (added 9-6a, 9-5, 9-6); all 7 stories done and merged to main (#123–#132)
+    by 2026-06-10, ahead of the planned window. Quality gates held throughout (1503 tests,
+    coverage ≥80%, 0 production incidents).
+  retrospective: |
+    Epic 9 retrospective completed 2026-06-10 (party mode; Bob facilitating).
+    Full write-up: docs/sprint-artifacts/epic-9-retro-2026-06-10.md
+    Highlights: course-correction absorbed +3 stories with no quality drop; Sprint 14 retro
+    lessons applied (spike-first 9.6a ADR before 9.6 + API-currency checks in ACs); Epic 2
+    schema-ahead made 9.3 a one-tier change.
+    Watch-outs: correct-course didn't update current_sprint.stories/waves (reconciled 2026-06-10);
+    design validation landed late on 9.2; physical-device watch validation still pending (next RC).
+    Top action items: reconcile the sprint record within correct-course (Bob); validate watch
+    usage-events + favourite sync on a physical pair at the next RC — GATES Epic 10 (ifero);
+    design sign-off before code-review for UI stories (Sally + Bob).
+
+# ============================================
+# CURRENT SPRINT
+# ============================================
+current_sprint:
+  number: 16
+  name: 'Sprint 16: Platform & Tech-Debt Clear-Out (Epic 16)'
+  goal: 'Clear Epic 16 — ship the two reliability fixes (Android beta upload, cloud sync on cold open), migrate the styling engine to Unistyles, and stand up the design-in-code foundation (contribution workflow, design tokens, component gallery).'
+  status: in-progress # started 2026-06-11
+  planning_date: 2026-06-11
+  start_date: 2026-06-11
+  end_date: 2026-06-25
+  duration: 2 weeks
+  epics: [16]
+  stories:
+    - 16-7-fix-android-beta-upload-versioncode
+    - 16-8-fix-cloud-sync-cold-open-race
+    - 16-1-migrate-nativewind-to-unistyles
+    - 16-3-design-contribution-workflow
+    - 16-4-design-tokens-dtcg-style-dictionary
+    - 16-2-implement-logger-sentry-wrapper
+    - 16-5-component-gallery-storybook-chromatic
+  waves:
+    wave_1:
+      stories: [16-7, 16-8]
+      note: 'Ship-now reliability fixes (both ready-for-dev, independent). 16-7: Android RC alpha upload — authoritative versionCode via GITHUB_RUN_NUMBER through a new app.config.ts (+ prod offset band, release-signing fix, cicd.md doc). 16-8: cloud sync fails on every cold open — autoTriggeredRef latch-on-success + network-ready gate + retryWithBackoff.'
+    wave_2:
+      stories: [16-1]
+      note: 'Refine → dev. Migrate styling engine NativeWind/Tailwind → react-native-unistyles (atomic, ~31 className files, zero visual regression). Refinement first: incremental dev approach + Unistyles v3 plugin coexistence. UNBLOCKS 16-5.'
+    wave_3:
+      stories: [16-3, 16-4, 16-2]
+      note: 'Refine → dev, parallel-capable (engine-agnostic, independent of 16-1). 16-3: design-contribution workflow (CONTRIBUTING-DESIGN.md, labels/templates, docs/design/ home). 16-4: design tokens → portable DTCG JSON + Style Dictionary (tokens.generated.ts). 16-2: logger/Sentry wrapper + migrate ~65 console.* call sites (re-opened — was wrongly marked done). All three have draft story files needing a refinement pass.'
+    wave_4:
+      stories: [16-5]
+      note: 'Depends on Wave 2 (16-1 styling engine). Web Storybook (react-native-web) + Chromatic (free OSS) for visual component PR review. Refine → dev after Unistyles lands.'
+  notes: |
+    Sprint 16 planned 2026-06-11 after the Epic 9 retrospective. Theme: clear Epic 16
+    (Platform & Tech Debt) — ifero's call to tackle the whole bucket.
+    Scope: 7 stories across 4 waves. 16-2 (logger/Sentry) was found wrongly marked done
+    (corrected 2026-06-11 → drafted) and folded into Wave 3; 16-6 (Penpot) is kept in backlog
+    as trigger-gated ("when real visual designers want in").
+    Readiness reality: only 16-7 + 16-8 are ready-for-dev; 16-1, 16-2, 16-3, 16-4, 16-5 are all
+    drafted and need a refinement pass → ready-for-dev before dev. So the SM/PM refinement phase
+    is the gating work for this sprint — larger and prep-heavier than the focused Epic 9 one.
+    Dependency: 16-5 (component gallery) is blocked by 16-1 (styling engine) → Wave 4 after Wave 2.
+    Deferred: Epic 10 (Wear OS) stays gated on the Epic 9 retro action #2 (on-device watch
+    usage-event validation at the next RC); Epic 14 (Household) still needs UX design first.
 
 next_sprint: null
 
@@ -258,8 +259,9 @@ development_status:
   # PHASE 2 - ENHANCEMENTS
   # ============================================
 
-  # Epic 9: Smart Card Sorting
-  epic-9: in-progress
+  # Epic 9: Smart Card Sorting ✅ COMPLETE
+  epic-9: done
+  epic-9-completed: 2026-06-10
   9-1-track-card-usage: done
   9-2-mark-card-as-favorite: done # design signed off 2026-06-07 (Figma frame approved); impl + code review + QA complete; awaiting stakeholder commit approval
   9-3-implement-sorting-algorithm: done
@@ -267,7 +269,7 @@ development_status:
   9-5-selectable-watch-sort: done # 2026-06-10: impl complete on feature/9-5-selectable-watch-sort; dev-subagent code review (2 rounds → 0 comments) + QA (sonnet) approved. story.md at "review" — awaiting stakeholder approval to commit/PR.
   9-6a-watch-usage-event-adr: done # 2026-06-09: ADR-2026-06-09-001 RATIFIED → Accepted (Architect); 7 read-only refs refined + CARD_USED documented. Story .md at "review" (auto-flips to done on merge). Unblocked 9-6.
   9-6-count-watch-card-opens: done # 2026-06-10: impl complete on feature/9-6-count-watch-card-opens — CARD_USED per ADR-2026-06-09-001. Code review (opus) + QA (opus) both APPROVED 0 findings round 1. All gates green (1503 tests, coverage ≥80%, watch build OK). Awaiting stakeholder approval to commit/PR. ⚠️ transferUserInfo needs physical-pair validation.
-  epic-9-retrospective: optional
+  epic-9-retrospective: done # completed 2026-06-10 — docs/sprint-artifacts/epic-9-retro-2026-06-10.md
 
   # Epic 10: Wear OS App
   epic-10: backlog
@@ -354,13 +356,15 @@ development_status:
   # First story (16-1): migrate styling engine NativeWind/Tailwind → react-native-unistyles
   #   — faster, type-safe styling unified with shared/theme tokens; zero visual regression;
   #   ~31 className files; shared/theme preserved. Ships ATOMICALLY (no partial release).
-  epic-16: backlog
-  16-1-migrate-nativewind-to-unistyles: drafted # drafted in party mode 2026-06-04; ONE atomic story (decided NOT to split — solo dev, no partial release). Open decisions for refinement: incremental dev approach + Unistyles v3 plugin coexistence. NOT yet sprinted.
-  16-2-implement-logger-sentry-wrapper: done # follow-up from Story 9.2 code review (2026-06-07): docs prescribe a logger/Sentry wrapper but features/ uses console.* directly, so prod error reporting never fires. Implement wrapper + migrate call sites project-wide. Story file drafted.
-  16-3-design-contribution-workflow: backlog # design-in-code (party mode 2026-06-08): CONTRIBUTING-DESIGN.md + design label/issue template + PR-conventions exemption + Figma demotion + docs/design/ home. Engine-agnostic. Answers "contribute UX via PRs". NOT yet sprinted.
-  16-4-design-tokens-dtcg-style-dictionary: backlog # promote shared/theme tokens to portable DTCG JSON + Style Dictionary generating tokens.generated.ts; keep catalogue/statusBar/TAILWIND_* hand-authored. Engine-agnostic. NOT yet sprinted.
-  16-5-component-gallery-storybook-chromatic: backlog # web Storybook (react-native-web) + Chromatic (free OSS) for visual component PR review. BLOCKED BY 16-1 (styling engine). NOT yet sprinted.
-  16-6-stand-up-penpot-design-space: backlog # FOLLOW-UP (requested): open no-seat-limit Penpot as ideation surface; repo stays canonical. TRIGGER: real visual designers want in. NOT yet sprinted.
+  epic-16: in-progress # Sprint 16 — Platform & Tech-Debt Clear-Out (planned 2026-06-11)
+  16-1-migrate-nativewind-to-unistyles: ready-for-dev # Sprint 16 Wave 2. Refined 2026-06-11: INCREMENTAL migration (feature batches) w/ big-bang fallback gated by the Task-2 coexistence spike; Unistyles v3.x (New Arch confirmed: newArchEnabled true, RN 0.83.6); atomic release (AC7). Migrate 31 className files NativeWind/Tailwind → react-native-unistyles, shared/theme preserved. UNBLOCKS 16-5.
+  16-2-implement-logger-sentry-wrapper: ready-for-dev # Sprint 16 Wave 3. Refined 2026-06-11: FULL Sentry now (npx @sentry/wizard -i reactNative --saas --org andrea-pacino --project react-native); keep info/warn/error API (__DEV__-gate info/warn, prod Sentry.captureException in error); PII scrub via beforeSend (GDPR); migrate ~30 console.* files incl core/privacy/consent-logger.ts; add no-console ESLint rule. (Was wrongly 'done' earlier today — corrected.)
+  16-3-design-contribution-workflow: ready-for-dev # Sprint 16 Wave 3 (engine-agnostic). Refined 2026-06-11: story-vs-no-story fast-path CONFIRMED (token/visual polish → no story via design label; new component/screen/behavior → story). design-in-code: CONTRIBUTING-DESIGN.md + design issue template + PR-conventions design-label exemption + Figma node-ID demotion + docs/design/ home.
+  16-4-design-tokens-dtcg-style-dictionary: ready-for-dev # Sprint 16 Wave 3 (engine-agnostic). Refined 2026-06-11: COMMIT tokens.generated.ts (+ tokens:check drift guard); MVP = colors + spacing/layout primitives (typography tuple + sync-tokens DEFERRED); DTCG JSON under tokens/. Keep catalogue/statusBar/TAILWIND_* + tuple/interpolation hand-authored; all public exports byte-stable.
+  16-5-component-gallery-storybook-chromatic: ready-for-dev # Sprint 16 Wave 4. Refined 2026-06-11: build web Storybook pipeline against Unistyles AFTER 16-1 (no engine-agnostic spike). DEV-GATED on 16-1 done + Chromatic project/token (human prereq). MVP stories: Button/TextField/ToggleSwitch/CardShell → ActionRow/ColorPicker/BottomSheet. Chromatic via path-filtered chromatic.yml (onlyChanged), off the merge critical path.
+  16-6-stand-up-penpot-design-space: backlog # KEPT IN BACKLOG for Sprint 16 (ifero, 2026-06-11) — trigger-gated: open no-seat-limit Penpot only when real visual designers want in. Draft file exists; not committed to Sprint 16.
+  16-7-fix-android-beta-upload-versioncode: ready-for-dev # 2026-06-11: CI tech-debt — Android RC alpha upload fails "Version code 1 has already been used" (prebuild regenerates build.gradle versionCode=1). Refined 2026-06-11 w/ ifero: versionCode from GITHUB_RUN_NUMBER plumbed via new app.config.ts (prod offset band to avoid cross-workflow collision); release signingConfig fix kept in scope; also fix prod lane + cicd.md doc. Diagnosed from CI run 27338428755.
+  16-8-fix-cloud-sync-cold-open-race: ready-for-dev # 2026-06-11: bug (filed as tech debt per ifero) — cloud sync fails on every cold open, recovers on manual pull. Confirmed w/ ifero (signed-in; pull-to-refresh works; banner "Cloud sync failed. Pull to retry.") → autoTriggeredRef latch race is root cause (useCloudSync.ts:108-121). Fix: latch-on-success (root) + network-ready gate + retryWithBackoff (defense-in-depth). Refined → ready-for-dev 2026-06-11.
   epic-16-retrospective: optional
 
   # Epic 17: Apple Wallet Pass Support — FEASIBILITY-FIRST

--- a/docs/sprint-artifacts/stories/16-1-migrate-nativewind-to-unistyles.md
+++ b/docs/sprint-artifacts/stories/16-1-migrate-nativewind-to-unistyles.md
@@ -1,6 +1,6 @@
 # Story 16.1: Migrate Styling Engine — NativeWind → Unistyles [Enabling]
 
-Status: drafted
+Status: ready-for-dev
 
 ## Story
 
@@ -42,7 +42,7 @@ This story migrates the styling mechanism to **react-native-unistyles (v3.x)**, 
 
 ### AC4: NativeWind fully removed
 
-- [ ] `nativewind` + `tailwindcss` removed from package.json
+- [ ] `nativewind` + `tailwindcss` + `prettier-plugin-tailwindcss` removed from package.json
 - [ ] `tailwind.config.js`, `global.css`, `nativewind-env.d.ts` deleted
 - [ ] NativeWind references removed from `babel.config.js` and `metro.config.js`
 - [ ] `global.css` import removed from the app entrypoint
@@ -101,12 +101,14 @@ This story migrates the styling mechanism to **react-native-unistyles (v3.x)**, 
 
 ## Dev Notes
 
-### Open Decisions (resolve during refinement → ready-for-dev)
+### Resolved Decisions (2026-06-11, refinement)
 
-1. **Migration approach** — recommend **incremental** (batch by feature, brief coexistence) over big-bang. _Owner: Winston._
-2. **Unistyles version** — confirm v3.x (New Arch / Nitro Modules) vs a 2.x line. v3 recommended given Expo 55 New Arch default.
-3. **Plugin coexistence** — verify NativeWind + Unistyles babel plugins don't conflict mid-migration (validated in Task 2 spike). If they do, migration becomes big-bang.
-4. **Scope split — DECIDED (2026-06-04): do NOT split.** Stays one atomic story. Rationale: solo dev (no parallel-work or independent-review benefit), and the migration must ship all-or-nothing to avoid a half-baked state where NativeWind and Unistyles both reach users (see AC7). Internal dev may still proceed in safe per-feature batches/commits for rollback, but the story is "done" — and released — only when AC3 + AC4 + AC5 hold together.
+1. **Migration approach — INCREMENTAL with a big-bang fallback.** Migrate feature-by-feature (cards → auth → settings → onboarding → sync indicators → shared) in rollback-safe commits. **Gated by the Task 2 spike:** if the NativeWind + Unistyles babel plugins cannot coexist mid-migration, fall back to a single big-bang migration. Ships atomically either way (AC7). _Owner: Winston._
+2. **Unistyles version — v3.x (confirmed).** New Architecture prerequisite verified in-repo: `app.json` `newArchEnabled: true`, RN 0.83.6, Expo ^55.0.19. v3 (Nitro Modules) is correct; no 2.x line.
+3. **Plugin coexistence — empirical, decided by the Task 2 spike** (not a pre-decision). The spike outcome selects incremental (coexistence OK) vs big-bang (conflict).
+4. **Scope split — NO (decided 2026-06-04).** One atomic story; released only when AC3 + AC4 + AC5 hold together (AC7). Internal per-feature batches/commits allowed for rollback safety.
+
+_Repo survey (2026-06-11) confirmed the Key Facts below: 31 `className` files, NativeWind 4.2.1 / tailwindcss ^3.4.0 / `prettier-plugin-tailwindcss` present, `react-native-unistyles` NOT yet installed, `shared/theme` tokens intact, New Arch on._
 
 ### Key Facts (measured 2026-06-04)
 

--- a/docs/sprint-artifacts/stories/16-2-implement-logger-sentry-wrapper.md
+++ b/docs/sprint-artifacts/stories/16-2-implement-logger-sentry-wrapper.md
@@ -1,6 +1,6 @@
 # Story 16.2: Implement logger/Sentry wrapper and migrate console.\* call sites
 
-Status: drafted
+Status: ready-for-dev
 
 ## Story
 
@@ -13,7 +13,7 @@ so that production error reporting actually fires and logging is consistent acro
 Surfaced during **Story 9.2** code review (2026-06-07). `docs/project_context.md` (Error Handling → Logging) and `CONTRIBUTING.md` prescribe a `logger` wrapper with `Sentry.captureException` in production instead of `console.*`. Current state (verified 2026-06-08):
 
 - A **minimal `logger` stub already exists** at `core/utils/logger.ts` (added 2026-03-28, exported from the `core/utils` barrel). It exposes `info` / `warn` / `error` but only **forwards directly to `console.*`** — no `__DEV__` gating and no Sentry routing.
-- Adoption is **partial**: only a couple of `core/` call sites use it (`core/sync/retry.ts`, `core/schemas/index.ts`). **~65 `console.*` call sites** remain across `features/`, `core/`, `shared/`, `app/` (excluding tests) — e.g. `features/settings/screens/SettingsScreen.tsx`, `features/settings/hooks/useImportData.ts`, `features/cards/hooks/useTrackCardUsage.ts`, `useDeleteCard.ts`, `useToggleFavorite.ts`, `features/cards/components/CardDetails.tsx`.
+- Adoption is **partial**: only a couple of `core/` call sites use it (`core/sync/retry.ts`, `core/schemas/index.ts`). **~30 files with `console.*`** remain (verified 2026-06-11; the earlier "~65" was an occurrence estimate) across `features/`, `core/`, `shared/`, `app/` (excluding tests) — e.g. `features/settings/screens/SettingsScreen.tsx`, `features/settings/hooks/useImportData.ts`, `features/cards/hooks/useTrackCardUsage.ts`, `useDeleteCard.ts`, `useToggleFavorite.ts`, `features/cards/components/CardDetails.tsx`.
 - **Net effect: production errors are never captured by Sentry** — the stub's `error` just calls `console.error`.
 
 This is a pre-existing, codebase-wide convention divergence — not introduced by any single feature story — so it should be fixed project-wide in one change.
@@ -22,35 +22,35 @@ _Part of Epic 16 — Platform & Tech Debt (standing tech-debt bucket; see also S
 
 ## Acceptance Criteria
 
-1. The `logger` module (`core/utils/logger.ts`, exported from `core/utils`) is hardened to provide `log` / `warn` / `error`:
-   - `log` / `warn` are dev-only (gated on `__DEV__`).
+1. The `logger` module (`core/utils/logger.ts`, exported from `core/utils`) is hardened, **keeping its current `info` / `warn` / `error` API** (no rename):
+   - `info` / `warn` are dev-only (gated on `__DEV__`).
    - `error` always logs and, in production (`!__DEV__`), calls `Sentry.captureException`.
-2. Sentry is initialised appropriately per environment, or the wrapper degrades gracefully if Sentry isn't configured — and never leaks PII / card data (GDPR — see privacy rules).
-3. All `console.error` / `console.log` / `console.warn` call sites in `features/`, `core/`, `shared/`, and `app/` are migrated to the wrapper (excluding intentional build/dev tooling under `scripts/`).
+2. **Sentry is installed and initialised** (decision 2026-06-11: full Sentry now) via `npx @sentry/wizard@latest -i reactNative --saas --org andrea-pacino --project react-native`, configured per environment (dev vs prod), and **never leaks PII / card data** (GDPR — scrub via `beforeSend` before transmit). Done = a thrown error in a prod build reaches the Sentry project (`andrea-pacino/react-native`).
+3. All `console.*` call sites (~30 files, verified 2026-06-11) in `features/`, `core/`, `shared/`, and `app/` are migrated to the wrapper — **including `core/privacy/consent-logger.ts`** (verify its consent-audit behaviour is preserved) — excluding build/dev tooling under `scripts/`.
 4. Tests that currently assert on `console.error` (e.g. `useTrackCardUsage.test.ts`, `useToggleFavorite.test.ts`, `useDeleteCard.test.ts`) are updated to assert on the wrapper.
 5. ESLint enforces the convention (e.g. `no-console`, allowing only the wrapper) so it cannot regress.
 6. `yarn lint`, `yarn typecheck`, `yarn test` all pass; coverage threshold maintained.
 
 ## Tasks / Subtasks
 
-- [ ] Harden `core/utils/logger.ts` (already exported from `core/utils`): add `__DEV__` gating for `log`/`warn` and prod `Sentry.captureException` in `error`. Reconcile the API (`log` vs the stub's current `info`).
-- [ ] Decide on / wire Sentry init (confirm `@sentry/react-native` dependency, env config, PII scrubbing) — or a graceful no-op if Sentry is deferred.
-- [ ] Migrate the ~65 `console.*` call sites across `features/`, `core/`, `shared/`, `app/` to the wrapper.
+- [ ] Harden `core/utils/logger.ts` (keep the `info`/`warn`/`error` API): `__DEV__`-gate `info`/`warn`; `error` always logs and calls `Sentry.captureException` in prod.
+- [ ] Install + wire Sentry: run `npx @sentry/wizard@latest -i reactNative --saas --org andrea-pacino --project react-native`; configure per-env init + a `beforeSend` PII/card-data scrub; prebuild + `pod install` (repo CocoaPods workaround).
+- [ ] Migrate the ~30 `console.*` files across `features/`, `core/`, `shared/`, `app/` to the wrapper — including `core/privacy/consent-logger.ts`.
 - [ ] Update tests that assert on `console.*` to target the wrapper.
 - [ ] Add/enable an ESLint `no-console` rule (wrapper-allowed); fix violations.
 - [ ] Run all quality gates.
 
 ## Dev Notes
 
-### Open Decisions (resolve during refinement → ready-for-dev)
+### Resolved Decisions (2026-06-11, refinement with ifero)
 
-- [ ] Confirm Sentry is the chosen provider + how it's initialised per environment (dev/prod).
-- [ ] Confirm the exact logger API surface and the ESLint enforcement approach. The existing stub exposes `info`/`warn`/`error`; AC1 proposes `log`/`warn`/`error` — decide whether to rename `info`→`log` (and migrate the existing `logger.*` adopters) or keep `info`.
-- [ ] Confirm PII-scrubbing requirements (no card data / PII to Sentry — GDPR).
-- [ ] Confirm whether `@sentry/*` is already a dependency; if not, installing it is part of this story.
-- [ ] Decide whether `core/privacy/consent-logger.ts` (a separate domain logger that also calls `console.warn` directly) is in scope for migration.
+- **Sentry — full adoption now.** Install via `npx @sentry/wizard@latest -i reactNative --saas --org andrea-pacino --project react-native` (SaaS org `andrea-pacino`, project `react-native`). Initialise per environment with **real prod capture**. `@sentry/*` is **not** a dependency today — the wizard adds it (native dep → prebuild + `pod install`).
+- **Logger API — keep `info` / `warn` / `error`** (no rename to `log`). Zero churn for the 2 existing adopters; just harden behaviour. _(Supersedes the original AC1 `log/warn/error` proposal.)_
+- **PII scrubbing — required (GDPR).** No card data / PII to Sentry; scrub event payloads (`beforeSend`) before transmit.
+- **`consent-logger.ts` — in scope.** Migrate it through the wrapper too; verify its consent-audit behaviour is preserved.
+- **ESLint `no-console` — add it** (wrapper-allowed) so the convention can't regress.
 
-> Acceptance Criteria above are a **draft** pending these decisions.
+_Repo survey (2026-06-11): `logger.ts` is a console-forwarding stub (`info`/`warn`/`error`); ~30 files use `console.*` (non-test); adopters = `core/schemas/index.ts`, `core/sync/retry.ts`; no `no-console` rule configured yet._
 
 ### References
 

--- a/docs/sprint-artifacts/stories/16-3-design-contribution-workflow.md
+++ b/docs/sprint-artifacts/stories/16-3-design-contribution-workflow.md
@@ -1,10 +1,12 @@
 # Story 16.3: Establish a design-in-code contribution workflow (docs + GitHub scaffolding)
 
-Status: backlog
+Status: ready-for-dev
 
 Epic: 16 — Platform & Tech Debt
 
 ## Story
+
+<!-- Status: ready-for-dev (refined 2026-06-11) -->
 
 As a maintainer of an open-source project,
 I want a documented, PR-based path for anyone to propose UX/UI changes against the git repo,
@@ -52,8 +54,10 @@ Sibling stories: 16-4 (token source), 16-5 (Storybook/Chromatic preview — bloc
 - Engine-agnostic: unaffected by 16-1 (NativeWind → Unistyles).
 - Reviewer-preview wording should link to 16-5 deliverables and degrade gracefully until 16-5 lands.
 
-## Definition of Ready (before moving to ready-for-dev)
+## Definition of Ready (resolved 2026-06-11)
 
-- [ ] Confirm the `design` GitHub label is (or will be) created.
-- [ ] Confirm the `docs/design/` location and structure.
-- [ ] Confirm the story-vs-no-story policy wording with the maintainer.
+- [x] `design` GitHub label — created during dev via `gh label create design` (AC4).
+- [x] `docs/design/` location + structure confirmed — `docs/design/` with `wireframes/`, `flows/`, and a `README.md` index (AC7); existing `docs/ux-designs/` + `docs/ux-design-specification.md` unchanged.
+- [x] **Story-vs-no-story policy — CONFIRMED (ifero, 2026-06-11):** token / visual polish with NO behavior change → no story (use the `design`-label fast-path); new screen / component / behavior → story required (normal spec-first flow). Narrow exemption, per AC1's decision table.
+
+> Refinement note: two PR-template files exist (`.github/PULL_REQUEST_TEMPLATE.md` + `.github/pull_request_template.md`) — dev should reconcile/confirm the canonical one before applying AC5.

--- a/docs/sprint-artifacts/stories/16-4-design-tokens-dtcg-style-dictionary.md
+++ b/docs/sprint-artifacts/stories/16-4-design-tokens-dtcg-style-dictionary.md
@@ -1,6 +1,6 @@
 # Story 16.4: Make design tokens a portable DTCG source via Style Dictionary
 
-Status: backlog
+Status: ready-for-dev
 
 Epic: 16 — Platform & Tech Debt
 
@@ -27,7 +27,7 @@ Engine-agnostic: 16-1 (NativeWind → Unistyles) explicitly preserves `shared/th
 
 ## Acceptance Criteria (draft — refine before dev)
 
-1. `tokens/*.json` (DTCG format) authored for **primitives + semantic color maps only**: `PRIMARY_COLORS`, `NEUTRAL_COLORS`, `CARD_COLORS`, the color members of `LIGHT_THEME`/`DARK_THEME` (excluding `statusBar`), `SPACING`, `TOUCH_TARGET`, `LAYOUT`, and `TYPOGRAPHY`.
+1. `tokens/*.json` (DTCG format) authored for **primitives + semantic color maps** (MVP): `PRIMARY_COLORS`, `NEUTRAL_COLORS`, `CARD_COLORS`, the color members of `LIGHT_THEME`/`DARK_THEME` (excluding `statusBar`), `SPACING`, `TOUCH_TARGET`, and `LAYOUT`. **`TYPOGRAPHY` (tuple) and `sync-tokens` are DEFERRED** to a follow-up (MVP scope decision 2026-06-11).
 2. A Style Dictionary config generates `shared/theme/tokens.generated.ts` with the exact existing constant names and `as const` shapes. The generated file is **committed** (not gitignored) so Metro / Jest / tsc need no build step.
 3. `colors.ts` / `spacing.ts` / `typography.ts` are refactored to **import primitives** from `tokens.generated.ts` while keeping hand-authored: `BRAND_COLORS`/`getBrandColor`, `statusBar`, all `TAILWIND_*` exports, the typography tuple builder, the spacing interpolation. All **public named exports remain byte-stable**, so `tailwind.config.js`, every `@/shared/theme` consumer, and `colors.contrast.test.ts` work unchanged.
 4. `tokens:build` and `tokens:check` scripts exist; `tokens:check` regenerates to a temp location and `git diff --exit-code`s against the committed file (drift guard), mirroring the existing `check:catalogue-generated` pattern. A CI step runs `tokens:check`.
@@ -48,8 +48,8 @@ Engine-agnostic: 16-1 (NativeWind → Unistyles) explicitly preserves `shared/th
 - Honest framing: the JSON-canonical layer is what delivers "versioned, PR-able tokens"; the Style Dictionary codegen is the _means_, and its real payoff is **portability** (DTCG is readable by Figma Tokens / other tools), not necessity — the tokens already work in TS today.
 - Do **not** move `BRAND_COLORS`/`getBrandColor`/`statusBar` into JSON; they are catalogue-runtime / non-token data.
 
-## Definition of Ready (before moving to ready-for-dev)
+## Definition of Ready (resolved 2026-06-11)
 
-- [ ] Confirm the decision to commit `tokens.generated.ts` (recommended) vs gitignore + build step.
-- [ ] Confirm the MVP token scope (colors + spacing first; typography/sync deferred).
-- [ ] Confirm the DTCG file layout under `tokens/`.
+- [x] **Commit `shared/theme/tokens.generated.ts`** (CONFIRMED, recommended) — not gitignored; a `tokens:check` CI guard `git diff`s a fresh regen for drift (mirrors `check:catalogue-generated`). No build step needed for Metro/Jest/tsc.
+- [x] **MVP scope = colors + spacing/layout primitives** (CONFIRMED). The **typography tuple + `sync-tokens` are DEFERRED** to a follow-up (fiddliest custom Style Dictionary formats) — see AC1.
+- [x] **DTCG layout** confirmed — token JSON under `tokens/*.json` (e.g. `tokens/color.json`, `tokens/spacing.json`).

--- a/docs/sprint-artifacts/stories/16-5-component-gallery-storybook-chromatic.md
+++ b/docs/sprint-artifacts/stories/16-5-component-gallery-storybook-chromatic.md
@@ -1,6 +1,6 @@
 # Story 16.5: Component preview gallery — Storybook + Chromatic [Blocked by 16-1]
 
-Status: backlog
+Status: ready-for-dev
 
 Epic: 16 — Platform & Tech Debt
 
@@ -16,7 +16,7 @@ The component library lives at `shared/components/ui/` (Button, TextField, Actio
 
 **Dependency — `Blocked by: 16-1`.** Story 16-1 replaces NativeWind with react-native-unistyles and deletes `tailwind.config.js` / `global.css`. The web rendering pipeline for Storybook is styling-engine-specific, so we build it **once, against the final engine** to avoid throwaway plumbing.
 
-> Open decision (resolve at refinement, per maintainer): if 16-1 is deprioritized, build engine-agnostically by theming stories via the existing `ThemeProvider` + inline-style path (preserved by both engines), treating class-based layout as best-effort. This needs a **spike** first: Unistyles-3's native (Nitro/C++, New-Architecture) core rendering under `react-native-web` is unproven.
+> ✅ **Resolved 2026-06-11:** 16-1 (Unistyles migration) is committed to this sprint (Wave 2), so 16-5 takes the **"build once, against the final engine"** path — build the web Storybook pipeline against **Unistyles** after 16-1 lands. The engine-agnostic fallback (ThemeProvider + inline styles + Unistyles-on-web spike) is **not** taken. 16-5 is **dev-gated on 16-1** (Sprint 16 Wave 4).
 
 Components theme via `useTheme()` + inline styles (`className` is mostly layout), which is the safety net: colors/typography render correctly through the ThemeProvider even if class-based styling is imperfect on web.
 
@@ -30,7 +30,7 @@ Components theme via `useTheme()` + inline styles (`className` is mostly layout)
 
 ## Tasks / Subtasks (draft)
 
-- [ ] (Gate) Confirm 16-1 done, or take the refinement decision + run the Unistyles-on-web spike.
+- [ ] (Gate) 16-1 (Unistyles) must be `done` before 16-5 dev starts (Wave 4) — build the web pipeline against Unistyles. (No engine-agnostic spike: 16-1 is committed this sprint.)
 - [ ] Add Storybook + `react-native-web` deps; create `.storybook/main.ts` + `preview.tsx` (theme/i18n/SafeArea decorators; reproduce the styling pipeline on web).
 - [ ] Seed the 4 MVP stories; verify the light/dark toggle renders.
 - [ ] Add the 3 dependency-heavier stories (vector-icon fonts, i18n, Modal-on-web).
@@ -43,11 +43,13 @@ Components theme via `useTheme()` + inline styles (`className` is mostly layout)
 - Reanimated / gesture-handler are **not** used by the `ui/` primitives, so they are not a blocker for the MVP.
 - Keep the Chromatic workflow off the critical merge path; path-filter to UI surfaces only.
 
-## Definition of Ready (before moving to ready-for-dev)
+## Definition of Ready (resolved 2026-06-11)
 
-- [ ] 16-1 is `done` — OR a refinement decision to build engine-agnostically, with the Unistyles-on-web spike passed.
-- [ ] Chromatic project created and `CHROMATIC_PROJECT_TOKEN` available as a GitHub secret.
-- [ ] MVP story scope confirmed.
+- [x] **Engine path decided — build after 16-1 (Unistyles).** 16-1 is committed to Sprint 16 (Wave 2); 16-5 is **dev-gated** on it (Wave 4). No engine-agnostic spike.
+- [ ] **Chromatic project + `CHROMATIC_PROJECT_TOKEN` — human prerequisite (ifero):** create the free OSS Chromatic project and add the GitHub secret before the `chromatic.yml` step can run. (Spec is ready regardless.)
+- [x] **MVP story scope confirmed** — Button / TextField / ToggleSwitch / CardShell first; then ActionRow / ColorPicker / BottomSheet.
+
+> Status: spec is `ready-for-dev`, but **dev must not start until 16-1 is `done`** (Wave 4) and the Chromatic token exists.
 
 ## Blocks
 

--- a/docs/sprint-artifacts/stories/16-7-fix-android-beta-upload-versioncode.md
+++ b/docs/sprint-artifacts/stories/16-7-fix-android-beta-upload-versioncode.md
@@ -1,0 +1,94 @@
+# Story 16.7: Fix Android beta (alpha) Play upload — authoritative versionCode through Expo prebuild
+
+Status: ready-for-dev
+
+## Story
+
+As a maintainer/release engineer,
+I want the Android RC build to upload to Google Play with a correct, monotonically-incrementing versionCode (and to be signed with the real upload key),
+so that the beta (alpha-track) upload stops failing with "Version code 1 has already been used" and RC builds reliably reach testers.
+
+## Context
+
+Surfaced 2026-06-11 when the Android beta upload failed on RC tag `v1.0.0-rc.12`. Diagnosed by a dev investigation **confirmed against the real CI log** (run `27338428755`, job "Build Android Alpha (RC)"):
+
+- The **iOS** upload in the same run **succeeded**; only Android failed.
+- The Gradle build **succeeded** and the AAB **was signed** — the failure is purely the `upload_to_play_store` (fastlane `supply`) step:
+
+  > `Google Api Error: Invalid request - Version code 1 has already been used.`
+
+- **Root cause:** the `:beta` lane queries the Play alpha track for the max versionCode and passes `-Pandroid.injected.version.code=<max+1>` to `gradle bundleRelease` (`fastlane/Fastfile:221-230`). But `expo prebuild --platform android` **regenerates `android/app/build.gradle` with `versionCode 1` on every run**, because `app.json` has no `android.versionCode` (`app.json:28-34`). `supply` reads the versionCode from the **AAB's `AndroidManifest.xml`** (always `1`), not the Gradle property — so every RC re-submits `1` and Play rejects the duplicate. The computed `max+1` is silently discarded.
+- `android/` is **gitignored** (`.gitignore:46`) and only exists because prebuild regenerates it — so the fix **must** live in Expo config (`app.json`/`app.config.*`) or a config plugin, never by hand-editing the generated native files.
+
+**Secondary defects found in the same release path (now in scope — see Refined Decisions):**
+
+- The generated release buildType uses `signingConfigs.debug` (`android/app/build.gradle:115`); it works **only** because CI injects `android.injected.signing.*` (`beta-releases.yml:89-92`, `Fastfile:231-234`) — fragile if those props are ever absent.
+- The **production** lane has the identical latent versionCode bug (`fastlane/Fastfile:251-281`, `.github/workflows/store-upload.yml:62-112`).
+- The lane targets the **alpha** track (`Fastfile:240`), but `docs/cicd.md:165` calls it the "beta track" — doc inaccuracy.
+
+_Part of Epic 16 — Platform & Tech Debt (standing tech-debt bucket; see also 16-1, 16-2)._
+
+## Acceptance Criteria
+
+1. **Given** an Android RC build (`v*.*.*-rc.*`) **When** the pipeline uploads to Google Play **Then** it succeeds without "Version code N has already been used" — the AAB's manifest versionCode is strictly greater than the highest versionCode already present across **all** Play tracks.
+2. The versionCode is set in a way that **survives `expo prebuild`** — via a new `app.config.ts` that extends `app.json` and reads the value from an env var — **not** by editing the gitignored `android/app/build.gradle`, and **not** relying solely on `-Pandroid.injected.version.code`.
+3. The versionCode is sourced from **`GITHUB_RUN_NUMBER`** (mirroring the iOS lanes at `Fastfile:101,164`), with a local fallback (e.g. Unix timestamp). Because the alpha/beta and production uploads run in **separate workflows** with independent run counters, the **production** lane uses a distinct offset band (e.g. `GITHUB_RUN_NUMBER + 1_000_000`) so the two can never collide in Play's single shared versionCode space. The scheme's starting values must exceed all existing codes across alpha/internal/production (one-time check — see Prerequisites).
+4. The **same versionCode fix is applied to the production lane** (`upload_release` / `store-upload.yml`) so it doesn't hit the identical failure on first use.
+5. The release build is **signed with the real upload key**, not the debug-keystore fallback: a prebuild-safe `release` `signingConfig` (e.g. an Expo config plugin) is in place, and reliance on `android.injected.signing.*` as the _sole, unguarded_ path is removed (or, at minimum, the lane explicitly guards that all signing env vars are present before building).
+6. `docs/cicd.md` is corrected to reflect the actual target track (**alpha**), removing the "beta" mislabel. No lane/track rename.
+7. A successful RC upload to the Play alpha (testing) track is demonstrated — or, if Play access is unavailable in-session, the versionCode embedded in the locally-built AAB is verified (`aapt dump badging` / bundletool) to be the expected `GITHUB_RUN_NUMBER` value.
+
+## Tasks / Subtasks
+
+- [ ] Add `app.config.ts` that imports/extends `app.json` and sets `android.versionCode` from `process.env.ANDROID_VERSION_CODE` (fallback for local builds); verify `expo prebuild` bakes it into the generated `android/app/build.gradle versionCode` (AC: 1, 2, 3)
+- [ ] Alpha/beta lane (`Fastfile:216-248`): export `ANDROID_VERSION_CODE = GITHUB_RUN_NUMBER` (local fallback `Time.now.to_i`); stop treating `-Pandroid.injected.version.code` as the manifest source (AC: 3)
+- [ ] Production lane (`Fastfile:251-281` / `store-upload.yml`): export `ANDROID_VERSION_CODE = GITHUB_RUN_NUMBER + <offset>` so it can't collide with the beta workflow's counter (AC: 3, 4)
+- [ ] One-time check: confirm the run-number-derived codes exceed the highest existing versionCode across alpha/internal/production; set a base offset if needed (AC: 1)
+- [ ] Verify the built AAB manifest versionCode (`aapt dump badging` / bundletool) before upload (AC: 7)
+- [ ] Wire a real `release` `signingConfig` via an Expo config plugin so release builds use the upload key (not the debug fallback); or add an explicit guard that all `ANDROID_*` signing env vars are set before `bundleRelease` (AC: 5)
+- [ ] Correct `docs/cicd.md:165` (alpha vs "beta") (AC: 6)
+- [ ] Re-run the RC pipeline (or a dry run) to confirm a clean upload; capture the versionCode used (AC: 7)
+
+## Dev Notes
+
+### Refined Decisions (2026-06-11, with ifero)
+
+1. **versionCode source = `GITHUB_RUN_NUMBER`** (consistency with the iOS lanes, `Fastfile:101,164`), plumbed via the new `app.config.ts`. Production uses an **offset band** (e.g. `+1_000_000`) to avoid cross-workflow collision. _(Chosen over Play-max+1 and a timestamp scheme.)_
+2. **Mechanism = add `app.config.ts`** extending `app.json` — `app.json` is static and can't compute a versionCode; `expo-build-properties` is present (`app.json:59`) but does **not** set versionCode.
+3. **AC5 signing fix kept IN this story** — it's the same release path and would bite the very next upload once versionCode is fixed.
+4. **alpha/"beta" → fix the doc only** (`docs/cicd.md:165`); no lane/track rename (tight scope).
+5. **Play App Signing → human prerequisite** (verify enrolment; see Prerequisites) — doesn't block dev start.
+
+### Prerequisites (human / out-of-repo — verify before first upload attempt)
+
+- Confirm **Play App Signing** enrolment; if enrolled, `release.keystore` must be the **upload** key Play expects (relevant before re-attempting the upload).
+- Confirm the highest existing versionCode across alpha/internal/production so the `GITHUB_RUN_NUMBER` scheme's starting value clears them (add a base offset if a prior code is unexpectedly high).
+- Sanity: service account retains "Release to testing tracks" permission (auth already worked in run `27338428755`).
+
+### References
+
+- Investigation (2026-06-11): failing CI run `27338428755`, job "Build Android Alpha (RC)", tag `v1.0.0-rc.12`. Error: `Google Api Error: Invalid request - Version code 1 has already been used.`
+- Alpha/beta lane: `fastlane/Fastfile:216-248`; version logic `:221-230`; signing inject `:231-234`.
+- Production lane (same bugs): `fastlane/Fastfile:251-281`; `.github/workflows/store-upload.yml:62-112`.
+- iOS run-number precedent: `fastlane/Fastfile:101,164`. Android adhoc commit-hash scheme (not chosen): `Fastfile:199-201`.
+- Workflow: `.github/workflows/beta-releases.yml:58-108` (android-beta job); keystore decode `:89-92`.
+- Generated native (gitignored): `android/app/build.gradle:95` (`versionCode 1`), `:115` (debug signingConfig), `:112-122`.
+- Expo config: `app.json:28-34` (no `android.versionCode`); `app.json:59` (`expo-build-properties` present, not for versionCode); no `app.config.*` and no `eas.json` today.
+- Doc inaccuracy: `docs/cicd.md:165` ("beta" vs actual alpha).
+
+### Project Structure Notes
+
+- New file: `app.config.ts` (extends `app.json`; sets dynamic `android.versionCode`). `app.json` stays as the static base.
+- `android/` is **gitignored** (`.gitignore:46`) and regenerated by `expo prebuild` — the fix MUST live in Expo config / a config plugin, never in the generated files.
+- This is a **CI/release-pipeline + Expo-config** change — no app feature code, no RN/TS feature-layer impact.
+- Part of Epic 16 — Platform & Tech Debt (standing bucket; see 16-1, 16-2).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/docs/sprint-artifacts/stories/16-8-fix-cloud-sync-cold-open-race.md
+++ b/docs/sprint-artifacts/stories/16-8-fix-cloud-sync-cold-open-race.md
@@ -1,0 +1,97 @@
+# Story 16.8: Fix cloud sync failure on cold app open (auth/network readiness race)
+
+Status: ready-for-dev
+
+## Story
+
+As a signed-in user,
+I want cloud sync to reliably run when I open the app — and to recover on its own if the first attempt hits a cold-start hiccup,
+so that my cards sync on every open instead of failing until I manually pull-to-refresh.
+
+## Context
+
+Surfaced 2026-06-11: cloud sync fails on (nearly) **every cold app open** on the phone; a manual pull-to-refresh then succeeds. Diagnosed by a read-only dev investigation, grounded in the code:
+
+- The naive theory (Supabase client/session "not created yet") is **refuted**: `app/_layout.tsx` `initializeApp()` awaits `getSession()` (`:303`) and gates the UI behind `isReady` (`:378-389`), so the client + session are ready **before** the home screen (and the sync hooks) mount.
+- **Real root cause — `useCloudSync`'s auto-trigger** (`shared/hooks/useCloudSync.ts:108-115`) fires the first sync as soon as `authState === 'authenticated'`, but:
+  1. **No network gate** — unlike `useAutoSync` (`useAutoSync.ts:53`), it never checks `isConnected/isInternetReachable`; and `useNetworkStatus` **optimistically** initializes connectivity to `true` (`useNetworkStatus.ts:15-18`), so sync can fire before connectivity is verified.
+  2. **No retry/backoff** — `useCloudSync` has none (vs `useAutoSync`'s `retryWithBackoff`, `useAutoSync.ts:80-103`); a single transient cold-start failure surfaces immediately as the error banner _"Cloud sync failed. Pull to retry."_ (`useCloudSync.ts:85-87` → `app/index.tsx:43` → `SyncStatusContainer.tsx:35,54`).
+  3. **Latches on failure** — `autoTriggeredRef` is set `true` on the **first** attempt regardless of outcome (`useCloudSync.ts:113`) and only resets when `authState === 'guest'` (`:117-121`). So once the first cold-start fire fails, it **never auto-retries** — matching "fails every open, works on manual pull."
+
+### Confirmed 2026-06-11 (ifero)
+
+- **Signed in to an account** → the auto-trigger path is active (not a guest-mode red herring).
+- Failure banner is **"Cloud sync failed. Pull to retry."** → the catch path at `useCloudSync.ts:85-87`.
+- **Manual pull-to-refresh succeeds right after** → the client/session/network are healthy by then; this **pins the `autoTriggeredRef` latch race as the dominant cause**. Pull-to-refresh calls `forceSync`, which bypasses the latch and works.
+
+➡️ **Therefore: latch-on-success is the root-cause fix.** The network gate + retry/backoff are **defense-in-depth** — they stop the first-fire failure from happening at all, but even if one slips through, latch-on-success guarantees auto-recovery instead of a stuck failure.
+
+- Scope note: at-rest encryption does **not** gate sync (no crypto in the sync path). The only "keys" involved are the Supabase env credentials and the restored session JWT.
+
+Related (note for awareness): two `useCloudSync` instances auto-fire on the home screen (`app/index.tsx:33` + `features/cards/components/CardList.tsx:60`) → a double sync on open.
+
+_Part of Epic 16 — Platform & Tech Debt (standing tech-debt bucket; see 16-1, 16-2, 16-7). Filed here (vs an Epic 7 bugfix) per ifero, 2026-06-11._
+
+## Acceptance Criteria
+
+1. **(Root cause)** **Given** the auto-trigger latch (`autoTriggeredRef`) **Then** it is set only after a **successful** sync — a failed first attempt does **not** permanently suppress auto-sync for the session (it re-attempts on the next auth/network event).
+2. **Given** the first cold-start auto-sync fails transiently **When** connectivity returns or the next auth/network event fires **Then** sync **auto-retries and recovers** — reaching the same healthy state a manual pull-to-refresh reaches today, with no manual action required.
+3. **Given** I am signed in and open the app **When** the first auto-sync runs **Then** it fires only once the session is restored **and** the network is confirmed reachable (not on the optimistic default).
+4. **Given** a transient sync failure on open **Then** it is retried with backoff (matching `useAutoSync`) **before** surfacing the "Cloud sync failed. Pull to retry." banner — a single cold-start hiccup does not show a hard error.
+5. **Given** these changes **Then** happy-path and **guest-mode** behaviour are preserved (no auto-sync for guests), the manual pull-to-refresh (`forceSync`) path is unchanged, and sync-status indicators still reflect real state.
+6. Tests cover: latch-only-on-success (failed first fire still auto-retries); auto-recovery after a simulated cold-start failure; auto-sync gated on auth **and** network ready; no regression to guest/happy-path. `yarn lint` / `typecheck` / `test` pass; coverage maintained.
+
+## Tasks / Subtasks
+
+- [ ] **(Root cause)** Move the `autoTriggeredRef` latch to the **success** path so failures auto-recover on the next auth/network event (`useCloudSync.ts:113-121`) (AC: 1, 2)
+- [ ] Gate the `useCloudSync` auto-trigger on network-ready in addition to auth — consume `useNetworkStatus`, require `isConnected && isInternetReachable` (`useCloudSync.ts:108-115`) (AC: 3)
+- [ ] Wrap the sync run in `retryWithBackoff` (already used by `useAutoSync.ts:80-103`) (AC: 4)
+- [ ] _(Consider — decide in dev)_ consume the session from `onAuthStateChange`/`useAuthState` instead of a fresh `getSession()` snapshot to remove snapshot-vs-restore skew (`useAuthState.ts:42-44`, `useCloudSync.ts:43`) (AC: 2, 3)
+- [ ] _(Consider — decide in dev)_ de-dupe the two `useCloudSync` auto-fire instances (`app/index.tsx:33`, `features/cards/components/CardList.tsx:60`) so only one runs on open (AC: 5)
+- [ ] Tests: latch-on-success, cold-start failure → auto-recovery, auth+network gating, guest/happy-path unchanged (AC: 6)
+- [ ] Verify on a real cold open (signed-in) that sync succeeds without a manual pull (AC: 1, 2)
+
+## Dev Notes
+
+### Confirmed symptom (2026-06-11, ifero)
+
+| Question                       | Answer                                  | Implication                                                    |
+| ------------------------------ | --------------------------------------- | -------------------------------------------------------------- |
+| Signed-in vs guest?            | **Signed in**                           | Auto-trigger path is active; diagnosis holds.                  |
+| Pull-to-refresh after failure? | **Succeeds**                            | Underlying sync is healthy → **latch race is the root cause**. |
+| Error text?                    | **"Cloud sync failed. Pull to retry."** | Generic catch path (`useCloudSync.ts:85-87`).                  |
+
+Two minor symptom details remain unconfirmed but are **non-blocking** (the dual-mode fix covers them): network type at open (Wi-Fi vs cellular) and first-launch-after-reinstall vs warm relaunch.
+
+### Recommended Fix (from investigation)
+
+The smallest, cleanest change is confined to **`shared/hooks/useCloudSync.ts`**: **latch-on-success (root)** + network gate + `retryWithBackoff` (defense-in-depth). The two "consider" items (session-from-`onAuthStateChange`, de-dupe instances) are robustness nice-to-haves — keep here or split during dev.
+
+### References
+
+- Investigation (2026-06-11): cloud sync fails on cold open; manual pull recovers. Confirmed signed-in + pull-recovers + generic banner.
+- Trigger + bug: `shared/hooks/useCloudSync.ts:108-115` (auto-fire), `:113-121` (latch), `:42-87` (run + error surface).
+- Gated/retried sibling to mirror: `shared/hooks/useAutoSync.ts:49-103` (network check `:53`, `retryWithBackoff` `:80`).
+- Optimistic network default: `shared/hooks/useNetworkStatus.ts:15-18`.
+- Startup/readiness: `app/_layout.tsx:267-314` (`getSession()` `:303`; `isReady` gate `:378-389`).
+- Auth state (deferred `INITIAL_SESSION`): `shared/supabase/useAuthState.ts:25-49` (`:42-44`).
+- Client (SecureStore adapter; corrupt-chunk → null): `shared/supabase/client.ts:197-219` (`:66,72`).
+- Error surfaced: `app/index.tsx:43`, `shared/components/SyncStatusContainer.tsx:35,54`.
+- Double-fire: `app/index.tsx:33`, `features/cards/components/CardList.tsx:60`.
+- Not a fresh regression: `useCloudSync.ts` last changed in Story 7.2; `useAuthState` (`e3541ff`) widened the loading window by relying solely on the deferred `INITIAL_SESSION`.
+
+### Project Structure Notes
+
+- Primary change: `shared/hooks/useCloudSync.ts` (+ its test). Optional: `shared/supabase/useAuthState.ts` (expose session), `app/index.tsx` / `features/cards/components/CardList.tsx` (de-dupe).
+- No schema or native change; contained to the sync-hook layer.
+- Part of Epic 16 — Platform & Tech Debt (see 16-1, 16-2, 16-7).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List


### PR DESCRIPTION
Sprint-planning + retrospective artifacts. **Docs only — no app code.**

## Epic 9 / Sprint 15
- Reconcile Sprint 15 scope (add 9-5, 9-6a, 9-6); close Sprint 15 + Epic 9 (done).
- Epic 9 retrospective: `docs/sprint-artifacts/epic-9-retro-2026-06-10.md`.
- Archive Sprint 14 retro to its own doc (preserved on the last_sprint roll).

## Sprint 16 — Platform & Tech-Debt Clear-Out (Epic 16)
- Roll Sprint 15 -> `last_sprint`; Sprint 16 -> `current_sprint` (**in-progress**); 7 stories, 4 waves.
- New stories: **16-7** (Android alpha upload versionCode fix), **16-8** (cloud sync cold-open race fix).
- Refined **16-1..16-5** -> `ready-for-dev`; corrected **16-2** (was wrongly `done`); **16-6** kept trigger-gated in backlog.

## Human prerequisites (gate dev of their story, not this PR)
- 16-2: run `@sentry/wizard` (`andrea-pacino/react-native`)
- 16-5: create Chromatic project + `CHROMATIC_PROJECT_TOKEN` secret
- 16-7: confirm Play App Signing enrolment
- 16-3: `gh label create design`

🤖 Generated with [Claude Code](https://claude.com/claude-code)