### PR TITLE
chore(ci): upload Sentry symbols on builds + fix missing-token failures

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -28,6 +28,10 @@ jobs:
       ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/release.keystore
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN is inlined into the JS bundle at build time (runtime reporting);
+      # auth token lets the build upload source maps + ProGuard mappings for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -45,6 +49,20 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        # sentry.gradle uploads source maps + ProGuard mappings via sentry-cli,
+        # which needs SENTRY_AUTH_TOKEN. Skip cleanly when the token is absent
+        # (SENTRY_DISABLE_AUTO_UPLOAD is honoured by sentry.gradle) so the build
+        # never fails for a missing token; enable upload when it is present.
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Prebuild native projects
         run: npx expo prebuild --platform android
       - name: Decode Android release keystore

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -22,6 +22,10 @@ jobs:
       APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN inlined into the bundle at build time; auth token enables
+      # source-map + native-symbol upload for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -43,6 +47,16 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Prebuild native projects
         run: npx expo prebuild --platform ios
       - name: Generate watchOS catalogue (Brands.swift)
@@ -67,6 +81,10 @@ jobs:
       ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/release.keystore
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN inlined into the bundle at build time; auth token enables
+      # source-map + native-symbol upload for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -84,6 +102,16 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Compute Android versionCode
         # Authoritative versionCode baked into the AAB manifest by app.config.ts
         # during prebuild. Alpha/beta band = the workflow run number.

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -31,6 +31,10 @@ jobs:
       APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN is inlined into the JS bundle at build time (runtime reporting);
+      # auth token lets the build phases upload source maps + dSYMs for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -52,6 +56,21 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        # The Sentry Expo plugin adds build phases that upload source maps + dSYMs
+        # via sentry-cli, which requires SENTRY_AUTH_TOKEN. Without it the phases
+        # fail the build, so skip upload cleanly when the token is absent
+        # (SENTRY_DISABLE_AUTO_UPLOAD is honoured by the iOS scripts and Android
+        # sentry.gradle alike) and enable it when present.
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Prebuild native projects
         run: npx expo prebuild --platform ios
       - name: Generate watchOS catalogue (Brands.swift)

--- a/.github/workflows/store-upload.yml
+++ b/.github/workflows/store-upload.yml
@@ -26,6 +26,10 @@ jobs:
       APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN inlined into the bundle at build time; auth token enables
+      # source-map + native-symbol upload for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -47,6 +51,16 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Prebuild native projects
         run: npx expo prebuild --platform ios
       - name: Generate watchOS catalogue (Brands.swift)
@@ -71,6 +85,10 @@ jobs:
       ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/release.keystore
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
       EXPO_PUBLIC_SUPABASE_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}
+      # Sentry: DSN inlined into the bundle at build time; auth token enables
+      # source-map + native-symbol upload for symbolication.
+      EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_COLORS: '1'
 
@@ -88,6 +106,16 @@ jobs:
         run: |
           echo "EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}" >> .env
           echo "EXPO_PUBLIC_SUPABASE_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_KEY }}" >> .env
+          echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}" >> .env
+      - name: Configure Sentry symbol upload
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN present — Sentry symbol/source-map upload enabled."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+          else
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry symbol upload (crashes won't be symbolicated). Add the SENTRY_AUTH_TOKEN repo secret to enable."
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+          fi
       - name: Compute Android versionCode
         # Authoritative versionCode baked into the AAB manifest by app.config.ts
         # during prebuild. Production band = run number + 1,000,000 so this


### PR DESCRIPTION
## Problem

Merging #139 (Sentry integration) added the `@sentry/react-native` Expo config plugin, which injects `sentry-cli` build phases that upload source maps + native symbols. Those phases **require `SENTRY_AUTH_TOKEN`** and **fail the build when it's absent** — breaking both native builds on `main`:

- **iOS AdHoc** — failed at `'Upload Debug Symbols to Sentry'` / source-map phase (`Auth token is required`).
- **Android AdHoc** — failed at `:app:…_SentryUpload` (`Auth token is required`).

Separately, the build workflows only wrote `EXPO_PUBLIC_SUPABASE_*` to `.env`, so production builds shipped with **no Sentry DSN** — meaning Sentry would be a no-op at runtime even once symbol upload worked. (`EXPO_PUBLIC_*` vars are inlined into the JS bundle at build time.)

## Fix (applied to `ios-release`, `android-release`, `beta-releases`, `store-upload`)

1. **Pass `SENTRY_AUTH_TOKEN`** (repo secret) to every native-build job → enables source-map + symbol upload (iOS dSYMs, Android ProGuard mappings).
2. **Bake `EXPO_PUBLIC_SENTRY_DSN`** (repo secret) into the build `.env` → production builds actually report to Sentry.
3. **Guard:** a `Configure Sentry symbol upload` step sets `SENTRY_DISABLE_AUTO_UPLOAD=true` when the token is absent, so builds **skip upload cleanly instead of failing** (honoured by the iOS scripts *and* `sentry.gradle`). With the token present, upload runs.

## ⚠️ Required: add two repo secrets
- `SENTRY_AUTH_TOKEN` — a Sentry **org auth token** with `project:releases` + `project:write` scope (Sentry → Settings → Auth Tokens).
- `EXPO_PUBLIC_SENTRY_DSN` — the project DSN (`andrea-pacino/react-native`).

Until they're added, builds **pass** but symbols/source maps are not uploaded (a CI warning is emitted) and the shipped app has no DSN.

## Validation
Both adhoc workflows dispatched on this branch (no token present → upload-skip path) to confirm they go green. Links in the checks below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)