### PR TITLE
chore(test): order jest moduleNameMapper so SVG imports reach svgMock

### DIFF
--- a/__mocks__/svgMock.js
+++ b/__mocks__/svgMock.js
@@ -1,7 +1,18 @@
 /* global module, require */
 /**
- * SVG mock for Jest — react-native-svg-transformer imports .svg as React components.
- * In tests, render as a simple View with the SVG filename as testID.
+ * SVG mock for Jest — `react-native-svg-transformer` turns `.svg` imports into
+ * React components at runtime, so tests must see a component too, not an asset
+ * object. That is the whole reason this file exists.
+ *
+ * Reached via the `\.svg$` entry in `jest.config.js`'s `moduleNameMapper`, which
+ * MUST stay ahead of the `^@/` alias entry — Jest applies only the first matching
+ * pattern, so putting the alias first silently routed every `@/assets/….svg`
+ * import past this mock and into the asset transformer instead. See the comment
+ * there, and `test/svg-module-resolution.test.tsx`, which pins it.
+ *
+ * Renders a plain `View`, forwarding all props (so `width`/`height`/a11y props
+ * stay assertable) and defaulting `testID` to `svg-mock` when the caller passes
+ * none — pass your own `testID` to target a specific mark.
  */
 const React = require('react');
 const { View } = require('react-native');

--- a/features/cards/components/CatalogueGrid.test.tsx
+++ b/features/cards/components/CatalogueGrid.test.tsx
@@ -63,10 +63,6 @@ jest.mock('@/catalogue/italy.json', () => ({
   ]
 }));
 
-// Mock SVG files for brand logos
-jest.mock('@/assets/images/brands/esselunga.svg', () => 'esselunga-logo');
-jest.mock('@/assets/images/brands/carrefour.svg', () => 'carrefour-logo');
-
 describe('CatalogueGrid', () => {
   const mockRouter = {
     push: jest.fn()

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,10 +9,20 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|react-native-unistyles|react-native-nitro-modules|react-native-edge-to-edge|expo|expo-asset|expo-constants|expo-file-system|expo-font|expo-linking|expo-sqlite|@expo|expo-modules-core|expo-haptics|burnt|zod|@hookform|react-hook-form|@react-native-picker)/)'
   ],
+  // ORDER IS SIGNIFICANT. Jest applies only the FIRST pattern that matches a
+  // request, so `\.svg$` MUST precede the `^@/` alias. With the alias first, an
+  // `@/assets/…foo.svg` import never reached `svgMock.js`: it resolved to the real
+  // file and the react-native preset's asset transformer handed back a plain
+  // `{ testUri }` OBJECT. That is correct for a `.png` consumed as an `<Image>`
+  // source, but wrong for an SVG, which `react-native-svg-transformer` turns into
+  // a React COMPONENT at runtime — so tests silently disagreed with the app. It
+  // also made `BrandLogo`'s `typeof source === 'function'` discriminator
+  // impossible to satisfy from real data, hiding its SVG branch from every test.
+  // `.png` still lands on the alias and still yields an asset object, unchanged.
   moduleNameMapper: {
+    '\\.svg$': '<rootDir>/__mocks__/svgMock.js',
     '^@/(.*)$': '<rootDir>/$1',
-    '^@bwip-js/react-native$': '<rootDir>/__mocks__/@bwip-js/react-native.js',
-    '\\.svg$': '<rootDir>/__mocks__/svgMock.js'
+    '^@bwip-js/react-native$': '<rootDir>/__mocks__/@bwip-js/react-native.js'
   },
   testMatch: ['**/*.test.[jt]s?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '/.claude/', 'babel.config.test.js', 'targets/watch/'],

--- a/test/svg-module-resolution.test.tsx
+++ b/test/svg-module-resolution.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * SVG module resolution — a `jest.config.js` invariant, not a component test.
+ *
+ * `moduleNameMapper` is ordered, and Jest applies only the FIRST pattern that
+ * matches a request. For a long time `'^@/(.*)$'` sat ahead of `'\.svg$'`, so
+ * every `@/assets/….svg` import in the repo — all ~50 brand logos in
+ * `features/cards/utils/brandLogos.ts` — bypassed `__mocks__/svgMock.js`
+ * entirely. It resolved to the real file and the react-native preset's asset
+ * transformer returned a plain `{ testUri }` OBJECT.
+ *
+ * Nothing was red, which is exactly why it survived: it fails only when a test
+ * actually renders one, and then it fails as an opaque "Element type is invalid".
+ * The real damage was quieter. `BrandLogo` picks its branch with
+ * `typeof source === 'function'`, so with every SVG arriving as an object its SVG
+ * branch was unreachable from real data and tests rendered `<Image>` where the app
+ * renders `<SvgLogo>` — the suite and the product disagreed, silently.
+ *
+ * These tests pin the resolution itself rather than any one consumer, because the
+ * failure mode is a one-line reordering of a config file that no component test
+ * would ever point at. There is deliberately a negative case too: `.png` must
+ * KEEP resolving to an asset object, so a future "fix" cannot over-correct and
+ * break every `<Image source={…}>` in the app.
+ */
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import AliasedMark from '@/assets/images/app-icon-variant-aurora.svg';
+import AliasedPng from '@/assets/images/brands/coin.png';
+
+import { getBrandLogo } from '@/features/cards/utils/brandLogos';
+
+import RelativeMark from '../assets/images/app-icon-variant-aurora.svg';
+
+describe('SVG module resolution', () => {
+  it('resolves an @/-aliased .svg to a renderable component, not an asset object', () => {
+    // The regression this whole file exists for. `typeof 'object'` here means the
+    // `\.svg$` mapper has fallen behind the `^@/` alias again.
+    expect(typeof AliasedMark).toBe('function');
+  });
+
+  it('resolves a relative .svg to the same component', () => {
+    // Relative specifiers never matched the alias, so they always worked. Pinned
+    // so the two import styles cannot drift apart again.
+    expect(typeof RelativeMark).toBe('function');
+    expect(RelativeMark).toBe(AliasedMark);
+  });
+
+  it('actually renders, forwarding size and testID props', () => {
+    render(<AliasedMark width={200} height={200} testID="resolution-probe" />);
+
+    const mark = screen.getByTestId('resolution-probe');
+    expect(mark).toHaveProp('width', 200);
+    expect(mark).toHaveProp('height', 200);
+  });
+
+  it('still resolves an @/-aliased .png to an asset object', () => {
+    // The guard against over-correcting: PNGs are consumed as `<Image source>`,
+    // for which the asset object is the CORRECT shape. Only `.svg` changes.
+    expect(typeof AliasedPng).toBe('object');
+  });
+
+  it('lets BrandLogo distinguish an SVG brand from a PNG brand', () => {
+    // The consequence that actually matters in product code: `BrandLogo` branches
+    // on `typeof source === 'function'`. Before the mapper reorder both of these
+    // were objects, so the SVG branch could not be reached from real catalogue
+    // data and the wrong element was rendered in every test that got that far.
+    expect(typeof getBrandLogo('esselunga')).toBe('function');
+    expect(typeof getBrandLogo('coin')).toBe('object');
+  });
+});


### PR DESCRIPTION
## What

`moduleNameMapper` is ordered and Jest applies only the **first** matching pattern, but `'^@/(.*)$'` sat ahead of `'\.svg$'`. Every SVG in this repo is imported as `@/assets/…`, so **none of them ever reached `__mocks__/svgMock.js`** — they resolved to the real file and the react-native preset's asset transformer returned a plain `{ testUri }` object instead of a component.

## Why it mattered more than "the mock is dead code"

Nothing was red, which is exactly why it survived: it only fails when a test actually renders an SVG. The quieter damage was that [`BrandLogo.tsx`](features/cards/components/BrandLogo.tsx) picks its element with `typeof source === 'function'` — so with every SVG arriving as an object, that discriminator **could never be satisfied from real catalogue data**. Tests rendered `<Image>` where the app renders `<SvgLogo>`: the suite and the product disagreed silently. `BrandLogo` has no test file at all.

Two hand-rolled workarounds had already accumulated because of this — `jest.mock('@/assets/.../x.svg', () => 'x-logo')` in `CatalogueGrid.test.tsx` (bare strings standing in for components), and mocking `getBrandLogo` to return `undefined` in the add-card suites.

## Verified empirically, not assumed

The same file imported both ways in one test:

| Import | Result |
|---|---|
| `@/assets/images/…​.svg` | `typeof 'object'` — `{"testUri":"…"}` |
| `../…/…​.svg` (relative) | `typeof 'function'` — `displayName 'SvgMock'` |

## Changes

- Reorder the two entries, with a comment stating that the order is load-bearing.
- Rewrite `svgMock.js`'s comment — it claimed it used "the SVG filename as testID"; it actually uses `props.testID || 'svg-mock'`.
- Add `test/svg-module-resolution.test.tsx` pinning the invariant, with a **negative control**: `.png` must *keep* resolving to an asset object, because PNGs genuinely are `<Image source>` values. The asymmetry is deliberate, and the test would catch an over-correction.
- Drop the two now-vestigial per-file SVG mocks from `CatalogueGrid.test.tsx`; the suite is green without them.

Mutation-tested: restoring the old order fails **4 of 5** new tests, and the PNG negative control correctly keeps passing — proving it's a real control rather than a copy of the positive assertions.

## Why `chore:` and not `fix:`

Per [`check-pr-conventions.mjs:59-63`](scripts/check-pr-conventions.mjs), `chore:` is exempt from the spec-first story requirement. This touches only jest config, a mock and test files — CONTRIBUTING's definition of `chore/` ("tooling, config, or maintenance, no product code"). Inventing a story file purely to satisfy the linter would have been backwards.

## ⚠️ Merge order

**This is a prerequisite for Story 16.17** (#PR to follow). That PR's `AppLaunchScreen` imports its mark via the `@/` alias; without this fix, 5+ of its tests fail. Verified by simulating it. **Merge this first.**

## Gates

`yarn lint` · `yarn typecheck` · `yarn tokens:check` · `yarn test` (169 suites / 1825 tests) — all green, full suite re-run because this changes module resolution for every SVG in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)