### PR TITLE
docs(story): add story 16.10 offline cold-start hang fix, ready-for-dev (Story 16.10)

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -149,7 +149,32 @@ current_sprint:
     as a tech-debt story (ifero's call); drafted by Bob, refined by Winston (Architect)
     → ready-for-dev 2026-06-18 (AD-2 cards→auth exception ratified).
 
-next_sprint: null
+next_sprint:
+  # PROPOSED by PM (John) 2026-07-09 from 3 stakeholder-reported bugs. NOT finalized:
+  # needs an SM sprint-planning pass (waves/capacity) + SM/Architect story refinement
+  # (all three stories are `drafted`) to reach ready-for-dev before dev starts.
+  number: 17
+  name: 'Sprint 17: Reliability & Auth Hardening'
+  goal: 'Fix the remaining stakeholder-reported defects: stop deleted cards resurrecting on cloud sync (16-11), and rebuild password management on OTP — reset-via-OTP (6-19) and change-password-in-Settings (6-20). NOTE: 16-10 (offline cold-start hang, CRITICAL) is fast-tracked as a HOTFIX ahead of this sprint.'
+  status: proposed
+  epics: [16, 6]
+  stories:
+    - 16-11-fix-card-deletion-cloud-resurrection
+    - 6-19-password-reset-via-otp
+    - 6-20-change-password-in-settings
+  waves:
+    wave_1:
+      stories: [16-11]
+      note: 'Data-integrity sync fix (independent). Cousin of 16-8 — coordinate with its useCloudSync singleton store.'
+    wave_2:
+      stories: [6-19, 6-20]
+      note: 'Auth/OTP thread: 6-19 builds the recovery-OTP plumbing (send/verify wrappers + OTP UX); 6-20 reuses it for the Settings change-password entry. Sequence 6-19 -> 6-20.'
+  notes: |
+    Proposed 2026-07-09 by PM (John) from ifero's bug report. Not yet finalized —
+    run SM sprint-planning to confirm sequencing/capacity, and SM/Architect refinement
+    to lift 16-11 / 6-19 / 6-20 from `drafted` -> ready-for-dev.
+    HOTFIX: 16-10 (offline cold-start hang) is CRITICAL — it breaks the offline-first
+    promise — and is to be picked up immediately, ahead of Sprint 17, per ifero.
 
 development_status:
   # ============================================
@@ -237,6 +262,8 @@ development_status:
   6-17-design-otp-verification-screen: done # Sprint 13 — Figma OTP Verification page approved by Ifero on 2026-04-28; design dependency cleared
   6-18-otp-email-verification-flow: done # Sprint 13 — OTP verify flow implemented, full validation green, dev+QA subagent reviews approved on 2026-04-29
   6-18a-otp-verification-followup: done # Sprint 14 — stakeholder-approved follow-up bugfix for 8-digit OTP + single-field redesign from Story 6.18
+  6-19-password-reset-via-otp: drafted # 2026-07-09: forgot-password reset is dead — resetPasswordForEmail deep-link (auth.ts:322, redirect :318) never lands: app scheme not in Supabase redirect allowlist (config.toml:154,156 = 127.0.0.1 only), warm-start deep links unhandled (getInitialURL cold-start only, no url listener), no recovery email template (config.toml:230-232 confirmation only). Replace with OTP recovery: send code -> verifyOtp(type:recovery) -> new-password screen -> updateUser(password). Reuses proven verifyEmailOtp/VerifyEmailScreen 8-digit OTP (auth.ts:212-241). Supersedes 6-8's un-verified deep-link. Drafted by PM (John); Sprint 17. Needs SM/Architect refinement -> ready-for-dev.
+  6-20-change-password-in-settings: drafted # 2026-07-09: signed-in users have NO way to change password (Settings AccountSection.tsx exposes only Sign Out :66 + Delete Account :74). Add OTP-gated Change Password: Settings row -> OTP -> new password -> updateUser(password) (auth.ts:345 exists). Shares recovery-OTP plumbing with 6-19 (sequence after it). Drafted by PM (John); Sprint 17. Needs refinement -> ready-for-dev.
   epic-6-retrospective: optional
 
   # Epic 7: Cloud Synchronization
@@ -373,6 +400,8 @@ development_status:
   16-7-fix-android-beta-upload-versioncode: done # 2026-06-13: impl complete on feature/16-7-fix-android-beta-upload-versioncode — env-driven versionCode via app.config.ts (verified into merged manifest), workflow Compute steps, Fastfile signing-env guard, cicd.md track fix. dev code-review (sonnet, 3 rounds → 0) + QA (sonnet, 2 rounds → 0) APPROVED; 1535 tests green. Awaiting stakeholder approval to commit/PR. [2026-06-11 refine] CI tech-debt — Android RC alpha upload fails "Version code 1 has already been used" (prebuild regenerates build.gradle versionCode=1). Refined 2026-06-11 w/ ifero: versionCode from GITHUB_RUN_NUMBER plumbed via new app.config.ts (prod offset band to avoid cross-workflow collision); release signingConfig fix kept in scope; also fix prod lane + cicd.md doc. Diagnosed from CI run 27338428755.
   16-8-fix-cloud-sync-cold-open-race: done # 2026-06-13: latch-on-success + network gate + retryWithBackoff on feature/16-8-fix-cloud-sync-cold-open-race. Code review + QA review approved by sonnet subagents. Awaiting stakeholder approval. — bug (filed as tech debt per ifero) — cloud sync fails on every cold open, recovers on manual pull. Confirmed w/ ifero (signed-in; pull-to-refresh works; banner "Cloud sync failed. Pull to retry.") → autoTriggeredRef latch race is root cause (useCloudSync.ts:108-121). Fix: latch-on-success (root) + network-ready gate + retryWithBackoff (defense-in-depth). Refined → ready-for-dev 2026-06-11.
   16-9-relocate-app-screens-to-features: ready-for-dev # 2026-06-18: relocate fat screens out of app/ routing layer into features/cards/screens/ (index/card[id]/card[id]edit/barcode[id]) + implement the documented-but-MISSING route-file lint rule (root cause) + remove app/__tests__ (co-locate). Drafted by Bob (SM); REFINED → ready-for-dev by Winston (Architect) same day. AD-6: sequence BEFORE 16-2 (both touch console.* in the 3 card screens). AD-2 (cards→auth exception for HomeScreen's guest/migration banners) RATIFIED by ifero 2026-06-18. Pure refactor, engine-agnostic.
+  16-10-fix-offline-cold-start-hang: ready-for-dev # 2026-07-09 HOTFIX (CRITICAL — breaks offline-first): offline cold start hangs on the loading spinner forever. Root cause app/_layout.tsx:311 — unguarded await auth.getSession() (autoRefreshToken:true -> network token refresh, no timeout/abort); offline it never settles so setIsReady(true) (:317) never fires. REFINED -> ready-for-dev by Winston (Architect) 2026-07-09: AD-16-10-01 locks the fix — gate boot on the synchronous INITIAL_SESSION (useAuthState.ts:37-44, storage-only, no network) + safety timeout; REJECTED the getSession-timeout option (bounds but doesn't remove the hang). Preserves the no-flash welcome-gate intent (app/_layout.tsx:306-309); also fixes latent isAuthenticated staleness. Drafted by PM (John); FAST-TRACKED as a hotfix ahead of Sprint 17. Sibling of 16-8.
+  16-11-fix-card-deletion-cloud-resurrection: drafted # 2026-07-09: signed-in card delete resurrects on the next useCloudSync (pull-to-refresh/cold-open). Two uncoordinated sync engines: useCloudSync is deletion-blind — full-fetch + mergeCards re-adds cloud-only cards (cloud-sync.ts:337-340,:591) + re-upload (useCloudSync.ts:155-181); never drains syncPendingDeletions (deletion-tracker.ts:3) nor calls deleteCardFromCloud (cards.ts:75-87). Deletion-aware processPendingSync (useAutoSync -> sync-trigger.ts:128-142) loses the race. Purpose-built mergeWithDeletions (cloud-sync.ts:470-523) is DEAD CODE. Cousin of 16-8. Drafted by PM (John); Sprint 17. Needs refinement -> ready-for-dev.
   epic-16-retrospective: optional
 
   # Epic 17: Apple Wallet Pass Support — FEASIBILITY-FIRST

--- a/docs/sprint-artifacts/stories/16-10-fix-offline-cold-start-hang.md
+++ b/docs/sprint-artifacts/stories/16-10-fix-offline-cold-start-hang.md
@@ -1,0 +1,102 @@
+# Story 16.10: Fix offline cold-start hang (app stuck on the loading spinner with no connectivity)
+
+Status: ready-for-dev
+
+## Story
+
+As a user opening the app with no internet connection,
+I want the app to boot into my cached cards instead of hanging on the loading spinner,
+so that the "offline-first" promise actually holds — my loyalty cards are usable in a shop with no signal.
+
+## Context
+
+Reported by ifero 2026-07-09: with the device **offline**, the app gets stuck on the loading screen **indefinitely**. This directly contradicts the offline-first product promise (the headline reason this product exists). Highest-priority defect of the batch.
+
+Root cause, confirmed in code (dev investigation + Architect verification, 2026-07-09):
+
+- **Boot gate:** `RootLayout` renders a hand-rolled `ActivityIndicator` while `!isReady` (`app/_layout.tsx:386-392`); the real UI mounts only when `isReady === true` (`:394-398`). `isReady` starts `false` (`:271`) and flips at exactly one place — `setIsReady(true)` (`:317`) — reached only if `initializeApp()` (`:276-322`) runs to completion. There is no `expo-splash-screen` gating; this spinner **is** the "loading screen".
+- **The hang — an unguarded network await:** `initializeApp()` awaits `getSupabaseClient().auth.getSession()` (`app/_layout.tsx:311`). The client is `autoRefreshToken: true`, `persistSession: true` over a SecureStore adapter (`shared/supabase/client.ts:198-204`). On a cold launch with a **persisted-but-expired** token, `getSession()` performs a **network** token refresh; offline it never settles (no response + auth-js retry/backoff). There is **no timeout / `Promise.race` / `AbortController`** on this path.
+- **Why this specific await exists (must be preserved):** the comment at `:306-309` states it resolves auth state _before_ any UI renders "so the welcome gate (`RootLayoutContent`) never flashes or bounces an already signed-in user." The result feeds `RootLayoutContent isAuthenticated={isAuthenticated}` (`:396`). So the fix must still know auth state before first paint — just without the network.
+- **The `try/catch` is a false safety net:** `:313-315` only catches a _rejected_ promise; it cannot rescue a promise that never resolves.
+- **The offline-safe answer already exists in-repo:** `shared/supabase/useAuthState.ts:37-44` subscribes to `onAuthStateChange`; Supabase fires `INITIAL_SESSION` **synchronously from storage** (its comment: "sets the initial state without needing a separate getSession() call") — same persisted session, **no network**.
+- **Secondary risk (verify):** `Updates.checkForUpdateAsync()` / `fetchUpdateAsync()` / `reloadAsync()` (`:279-291`) are network calls, but `Updates.isEnabled`-gated and `try/catch`-wrapped; they normally reject fast offline. Confirm they can't stall the gate.
+
+_Part of Epic 16 — Platform & Tech Debt (reliability bucket; see 16-7, 16-8). Filed here per the 16-8 precedent. **Fast-tracked as a HOTFIX ahead of Sprint 17 per ifero (2026-07-09).**_
+
+## Architecture Decision — AD-16-10-01: gate boot on the synchronous `INITIAL_SESSION`, not a network `getSession()`
+
+**Decision.** Remove the blocking `await …auth.getSession()` from the boot path (`app/_layout.tsx:311`). Derive the initial `isAuthenticated` value from Supabase's **synchronous `INITIAL_SESSION`** event (via `onAuthStateChange`, storage-only — no network), and flip `isReady` when that first event arrives. Add a short **safety timeout** so `isReady` is guaranteed to flip to a safe default (`guest`) even if the listener never fires.
+
+**Rejected — Option B (bound the `getSession()` await with a timeout/abort).** It _bounds_ the hang but doesn't _remove_ it: every offline cold-start with an expired token still burns the full timeout as spinner time. That's a slower brick, not a fix. Option A makes offline boot **instant**.
+
+**Why Option A is the lean choice:**
+
+- **Reuses a proven, boring mechanism.** `useAuthState.ts` (Story 6.9) already relies on the synchronous `INITIAL_SESSION` — same SecureStore adapter, same persisted session, no network. We wire in an existing pattern, not a new one.
+- **Preserves the no-flash intent.** Gating `isReady` on receipt of the first `INITIAL_SESSION` keeps auth state known before first paint (so signed-in users aren't bounced to welcome) — but the gate is now a storage read, not a network refresh.
+- **Fixes a latent staleness bug.** `isAuthenticated` is currently a one-shot boot snapshot; sourcing it from `onAuthStateChange` makes it reactive for the app's lifetime.
+- **Token refresh still happens — lazily.** With `autoRefreshToken: true`, the network refresh runs in the background once the app is up and connectivity allows, driven by the same listener. Boot no longer waits on it.
+
+**Constraints for the dev (must hold):**
+
+- `setIsReady(true)` must be reachable with **zero** network dependency (test: gate flips with NetInfo offline + a persisted, expired token).
+- Keep the `dbError` path (`:377-384`) and guest-session bootstrap (`:296-304`) intact.
+- Verify `Updates.checkForUpdateAsync()` (`:279-291`) cannot stall boot offline; bound it if it can.
+
+**Recommended structure (dev discretion):** extract the boot auth-gate into a small, unit-testable hook in `shared/` (extend/compose `useAuthState`) so `app/_layout.tsx` stays thin and the offline-boot behaviour is testable in isolation. Scoped as **AD-16-10-01** (story-local; no `docs/architecture.md` change — it's a boot-sequencing fix within an existing pattern).
+
+## Acceptance Criteria
+
+1. **Given** the device is offline (airplane mode / no reachable network) **and** the app is cold-started, **When** the app boots, **Then** it reaches the main UI and displays locally-cached cards within a bounded time — it **never** hangs on the loading spinner.
+2. **Given** a persisted-but-expired session and no connectivity, **When** boot runs, **Then** **no blocking network call gates `isReady`** — the initial auth state is derived from the synchronous `INITIAL_SESSION` (storage-only) and `setIsReady(true)` is reached without a network round-trip.
+3. **Given** the app booted offline, **When** connectivity returns, **Then** the session recovers via the background auto-refresh / `onAuthStateChange` (no manual restart) and sync resumes.
+4. **Given** a signed-in user (online **or** offline), **When** the app boots, **Then** they are **not** flashed/bounced onto the welcome screen — auth state is known before first paint (the no-flash guarantee is preserved).
+5. **Given** the online happy path, **Then** boot behaviour and perceived latency are unchanged; **and** guest mode offline boots to cached cards (no regression).
+6. **Given** the defensive safety timeout, **When** (hypothetically) the `INITIAL_SESSION` listener never fires, **Then** `isReady` still flips to a safe default (guest) within the timeout — the app can never hang.
+7. Tests cover: offline-cold-start reaches `isReady` with **no network** (expired token, NetInfo offline); no-flash for signed-in; connectivity-return recovery; safety-timeout fallback; online happy path unchanged. `yarn lint` / `typecheck` / `test` pass; coverage maintained.
+
+## Tasks / Subtasks
+
+- [ ] Replace the blocking `getSession()` await (`app/_layout.tsx:306-315`) with an `onAuthStateChange` subscription that sets `isAuthenticated` from the first (`INITIAL_SESSION`) event and flips `isReady` on receipt — reuse the pattern in `useAuthState.ts:37-44` (AC: 1, 2, 4)
+- [ ] Add a safety timeout that flips `isReady` (default guest) if no auth event arrives within N ms (AC: 6)
+- [ ] Ensure background token refresh + reactive auth updates keep `isAuthenticated` correct after connectivity returns (AC: 3)
+- [ ] Verify `Updates.checkForUpdateAsync()` (`:279-291`) can't stall boot offline; bound it if needed (AC: 1)
+- [ ] Preserve the `dbError` path (`:377-384`), the guest-session bootstrap (`:296-304`), and the no-flash welcome gate (AC: 4, 5)
+- [ ] _(Recommended)_ extract the boot auth-gate into a testable `shared/` hook so `_layout.tsx` stays thin (AC: 7)
+- [ ] Tests: offline-cold-start (expired token, NetInfo offline) reaches `isReady` with no network; no-flash signed-in; connectivity-return recovery; safety-timeout fallback; online happy path (AC: 7)
+- [ ] Device smoke test: airplane-mode cold start shows cached cards (AC: 1) — stakeholder (ifero) on RC build.
+
+## Dev Notes
+
+### Locked approach
+
+See **AD-16-10-01** above — Option A (gate on synchronous `INITIAL_SESSION` + safety timeout). No open fork remains for the dev; the "how" is decided. Keep the change tight (`app/_layout.tsx` + an optional `shared/` boot-auth hook). No schema or native change.
+
+### References
+
+- Boot gate + hang: `app/_layout.tsx:269-399` — `:311` hung await, `:306-315` intent + false-safety `try/catch`, `:317` `setIsReady(true)`, `:386-392` spinner, `:396` `isAuthenticated` prop, `:279-291` `Updates.*`.
+- Client auth config: `shared/supabase/client.ts:197-204` (`autoRefreshToken: true` `:200`, `detectSessionInUrl: false` `:201`).
+- Offline-safe pattern to reuse: `shared/supabase/useAuthState.ts:25-49` (`:37-44` `INITIAL_SESSION`).
+- Connectivity (available if needed): `shared/hooks/useNetworkStatus.ts` (optimistic default → confirmed via `NetInfo.fetch()`).
+- Local DB init (ruled out — local-only): `core/database/database.ts:9,50`.
+- Coding rules: `docs/project_context.md`, `AGENTS.md` (layer boundaries `app → features → shared → core`; `const` arrows; `logger` wrapper).
+
+### Definition of Ready
+
+- [x] Status, Story, Context present
+- [x] Root cause confirmed in code (file:line)
+- [x] Architecture decision locked (AD-16-10-01) — no open fix fork
+- [x] Acceptance criteria testable and mapped to tasks
+- [x] Scope tight (single file + optional `shared/` hook; no schema/native change)
+- [x] Test strategy defined (offline boot / no-flash / recovery / safety timeout)
+- [ ] Device smoke test owner assigned (ifero, on next RC) — post-merge validation, not a dev blocker
+
+### Project Structure Notes
+
+Primary change confined to `app/_layout.tsx` (optionally a small `shared/` boot-auth hook). No schema or native change. Part of Epic 16 — Platform & Tech Debt. Sibling to 16-8.
+
+## Change Log
+
+| Date       | Change                                                                                                                                                                                                                                                                                                                     | Author              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| 2026-07-09 | Story drafted from stakeholder bug report (offline infinite loading). Status → drafted.                                                                                                                                                                                                                                    | John (PM)           |
+| 2026-07-09 | Refined to ready-for-dev: locked the boot-gate fix as **AD-16-10-01** (gate on synchronous `INITIAL_SESSION`; rejected the `getSession()`-timeout option), made the no-flash guarantee + safety-timeout explicit ACs, rewrote tasks to the locked approach, added the Definition of Ready. Status drafted → ready-for-dev. | Winston (Architect) |


### PR DESCRIPTION
## Summary

Adds **Story 16.10 — Fix offline cold-start hang** at `ready-for-dev`, and locks the fix approach as an Architecture Decision (AD-16-10-01). This is a **spec/docs** change (story file + sprint board); the code fix lands separately via `dev-story` on a `fix/` branch.

🔴 **Hotfix priority** — the bug bricks the app when offline, directly breaking the offline-first promise. Fast-tracked ahead of Sprint 17 (per @ifero).

## The bug

Offline cold start hangs on the loading spinner indefinitely. Root cause: the boot gate awaits `getSupabaseClient().auth.getSession()` (`app/_layout.tsx:311`); with `autoRefreshToken: true` and a persisted-but-expired token that triggers a **network** token refresh with no timeout — offline it never settles, so `setIsReady(true)` (`:317`) never fires and the `!isReady` spinner (`:386-392`) stays up forever. The surrounding `try/catch` only catches a rejected promise, not one that never resolves.

## Decision — AD-16-10-01

Gate boot on Supabase's **synchronous `INITIAL_SESSION`** event (storage-only, no network — the pattern already shipped in `useAuthState.ts:37-44`) plus a safety timeout.

**Rejected:** bounding the `getSession()` await with a timeout/abort — it *bounds* the hang but still burns spinner-time on every offline cold start. The `INITIAL_SESSION` gate makes offline boot **instant**, preserves the no-flash welcome-gate intent (`app/_layout.tsx:306-309`), and fixes a latent `isAuthenticated` staleness bug (one-shot snapshot → reactive).

## Definition of Ready

- [x] Root cause confirmed in code (file:line)
- [x] Architecture decision locked (AD-16-10-01) — no open fix fork for the dev
- [x] Testable acceptance criteria mapped to tasks
- [x] Scope tight (single file + optional `shared/` hook; no schema/native change)
- [x] Test strategy defined (offline boot / no-flash / recovery / safety-timeout)
- [ ] Device smoke test owner = @ifero, post-merge (validation gate, not a dev blocker)

## Scope & testing

**Docs-only** — no `.ts/.tsx` touched, so no unit tests change in this PR (implementation + tests follow in the `fix/` PR). The board (`sprint-status.yaml`) also registers the queued Sprint 17 drafts (`16-11`, `6-19`, `6-20`) and the proposed Sprint 17.

**Story spec:** `docs/sprint-artifacts/stories/16-10-fix-offline-cold-start-hang.md`

---

_Spec authored by the PM/Architect BMAD agents (John → Winston). Please don't merge if you'd rather the implementation ride in the same PR — say so and we'll fold the `fix/` work in._
