### PR TITLE
chore(config): remove the dead Expo web target

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,15 @@ import { resolve } from 'node:path';
 
 import type { StorybookConfig } from '@storybook/react-native-web-vite';
 
+// This Storybook is the ONLY consumer of `react-native-web` and `react-dom` — do not
+// drop them as "unused" deps. The app itself has no web target (there is no `expo.web`
+// in app.json; `expo start --web` cannot bundle, because the entry reaches native-only
+// modules such as `react-native-watch-connectivity` and `expo-sqlite`). This surface is
+// independent of that: it bundles through Vite, never reads app.json, and only mounts
+// the `shared/components/ui` primitives — never the app entry. It is what backs the
+// Chromatic visual-diff workflow (Story 16.5) and is the right place to eyeball a
+// component at a fixed viewport.
+
 const projectRoot = process.cwd();
 
 const config: StorybookConfig = {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,14 @@ npm expo lint                   # Run ESLint
 ```bash
 npx eas-cli@latest build --platform ios -s            # Use EAS to build for iOS platform and submit to App Store
 npx eas-cli@latest build --platform android -s        # Use EAS to build for Android platform and submit to Google Play Store
-npx expo export -p web && npx eas-cli@latest deploy   # Deploy web to EAS Hosting
 ```
+
+> **There is no web target.** This is a phone + wearable app (iOS, Android, watchOS, Wear OS)
+> and the JS entry pulls in native-only modules (`react-native-watch-connectivity`,
+> `expo-sqlite`, `react-native-image-code-scanner`, `expo-brightness`, `burnt`) that have no
+> web implementation, so `expo start --web` / `expo export -p web` cannot bundle. Do not add
+> `expo.web` to `app.json`. To preview UI in a browser, use the Storybook surface
+> (`yarn storybook`) — that is what `react-native-web` is installed for.
 
 ## 🚨 Critical Instructions (From Dev Memory)
 

--- a/app.json
+++ b/app.json
@@ -27,11 +27,6 @@
       },
       "package": "com.iferoporefi.myloyaltycards"
     },
-    "web": {
-      "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/favicon.png"
-    },
     "plugins": [
       "expo-router",
       "expo-secure-store",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,12 @@ _This document builds collaboratively through step-by-step discovery. Sections a
 
 - React Native + Expo as development framework
 - 4 target platforms: iOS, Android, watchOS, Wear OS
+- **Web is explicitly not a target.** The app is portrait phone + wearable only; its JS entry
+  reaches native-only modules with no web implementation (`react-native-watch-connectivity`,
+  `expo-sqlite`, `react-native-image-code-scanner`, `expo-brightness`, `burnt`), so a web
+  bundle is not buildable without shimming each one. `app.json` therefore declares no
+  `expo.web` block. `react-native-web`/`react-dom` remain installed **for Storybook only**
+  (`.storybook/`, Chromatic — Story 16.5), which bundles via Vite and never loads the app entry.
 - Wearable storage limits (~100MB for app + data)
 - Expo dev client with custom native modules for wearable features
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "preios": "node scripts/ensure-expo-sqlite-vendor-files.mjs",
-    "web": "expo start --web",
     "fastlane:match": "./scripts/fastlane-match.sh",
     "fastlane:match:bootstrap": "./scripts/fastlane-match.sh bootstrap",
     "fastlane:match:fetch": "./scripts/fastlane-match.sh fetch",


### PR DESCRIPTION
## Problem

`app.json` declared an `expo.web` target, and `package.json` shipped a `yarn web` script — but neither could ever bundle:

```
Unable to resolve module ./RNWatch
from node_modules/react-native-watch-connectivity/dist/index.js:13
```

`react-native-watch-connectivity` ships no web implementation and is reachable from the app entry:

```
app/_layout.tsx → core/database/card-repository.ts → core/watch-connectivity.ts
```

That is only the **first** wall. It fails at 99.8% of 2484 modules, and behind it sit `expo-sqlite` (5 files — the entire persistence layer, which would need a WASM path), `react-native-image-code-scanner` (a Nitro module), `expo-brightness`, `burnt` and `@bwip-js/react-native`. The repo has **zero** `.web.ts` shims and **zero** `Platform.OS === 'web'` branches, so making web work means authoring and permanently maintaining a shim for each — to preview a layout.

`docs/architecture.md` already lists four target platforms (iOS, Android, watchOS, Wear OS) and never included web. `app.json` sets `"orientation": "portrait"`, and `shared/theme/unistyles.ts` records "Phone-only app — no responsive breakpoints are required". The `expo.web` block was `create-expo-app` residue.

## Change

- Remove `expo.web` from `app.json` and the `web` script from `package.json`.
- Remove the `expo export -p web && eas-cli deploy` line from `AGENTS.md` — there is no `eas.json` in the repo, so it could never have run.
- **Keep `react-native-web` and `react-dom`.** `@storybook/react-native-web-vite` is their real consumer (33 stories under `shared/components/ui/`, plus the Chromatic visual-diff workflow). Storybook bundles through **Vite**, never reads `app.json`, and only mounts the UI primitives — never the app entry — so it is unaffected. This is now recorded in `.storybook/main.ts`, because `app.json` is strict JSON and cannot carry the comment: without it, the next dependency cleanup deletes two apparently-unused web deps and silently breaks visual-regression CI.
- State the constraint in `docs/architecture.md` beside the platform list, so nobody re-adds `expo.web`.

## Verification

| Gate | Result |
| --- | --- |
| `yarn typecheck` | pass |
| `yarn lint` | pass |
| `yarn tokens:check` | pass |
| `yarn splash:check` | pass |
| `yarn test` | 169 suites / 1825 tests pass |
| `yarn build-storybook` | succeeds — confirms Storybook is independent of `expo.web` |
| `npx expo config --type public` | exit 0, no `web` key, `android.versionCode` still injected by `app.config.ts` |

`app.json` has real consumers, so both were checked: `app.config.ts` only spreads the static config and adds `android.versionCode`, and neither `app.config.test.ts` nor `shared/components/launch/constants.test.ts` (which imports `app.json` directly to assert splash agreement) references the web block.

## Notes

Discovered during Story 16.22 while trying to use the web target to check card-grid layout at 320/360 px. Unrelated to that story's layout fix, so it was kept out of its PR. The visual-verification need it was reaching for is better served by the existing Storybook + Chromatic surface (Story 16.5).

Follow-up left out of scope: `assets/favicon.png` is now orphaned (`expo.web` was its only reference), and `tsconfig.json` still lists `web-build` in `exclude` (harmless — it excludes a path that will never exist).