### PR TITLE
chore(ci): raise the watchOS job timeout above its measured p95

### DIFF
--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -1,6 +1,9 @@
 name: CI — watchOS tests
 
 on:
+  # Lets a maintainer re-measure the job duration on demand when re-tuning
+  # timeout-minutes, without pushing a throwaway commit to a trigger path.
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -9,6 +12,7 @@ on:
       - 'ios/**'
       - 'app.json'
       - 'fastlane/Fastfile'
+      - '.github/workflows/watchos-tests.yml'
   push:
     branches: [main]
     paths:
@@ -17,6 +21,7 @@ on:
       - 'ios/**'
       - 'app.json'
       - 'fastlane/Fastfile'
+      - '.github/workflows/watchos-tests.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -25,7 +30,19 @@ jobs:
   watchos-tests:
     name: watchOS (xcodebuild) tests
     runs-on: macos-latest
-    timeout-minutes: 30
+    # Job wall-clock for green runs, measured over the last 30 successful runs
+    # (includes the ~2m of cache-save post-steps, which count against this
+    # ceiling): median ~23m, p95 ~28m, slowest ~29m. The old 30m limit sat
+    # inside that noise band, so a slow runner draw surfaced as a red
+    # `cancelled` check with zero failing steps rather than as a real failure.
+    #
+    # Nearly all of it is the xcodebuild step: the `watch` scheme depends on the
+    # parent iOS app, so ~23m goes to compiling that app's Pod tree (RNSVG,
+    # RNReanimated, RNScreens, SDWebImage, …) to reach a watch target that
+    # itself compiles in ~17s. Caching does not reach that cost — see the PR
+    # that raised this limit — so headroom is the fix until the scheme's
+    # dependency graph is narrowed.
+    timeout-minutes: 50
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The watchOS workflow intermittently reported a **red check with no failing step**. Its conclusion was `cancelled`, which reads like a test failure but is the job hitting its own ceiling.

Run `30557440139` is the confirmed case: it ran for thirty minutes and twenty-eight seconds against `timeout-minutes: 30` and was cancelled mid-`xcodebuild`, with every preceding step green.

Two other recent `cancelled` runs turned out **not** to be timeouts — run `30450542202` stopped after six minutes and run `30449963951` after fifteen. The first was cancelled when its branch was deleted on merge (that branch no longer exists). So `cancelled` on this workflow has more than one cause, and the timeout is the one worth fixing.

## Measurement

Job wall-clock over the last thirty successful runs — measured job start to job end, so the cache-save post-steps are included, because those also count against `timeout-minutes`:

| statistic | duration |
| --------- | -------- |
| min       | 13m 24s  |
| median    | 22m 30s  |
| p90       | 26m 54s  |
| p95       | 28m 00s  |
| max       | 29m 06s  |

The last ten green runs are the current regime: median 24m 36s, slowest 29m 06s. Headroom against the old ceiling was **under a minute**, so the limit sat inside the runner-to-runner noise band — identical work varies more than twofold (13m to 29m) purely on the runner draw. That, not any code defect, explains the inversion where a branch run went red while its `main` counterpart passed.

## Where the time goes

Step breakdown of the slowest green run:

| step                                             | duration    |
| ------------------------------------------------ | ----------- |
| setup (checkout, Xcode, Node, cache restore)     | 8s          |
| `yarn install`                                   | 1m 10s      |
| Jest watch tests                                 | 33s         |
| `expo prebuild --clean` (includes `pod install`) | 1m 11s      |
| `Brands.swift` generate + check                  | 2s          |
| **`xcodebuild` watch target**                    | **23m 41s** |
| cache-save post-steps                            | 2m 19s      |

The `xcodebuild` step is the whole story. Attributing its log by compile target:

| target                              | share of step |
| ----------------------------------- | ------------- |
| RNSVG                               | 17%           |
| RNReanimated                        | 16%           |
| RNScreens                           | 10%           |
| SDWebImage                          | 9%            |
| ExpoModulesCore                     | 7%            |
| Unistyles                           | 5%            |
| …81 further pods                    | …             |
| **`watch` — the target under test** | **1% (~17s)** |

The `watch` scheme depends on the parent iOS app, so the job compiles that app's entire Pod tree in order to reach a watch target that itself compiles in about seventeen seconds.

## Change

- **`timeout-minutes: 30` → `50`.** That leaves roughly twenty minutes of headroom above the slowest observed green run — enough to absorb a slow runner draw plus ordinary build growth, while still catching a genuine hang well inside an hour.
- **Added `.github/workflows/watchos-tests.yml` to both `paths` filters.** Without it a change to this workflow does not trigger this workflow, so this PR could not verify itself.
- **Added `workflow_dispatch`,** so the duration can be re-measured on demand when re-tuning the ceiling, without pushing a throwaway commit to a trigger path.

**No step, command, or tested surface changed** — the job builds and checks exactly what it did before.

## On caching — evaluated, deliberately not added

The suggestion was to cache CocoaPods, DerivedData and yarn. Measurement says caching is the wrong lever here:

- **`ios/Pods` — cannot work.** `ios/` is gitignored and regenerated by `expo prebuild --clean`, which deletes the directory before recreating it; a restored `ios/Pods` would be wiped before anything could read it. `pod install` is also only about a minute of the run.
- **CocoaPods download cache** (`~/Library/Caches/CocoaPods`) survives `--clean`, but the entire cost it could address is that same ~1 minute of a ~29 minute job.
- **Xcode DerivedData** is the only cache that reaches the 23-minute step — and it would *reduce* reliability. `xcode-version: latest-stable` changes silently whenever GitHub rolls the runner image, and DerivedData embeds absolute paths, clang module caches and SDK assumptions. A stale restore against a new Xcode produces confusing build failures. Trading a well-understood timeout for cache-staleness failures is the wrong direction for a job whose presenting problem is false red checks.
- **yarn** install is already only 1m 10s, and the two cache-save post-steps together cost more (2m 19s) than the install they exist to speed up.

Two things worth a separate look, deliberately left alone here:

1. `actions/setup-node` (`cache: 'yarn'`) saves `~/Library/Caches/Yarn/v6`, while the explicit `actions/cache` step lists `~/.cache/yarn` — a Linux path that does not exist on this macOS runner, so that entry is a no-op and the two steps duplicate effort. The same block is copied in `ci-quality-gates.yml`, so changing one alone would create divergence.
2. The real fix for the duration is narrowing what the `watch` scheme pulls in, so the job stops compiling the full iOS Pod tree to build a watch target. That is a build-graph change, out of scope for a reliability fix.

Also noted: the `ios/**` path filter can never match, since `ios/` is gitignored and has no tracked files. Harmless, and left as-is in case the directory is ever committed.

## Verification

- Workflow YAML parses; all ten steps and their commands are byte-identical to before, with only the trigger list and `timeout-minutes` changed.
- `npx prettier --check` passes on the modified file.
- This PR touches a declared trigger path, so the workflow ran on it — which is itself proof the `paths` addition works, since without it the workflow would not have triggered at all.

**Result: watchOS run `30561377360` succeeded in 27m 19s**, inside the new ceiling with more than twenty minutes of headroom, zero non-success steps. All three PR checks are green.

One finding from that run worth recording, because it settles the caching question: it hit a **warm** yarn cache — `Install dependencies` took 1s (against 1m 10s cold) and the post-steps 11s (against 2m 19s) — and still consumed 27m 16s of step time, because `xcodebuild` is invariant at 23m 37s. So the best case a dependency cache can produce still burns **91% of the old thirty-minute budget**. Caching could not have fixed this check; only headroom or a smaller build could.

| step                                   | this run (warm) | earlier run (cold) |
| -------------------------------------- | --------------- | ------------------ |
| Install dependencies                   | 1s              | 1m 10s             |
| `expo prebuild --clean`                | 1m 34s          | 1m 11s             |
| **`xcodebuild` watch target**          | **23m 37s**     | **23m 41s**        |
| cache-save post-steps                  | 11s             | 2m 19s             |
| **total**                              | **27m 16s**     | **29m 06s**        |
