### PR TITLE
chore(test): co-locate tests and ban __tests__ folders

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check design tokens are in sync
         run: yarn tokens:check
 
+      - name: Check tests are co-located (no __tests__ folders)
+        run: yarn check:no-tests-folders
+
       - name: Run tests (with coverage)
         run: yarn test:coverage --watchAll=false --runInBand
 

--- a/features/auth/CreateAccountScreen.test.tsx
+++ b/features/auth/CreateAccountScreen.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import CreateAccountScreen from '../CreateAccountScreen';
+import CreateAccountScreen from './CreateAccountScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })

--- a/features/auth/ForgotPasswordScreen.test.tsx
+++ b/features/auth/ForgotPasswordScreen.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import ForgotPasswordScreen from '../ForgotPasswordScreen';
+import ForgotPasswordScreen from './ForgotPasswordScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })

--- a/features/auth/MigrationBanner.test.tsx
+++ b/features/auth/MigrationBanner.test.tsx
@@ -8,7 +8,7 @@
 import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 
-import MigrationBanner from '../MigrationBanner';
+import MigrationBanner from './MigrationBanner';
 
 // ---------------------------------------------------------------------------
 // Mock theme

--- a/features/auth/ResetPasswordScreen.test.tsx
+++ b/features/auth/ResetPasswordScreen.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import ResetPasswordScreen from '../ResetPasswordScreen';
+import ResetPasswordScreen from './ResetPasswordScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })

--- a/features/auth/SignInScreen.test.tsx
+++ b/features/auth/SignInScreen.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import SignInScreen from '../SignInScreen';
+import SignInScreen from './SignInScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })

--- a/features/auth/VerifyEmailScreen.test.tsx
+++ b/features/auth/VerifyEmailScreen.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import VerifyEmailScreen from '../VerifyEmailScreen';
+import VerifyEmailScreen from './VerifyEmailScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })

--- a/features/auth/components/ErrorBanner.test.tsx
+++ b/features/auth/components/ErrorBanner.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react-native';
 import React from 'react';
 
-import { ErrorBanner } from '../ErrorBanner';
+import { ErrorBanner } from './ErrorBanner';
 
 jest.mock('@/shared/theme', () => ({
   useTheme: () => ({

--- a/features/auth/components/GuestModeBanner.test.tsx
+++ b/features/auth/components/GuestModeBanner.test.tsx
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import { GuestModeBanner } from '../components';
+import { GuestModeBanner } from './GuestModeBanner';
 
 jest.mock('@/shared/theme', () => ({
   useTheme: () => ({

--- a/features/auth/components/PasswordInput.test.tsx
+++ b/features/auth/components/PasswordInput.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
 
-import { PasswordInput } from '../PasswordInput';
+import { PasswordInput } from './PasswordInput';
 
 jest.mock('@/shared/theme', () => ({
   useTheme: () => ({

--- a/features/auth/components/PasswordStrengthIndicator.test.tsx
+++ b/features/auth/components/PasswordStrengthIndicator.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react-native';
 import React from 'react';
 
-import { PasswordStrengthIndicator } from '../PasswordStrengthIndicator';
+import { PasswordStrengthIndicator } from './PasswordStrengthIndicator';
 
 jest.mock('@/shared/theme', () => ({
   useTheme: () => ({

--- a/features/auth/useGuestMigration.test.ts
+++ b/features/auth/useGuestMigration.test.ts
@@ -30,7 +30,7 @@ jest.mock('@/shared/supabase/auth', () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import { useGuestMigration, SUCCESS_BANNER_DELAY } from '../useGuestMigration';
+import { useGuestMigration, SUCCESS_BANNER_DELAY } from './useGuestMigration';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/features/privacy/DataSummaryScreen.test.tsx
+++ b/features/privacy/DataSummaryScreen.test.tsx
@@ -6,7 +6,7 @@
 import { render, screen } from '@testing-library/react-native';
 import React from 'react';
 
-import DataSummaryScreen from '../DataSummaryScreen';
+import DataSummaryScreen from './DataSummaryScreen';
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/features/privacy/PrivacyPolicyScreen.test.tsx
+++ b/features/privacy/PrivacyPolicyScreen.test.tsx
@@ -11,7 +11,7 @@ import { changeAppLanguage } from '@/shared/i18n';
 
 import { PRIVACY_POLICY_VERSION } from '@/assets/legal/privacy-policy';
 
-import PrivacyPolicyScreen from '../PrivacyPolicyScreen';
+import PrivacyPolicyScreen from './PrivacyPolicyScreen';
 
 // Mock useTheme
 jest.mock('@/shared/theme', () => ({

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chromatic": "chromatic",
     "tokens:build": "node scripts/build-tokens.mjs",
     "tokens:check": "node scripts/build-tokens.mjs --check",
+    "check:no-tests-folders": "node scripts/check-no-tests-folders.mjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/scripts/check-no-tests-folders.mjs
+++ b/scripts/check-no-tests-folders.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Enforces the project convention that tests are co-located next to their
+// subject as `*.test.ts(x)` — never grouped under a `__tests__/` folder.
+//
+// Fails (non-zero) if any tracked `__tests__/` directory exists outside the
+// allowlist. Inspects `git ls-files` only, so untracked/ignored trees
+// (node_modules, .claude worktrees, coverage) are never scanned.
+//
+// Allowlist: targets/watch/__tests__ holds watchOS contract/tooling tests that
+// are NOT run by the main Jest suite (jest.config.js ignores `targets/watch/`)
+// and are executed by a dedicated CI job that targets them by explicit path
+// (.github/workflows/watchos-tests.yml). They intentionally stay grouped.
+
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const ALLOWLIST = new Set(['targets/watch/__tests__']);
+
+// Every tracked path that contains a `__tests__` segment implies such a dir.
+const tracked = execSync('git ls-files', { encoding: 'utf8' }).split('\n').filter(Boolean);
+
+const offenders = new Set();
+for (const file of tracked) {
+  const parts = file.split('/');
+  const idx = parts.indexOf('__tests__');
+  if (idx === -1) continue;
+  const dir = parts.slice(0, idx + 1).join('/'); // up to and including `__tests__`
+  if (!ALLOWLIST.has(dir)) offenders.add(dir);
+}
+
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+const writeSummary = (md) => {
+  if (!summaryFile) return;
+  try {
+    appendFileSync(summaryFile, md);
+  } catch {
+    /* summary is best-effort */
+  }
+};
+
+if (offenders.size === 0) {
+  console.log('✓ No disallowed __tests__ folders — tests are co-located.');
+  writeSummary('### ✅ No __tests__ folders\n\nAll tests are co-located as `*.test.ts(x)`.\n');
+  process.exit(0);
+}
+
+const list = [...offenders].sort();
+console.log(`✗ Found ${list.length} disallowed __tests__ folder(s):\n`);
+for (const d of list) {
+  console.log(`  • ${d}/`);
+  console.log(`::error::Disallowed __tests__ folder: ${d}/`);
+}
+console.log(
+  '\nCo-locate each test as `<Subject>.test.ts(x)` next to the file it covers.\n' +
+    'If this is intentional watch/native test infra, add it to the ALLOWLIST in\n' +
+    'scripts/check-no-tests-folders.mjs.'
+);
+writeSummary(
+  `### ❌ Disallowed __tests__ folders\n\n` +
+    `Tests must be co-located as \`*.test.ts(x)\`. Found:\n\n` +
+    list.map((d) => `- \`${d}/\``).join('\n') +
+    `\n`
+);
+process.exit(1);

--- a/shared/components/ConsentCheckbox.test.tsx
+++ b/shared/components/ConsentCheckbox.test.tsx
@@ -6,7 +6,7 @@
 import { render, fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
 
-import ConsentCheckbox from '../ConsentCheckbox';
+import ConsentCheckbox from './ConsentCheckbox';
 
 // Mock useTheme
 jest.mock('@/shared/theme', () => ({


### PR DESCRIPTION
## Summary
Repo-wide follow-through on the "tests are co-located, never in `__tests__/`" convention: relocate the remaining `__tests__/`-grouped tests to sit beside their subject, and add a CI guard so the pattern can't silently return.

## ⚠️ Stacked on #149 — merge that first
This PR is **based on the `feature/16-9-relocate-app-screens-to-features` branch (#149)**, not `main`. #149 removes `app/__tests__/`; the new guard only goes green once that folder is gone. Merge order: **#149 → this**. After #149 lands, this auto-retargets to `main` (rebase: `git rebase --onto main feature/16-9-relocate-app-screens-to-features chore/remove-tests-folders`).

## What changed
- **Relocated 14 tests** out of 4 `__tests__/` dirs to co-located `*.test.ts(x)` beside their subject:
  - `features/auth/__tests__/` → `features/auth/` (7 screens + `useGuestMigration`)
  - `features/auth/components/__tests__/` → `features/auth/components/` (3)
  - `features/privacy/__tests__/` → `features/privacy/` (2)
  - `shared/components/__tests__/` → `shared/components/` (1)
  - `GuestModeBanner.test.tsx` moves to `features/auth/components/` (beside its subject), not `features/auth/`.
- **Fixed subject imports** on the move (`../X` → `./X`; `GuestModeBanner` now imports `./GuestModeBanner` directly instead of the `../components` barrel). Git tracked all 14 as renames (95–99% similarity).
- **Added a guard**: `scripts/check-no-tests-folders.mjs` + `yarn check:no-tests-folders`, wired into the CI quality-gates workflow. It fails on any tracked `__tests__/` dir outside the allowlist. Inspects `git ls-files` only (skips `node_modules`/`.claude` worktrees).

## Decisions (confirmed with maintainer)
1. **`targets/watch/__tests__` left as-is** and **allowlisted** in the guard — those are watchOS contract/tooling tests that the main Jest suite ignores (`jest.config.js` ignores `targets/watch/`) and that a dedicated CI job runs by explicit `--testPathPattern` (`watchos-tests.yml`). They don't map 1:1 to a source file, so co-location doesn't apply.
2. **`chore(test):`** with no story — a behavior-preserving test relocation is exempt from the spec-first story requirement (per `pr-conventions`).

## No config changes needed
Jest discovery (`**/*.test.[jt]s?(x)`) and the ESLint test-file overrides key off the `.test.` filename, not the folder — so relocated tests keep their discovery and lint treatment automatically.

## Test results (local, on this branch)
- `yarn check:no-tests-folders`: **green** (negative-tested — correctly fails on a stray `__tests__`)
- `yarn lint` / `yarn typecheck`: **green**
- Full suite: **161 suites / 1675 tests passing**, coverage ≥ 80% (unchanged — pure relocation)
- Pre-commit (lint-staged) and pre-push (typecheck→lint→test) gates passed; no `--no-verify`.
