### PR TITLE
chore(cards): make the pull-to-refresh test falsifiable

### DIFF
--- a/features/cards/components/CardList.test.tsx
+++ b/features/cards/components/CardList.test.tsx
@@ -7,7 +7,7 @@
  * no-results message, focus-effect refetch, pull-to-refresh, performance.
  */
 
-import { render, screen } from '@testing-library/react-native';
+import { act, render, screen } from '@testing-library/react-native';
 import { useFocusEffect } from 'expo-router';
 
 import { LoyaltyCard } from '@/core/schemas';
@@ -47,10 +47,23 @@ jest.mock('@/shared/hooks/useCloudSync', () => ({
   })
 }));
 
-jest.mock('expo-router', () => ({
-  useFocusEffect: jest.fn((callback: () => void) => callback()),
-  useRouter: () => ({ push: jest.fn() })
-}));
+/**
+ * Real `useFocusEffect` re-runs its callback when the callback's identity
+ * changes — on focus — NOT on every render. Modelling that with `useEffect`
+ * keeps `refetch` call counts meaningful: a mock that fired per render let the
+ * two `setIsRefreshing` re-renders inside `handleRefresh` bump `refetch` on
+ * their own, which masked a pull-to-refresh that never called `refetch` at all.
+ */
+jest.mock('expo-router', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mockReact = require('react');
+  return {
+    useFocusEffect: jest.fn((callback: () => void) => {
+      mockReact.useEffect(callback, [callback]);
+    }),
+    useRouter: () => ({ push: jest.fn() })
+  };
+});
 
 jest.mock('@/shared/theme', () => ({
   useTheme: () => ({
@@ -354,9 +367,20 @@ describe('CardList', () => {
       setupCards(twoCards);
       render(<CardList />);
 
-      const flashList = screen.getByTestId('card-list-flashlist');
-      const onRefresh = flashList.props.onRefresh;
-      expect(onRefresh).toBeDefined();
+      // `jest.setup.js` forwards `onRefresh` onto the mock FlashList's host
+      // View, so this is the component's own `handleRefresh`.
+      const onRefresh = screen.getByTestId('card-list-flashlist').props.onRefresh;
+
+      // Drop the mount-time focus-effect call so both assertions below can only
+      // be satisfied by `handleRefresh` itself.
+      mockRefetch.mockClear();
+
+      await act(async () => {
+        await onRefresh();
+      });
+
+      expect(mockForceSync).toHaveBeenCalledTimes(1);
+      expect(mockRefetch).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

The pull-to-refresh test in `CardList.test.tsx` was vacuous: it read FlashList's `onRefresh` prop and asserted only that it was defined, never invoking it. It could not fail even if pull-to-refresh were completely broken. This PR makes it exercise the behaviour its name claims.

Test-only change — no product code is touched.

## Related story / issue

None. This is test maintenance with no product-code change, so it carries a `chore:` title, which is story-exempt under CONTRIBUTING's spec-first rule.

It was found during the code review of the card-grid tile-overlap story and deliberately left out of that PR to keep its diff surgical — it is unrelated to the layout fix. It is intentionally **not** linked by number here: `mark-story-done` marks any story referenced from a merged PR as `done`, and that story is still open.

## Type of change

- [ ] ✨ `feat` — new feature
- [ ] 🐛 `fix` — bug fix
- [ ] ♻️ `refactor` — no behavior change
- [ ] 📝 `docs` — documentation / specs
- [x] ✅ `test` — tests only
- [x] 🔧 `chore` — tooling / maintenance
- [ ] 🏷️ `catalogue` — brand catalogue entry
- [ ] 🎨 `design` — UX/UI change

## What changed

Two parts, because the obvious fix was **not** sufficient on its own:

1. **The test** — grabs `onRefresh` off the mock FlashList, invokes it inside `await act(...)`, and asserts exact call counts on `forceSync` and `refetch`.
2. **The `expo-router` mock** — `useFocusEffect` now re-runs via `useEffect(cb, [cb])`, i.e. when its memoised callback's identity changes, instead of firing on every render.

Part 2 is load-bearing. The old mock invoked its callback on every render, and `handleRefresh` re-renders twice via `setIsRefreshing`, so `refetch`'s call count climbed on its own regardless of what the refresh path did. Simply baselining the count before refreshing was *still* unfalsifiable — see the mutation table below. Modelling the real hook's semantics matches the shim already used in `CardDetailScreen.test.tsx`, and this was the only mock in the repo with the per-render shape.

## Acceptance criteria

No new ACs. The `Pull-to-refresh — AC10` block now provides real coverage of that AC instead of an assertion that cannot fail.

## Screenshots / screen recordings

- [x] Not a user-visible change (no screenshots needed)

## How was this tested?

Mutation-tested — a green run proves little about a test whose entire defect was that it could not go red:

| Mutation to `handleRefresh`  | Before this PR | After this PR |
| ---------------------------- | -------------- | ------------- |
| entire body a no-op          | ✓ passed (bad) | ✕ fails       |
| drop only `await refetch()`  | ✓ passed (bad) | ✕ fails       |

Each mutation fails exactly one test — the intended one — leaving the other thirty in the file green.

- Test results: `yarn test` → **170 suites, 1878 tests, all passing**
- `yarn lint`, `yarn typecheck`, `yarn tokens:check`, `yarn splash:check` — all pass
- The full `pre-push` gate ran on push; `--no-verify` was **not** used
- Coverage: unchanged, since no product code is touched

## Author checklist

- [ ] A `ready-for-dev` story exists and its acceptance criteria are met — _n/a, `chore` test-maintenance PR (see above)_
- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally (I did **not** use `--no-verify`)
- [x] New behavior has co-located tests; coverage is not regressed
- [x] Follows the layer boundaries & rules in `docs/project-context.md` and `AGENTS.md`
- [ ] `docs/sprint-artifacts/sprint-status.yaml` and the story file are updated — _n/a, no story_
- [x] I performed a self-review of my own changes

---

### Follow-ups noticed, not fixed here

Two gaps in the PR-conventions tooling, both surfaced while making this PR comply:

1. `scripts/check-pr-conventions.mjs` exempts only `docs`/`chore` titles from the story requirement, so a legitimately test-only PR must either invent a story link or be relabelled `chore:` (as this one was). Adding `test` to the exempt list would remove the incentive to link an unrelated story.
2. In `scripts/lib/story-refs.mjs`, the numeric fallback's `story` prefix is optional, so **any** bare dotted or hyphenated number pair in a PR body resolves to a story. A plain dotted version string in a PR description is enough to mark a completely unrelated story `done` on merge — verified locally against the real stories directory. Requiring the `story` prefix, or the `stories/<id>.md` path form, would close it.
