### PR TITLE
feat(cards): size card-tile fallback plates from the tile and state the column-count floor

### DIFF
--- a/features/cards/components/CardTile.test.tsx
+++ b/features/cards/components/CardTile.test.tsx
@@ -20,6 +20,13 @@ import {
   SINGLE_TILE_HEIGHT,
   SINGLE_TILE_RADIUS
 } from './CardTile';
+import {
+  AVATAR_SIZE,
+  BADGE_CLEARANCE,
+  LOGO_SLOT_SIZE,
+  getFallbackChildMetrics,
+  getGridTileHeight
+} from '../utils/gridLayout';
 
 // Mock expo-router
 const mockPush = jest.fn();
@@ -223,23 +230,27 @@ describe('CardTile', () => {
     });
 
     /**
-     * The tile's fallback children (`logoSlot`, `avatarCircle`) are FIXED sizes and are
-     * centre-aligned, while `favouriteBadge` is pinned to the right edge. Before this
-     * story the tile never went below 171 pt, so they could never meet. Now that the
-     * tile tracks the viewport there is a width at which the centred fallback reaches
-     * the badge, so the clearance is asserted rather than assumed.
+     * The tile's two fallback children (`logoSlot`, `avatarCircle`) are centre-aligned
+     * while `favouriteBadge` is pinned to the right edge. Story 16.22 made the tile
+     * track the viewport, at which point the children's FIXED 64 / 48 pt became the
+     * same species of frozen measurement the tile itself had been — so they are now
+     * derived from the tile and capped against the badge by
+     * `gridLayout.getFallbackChildMetrics`.
      *
-     * At 136 pt (the tile at 320 dp, the narrowest width AC7 exercises) the abbreviation
-     * slot clears the badge by 6 pt. The collision point is ~124 pt of tile, i.e. a
-     * ~296 dp viewport — below every real device. It matters mainly as a floor for any
-     * future change that shrinks the tile further, a 3-column grid above all.
+     * The widths below deliberately go past what ships today. 136 pt is the tile at
+     * 320 dp (the narrowest width AC7 exercises), but the interesting cases are the
+     * ones a **3-column** grid produces — 116 pt at 412 dp and 98 pt at 360 dp — which
+     * is 16.22's own flagged follow-up and already the pattern in `CatalogueGrid.tsx`.
+     * A fixed 64 pt slot overlaps the badge by 4 pt at 116 pt, so these assertions are
+     * falsifiable against the previous implementation rather than vacuous.
+     *
+     * The exhaustive sweep across every 2- and 3-column width lives in
+     * `utils/gridLayout.test.ts`; these are the integration proof that the component
+     * actually applies it.
      */
     describe('fallback children clear the favourite badge', () => {
-      const NARROWEST_SUPPORTED_TILE_WIDTH = 136;
-
       /** Right-pinned badge: its left edge is tileWidth − (right + width). */
-      const badgeLeftEdge = (tileWidth: number, element: React.ReactElement) => {
-        render(element);
+      const badgeLeftEdge = (tileWidth: number): number => {
         const badge = StyleSheet.flatten(screen.getByTestId('favourite-badge').props.style) as {
           right?: number;
           width?: number;
@@ -250,11 +261,11 @@ describe('CardTile', () => {
       };
 
       /**
-       * Width of the nearest styled ancestor of a text node — the fallback container
-       * that holds it. Walks up rather than assuming a depth, because RNTL interposes
+       * Size of the nearest styled ancestor of a text node — the fallback plate that
+       * holds it. Walks up rather than assuming a depth, because RNTL interposes
        * composite elements that carry no style of their own.
        */
-      const enclosingWidth = (text: string): number | undefined => {
+      const enclosingSize = (text: string): number | undefined => {
         let node = screen.getByText(text).parent;
         while (node) {
           const style = StyleSheet.flatten(node.props?.style) as { width?: number } | undefined;
@@ -264,8 +275,15 @@ describe('CardTile', () => {
         return undefined;
       };
 
-      it('keeps the brand-abbreviation slot clear of the badge at 320 dp', () => {
-        // Catalogue brand whose SVG asset is missing → the abbreviation-slot branch.
+      /** Applied glyph size on the text node itself. */
+      const glyphSize = (text: string): number | undefined =>
+        (
+          StyleSheet.flatten(screen.getByText(text).props.style) as
+            | { fontSize?: number }
+            | undefined
+        )?.fontSize;
+
+      const asBrandWithoutSvg = () => {
         (useBrandLogo as jest.Mock).mockReturnValue({
           id: 'esselunga',
           name: 'Esselunga',
@@ -273,61 +291,133 @@ describe('CardTile', () => {
           logo: 'esselunga',
           aliases: []
         });
+        // Catalogue brand whose SVG asset is missing → the abbreviation-slot branch.
         (getBrandLogo as jest.Mock).mockReturnValue(undefined);
+      };
 
-        const left = badgeLeftEdge(
-          NARROWEST_SUPPORTED_TILE_WIDTH,
-          <CardTile
-            card={{ ...mockCard, brandId: 'esselunga', isFavorite: true }}
-            tileWidth={NARROWEST_SUPPORTED_TILE_WIDTH}
-            tileHeight={111}
-          />
-        );
-        const slotWidth = enclosingWidth('ES');
-        expect(slotWidth).toBeDefined();
+      /** Tile widths worth pinning: the reference, today's narrowest, and 3-column. */
+      const TILE_WIDTHS = [
+        { tileWidth: TILE_WIDTH, note: '390 dp, 2 columns — the design reference' },
+        { tileWidth: 136, note: '320 dp, 2 columns — narrowest shipping width' },
+        { tileWidth: 116, note: '412 dp, 3 columns — was a 4 pt overlap' },
+        { tileWidth: 98, note: '360 dp, 3 columns — the badge cap binds' }
+      ];
 
-        // Centred child, so its right edge is tileWidth / 2 + width / 2.
-        const slotRightEdge = NARROWEST_SUPPORTED_TILE_WIDTH / 2 + slotWidth! / 2;
-        expect(slotRightEdge).toBeLessThan(left);
+      describe.each(TILE_WIDTHS)('at a $tileWidth pt tile ($note)', ({ tileWidth }) => {
+        it('keeps the brand-abbreviation slot clear of the badge', () => {
+          asBrandWithoutSvg();
+          render(
+            <CardTile
+              card={{ ...mockCard, brandId: 'esselunga', isFavorite: true }}
+              tileWidth={tileWidth}
+              tileHeight={getGridTileHeight(tileWidth)}
+            />
+          );
+
+          const slotSize = enclosingSize('ES');
+          expect(slotSize).toBeDefined();
+          // Centred child, so its right edge is tileWidth / 2 + size / 2.
+          const rightEdge = tileWidth / 2 + slotSize! / 2;
+          expect(badgeLeftEdge(tileWidth) - rightEdge).toBeGreaterThanOrEqual(BADGE_CLEARANCE);
+        });
+
+        it('keeps the first-letter avatar clear of the badge', () => {
+          (useBrandLogo as jest.Mock).mockReturnValue(undefined);
+          render(
+            <CardTile
+              card={{ ...mockCard, isFavorite: true }}
+              tileWidth={tileWidth}
+              tileHeight={getGridTileHeight(tileWidth)}
+            />
+          );
+
+          const avatarSize = enclosingSize('T');
+          expect(avatarSize).toBeDefined();
+          const rightEdge = tileWidth / 2 + avatarSize! / 2;
+          expect(badgeLeftEdge(tileWidth) - rightEdge).toBeGreaterThanOrEqual(BADGE_CLEARANCE);
+        });
+
+        it('delegates both plate and glyph sizing to gridLayout', () => {
+          // Not a restatement of the clearance above: this pins that the component
+          // reads the shared arithmetic (and picks the right reference per branch)
+          // instead of carrying a second copy that could drift from the sweep.
+          asBrandWithoutSvg();
+          render(
+            <CardTile
+              card={{ ...mockCard, brandId: 'esselunga', isFavorite: true }}
+              tileWidth={tileWidth}
+              tileHeight={getGridTileHeight(tileWidth)}
+            />
+          );
+          const slot = getFallbackChildMetrics(tileWidth, LOGO_SLOT_SIZE);
+          expect(enclosingSize('ES')).toBe(slot.size);
+          expect(glyphSize('ES')).toBe(slot.fontSize);
+
+          (useBrandLogo as jest.Mock).mockReturnValue(undefined);
+          render(
+            <CardTile
+              card={mockCard}
+              tileWidth={tileWidth}
+              tileHeight={getGridTileHeight(tileWidth)}
+            />
+          );
+          const avatar = getFallbackChildMetrics(tileWidth, AVATAR_SIZE);
+          expect(enclosingSize('T')).toBe(avatar.size);
+          expect(glyphSize('T')).toBe(avatar.fontSize);
+        });
       });
 
-      it('keeps the first-letter avatar clear of the badge at 320 dp', () => {
-        (useBrandLogo as jest.Mock).mockReturnValue(undefined);
-
-        const left = badgeLeftEdge(
-          NARROWEST_SUPPORTED_TILE_WIDTH,
+      it('leaves the 390 dp reference tile pixel-identical to the fixed sizes it replaces', () => {
+        // The counterweight to the tests above: proportional sizing must not change
+        // the design reference. 64 / 48 / 18 pt were the shipped values.
+        asBrandWithoutSvg();
+        render(
           <CardTile
-            card={{ ...mockCard, isFavorite: true }}
-            tileWidth={NARROWEST_SUPPORTED_TILE_WIDTH}
-            tileHeight={111}
+            card={{ ...mockCard, brandId: 'esselunga', isFavorite: true }}
+            tileWidth={TILE_WIDTH}
+            tileHeight={TILE_HEIGHT}
           />
         );
-        const avatarWidth = enclosingWidth('T');
-        expect(avatarWidth).toBeDefined();
+        expect(enclosingSize('ES')).toBe(64);
+        expect(glyphSize('ES')).toBe(18);
 
-        const avatarRightEdge = NARROWEST_SUPPORTED_TILE_WIDTH / 2 + avatarWidth! / 2;
-        expect(avatarRightEdge).toBeLessThan(left);
+        (useBrandLogo as jest.Mock).mockReturnValue(undefined);
+        render(<CardTile card={mockCard} tileWidth={TILE_WIDTH} tileHeight={TILE_HEIGHT} />);
+        expect(enclosingSize('T')).toBe(48);
+        expect(glyphSize('T')).toBe(18);
+      });
+
+      it('shrinks the plates on a narrower tile rather than holding them fixed', () => {
+        // Falsifiability guard: the whole change is that these are no longer constant.
+        asBrandWithoutSvg();
+        render(
+          <CardTile
+            card={{ ...mockCard, brandId: 'esselunga', isFavorite: true }}
+            tileWidth={116}
+            tileHeight={getGridTileHeight(116)}
+          />
+        );
+        const narrow = enclosingSize('ES');
+        expect(narrow).toBeLessThan(64);
+        // ...and the previous fixed 64 pt would have overlapped here, by 4 pt.
+        expect(116 / 2 + 64 / 2).toBeGreaterThan(badgeLeftEdge(116));
       });
     });
 
-    it('keeps single-line tail ellipsis for the name regardless of tile size', () => {
-      // Deliberately NOT a claim about *where* truncation falls — RNTL runs no flex
-      // layout, so no unit test can observe that. What this pins is that passing a size
-      // prop doesn't disturb the name's truncation contract: still one line, still
-      // native tail ellipsis, at the narrow tile as at the reference tile.
-      //
-      // The real consequence — the name gets 136 pt instead of 171 at 320 dp, ~20 %
-      // less, compounded by Android's independent font-scale setting — is a product
-      // decision for ifero and is checked by hand in the AC7 script, not here.
-      for (const size of [{ tileWidth: 136, tileHeight: 111 }, {}]) {
-        const { unmount } = render(
-          <CardTile card={{ ...mockCard, name: 'Supermercato Esselunga Fidaty Plus' }} {...size} />
-        );
-        const name = screen.getByText('Supermercato Esselunga Fidaty Plus');
-        expect(name.props.numberOfLines).toBe(1);
-        expect(name.props.ellipsizeMode).toBe('tail');
-        unmount();
-      }
+    it('still delegates long-name truncation to the platform on a narrow tile', () => {
+      // The name sits BELOW the tile and tracks its width, so it truncates ~20 % sooner
+      // at 320 dp than at the 390 dp reference. Documented rather than changed: going to
+      // two lines or clamping the font scale is a design decision, not a bug fix.
+      render(
+        <CardTile
+          card={{ ...mockCard, name: 'Supermercato Esselunga Fidaty Plus' }}
+          tileWidth={136}
+          tileHeight={111}
+        />
+      );
+      const name = screen.getByText('Supermercato Esselunga Fidaty Plus');
+      expect(name.props.numberOfLines).toBe(1);
+      expect(name.props.ellipsizeMode).toBe('tail');
     });
   });
 

--- a/features/cards/components/CardTile.tsx
+++ b/features/cards/components/CardTile.tsx
@@ -13,6 +13,11 @@
  * at 390 dp and the fallback for callers that pass no size — they are NOT a
  * viewport-independent layout width. See gridLayout.ts for why that distinction
  * is the whole bug.
+ *
+ * The tile's own children follow the same rule: the two centred fallback plates
+ * (brand abbreviation, first-letter avatar) are sized from the tile and capped so
+ * they clear the right-pinned favourite badge, which stays fixed for legibility.
+ * `gridLayout.getFallbackChildMetrics` owns that arithmetic.
  */
 
 import { MaterialIcons } from '@expo/vector-icons';
@@ -38,12 +43,17 @@ import { BrandLogo } from './BrandLogo';
 import { useBrandLogo } from '../hooks/useBrandLogo';
 import { getBrandLogo } from '../utils/brandLogos';
 import {
+  AVATAR_SIZE,
+  BADGE_INSET,
+  BADGE_SIZE,
+  LOGO_SLOT_SIZE,
   SINGLE_TILE_HEIGHT,
   SINGLE_TILE_RADIUS,
   SINGLE_TILE_WIDTH,
   TILE_HEIGHT,
   TILE_RADIUS,
-  TILE_WIDTH
+  TILE_WIDTH,
+  getFallbackChildMetrics
 } from '../utils/gridLayout';
 
 /**
@@ -140,6 +150,18 @@ export const CardTile: React.FC<CardTileProps> = ({
   const logoWidth = Math.round(tileWidth * 0.85);
   const logoHeight = Math.round(tileHeight * 0.85);
 
+  // The two centred fallback plates track the tile and are capped so they cannot
+  // reach the right-pinned favourite badge; the glyph inside holds 18 pt unless the
+  // plate becomes too small for it. Only one branch renders, so only its reference
+  // size is needed: a brand means the abbreviation slot, no brand means the
+  // first-letter avatar. See gridLayout.getFallbackChildMetrics for the arithmetic.
+  //
+  // Note this does NOT apply to the SVG branch above: `logoWidth` is 85 % of the
+  // tile and has always run under the badge (145 pt of 171 at the design reference).
+  // That overlap is pre-existing and accepted — the badge's opaque plate reads fine
+  // over a largely transparent logo, where two translucent plates would not.
+  const fallback = getFallbackChildMetrics(tileWidth, brand ? LOGO_SLOT_SIZE : AVATAR_SIZE);
+
   return (
     <Pressable
       onPress={handlePress}
@@ -176,15 +198,24 @@ export const CardTile: React.FC<CardTileProps> = ({
           <BrandLogo source={logo} width={logoWidth} height={logoHeight} color={foregroundColor} />
         ) : brand ? (
           /* Catalogue card without SVG: brand name abbreviation fallback */
-          <View style={styles.logoSlot}>
-            <Text style={[styles.brandAbbreviation, { color: foregroundColor }]}>
+          <View style={[styles.logoSlot, { width: fallback.size, height: fallback.size }]}>
+            <Text
+              style={[
+                styles.brandAbbreviation,
+                { color: foregroundColor, fontSize: fallback.fontSize }
+              ]}
+            >
               {brand.name.substring(0, 2).toUpperCase()}
             </Text>
           </View>
         ) : (
           /* Custom card: first-letter circular avatar */
-          <View style={styles.avatarCircle}>
-            <Text style={[styles.avatarText, { color: foregroundColor }]}>{firstLetter}</Text>
+          <View style={[styles.avatarCircle, { width: fallback.size, height: fallback.size }]}>
+            <Text
+              style={[styles.avatarText, { color: foregroundColor, fontSize: fallback.fontSize }]}
+            >
+              {firstLetter}
+            </Text>
           </View>
         )}
 
@@ -215,11 +246,14 @@ const styles = StyleSheet.create({
   },
   favouriteBadge: {
     position: 'absolute',
-    top: 6,
-    right: 6,
-    width: 24,
-    height: 24,
-    borderRadius: 12,
+    // Sized from gridLayout's constants rather than literals, because the same two
+    // numbers define the keep-out that the fallback plates are capped against. If
+    // they could drift apart, the cap would silently stop matching the badge.
+    top: BADGE_INSET,
+    right: BADGE_INSET,
+    width: BADGE_SIZE,
+    height: BADGE_SIZE,
+    borderRadius: BADGE_SIZE / 2,
     backgroundColor: 'rgba(255, 255, 255, 0.95)',
     alignItems: 'center',
     justifyContent: 'center'
@@ -242,28 +276,27 @@ const styles = StyleSheet.create({
       }
     })
   },
+  // `width`/`height` and `fontSize` for both fallback plates are applied inline from
+  // getFallbackChildMetrics(), because they depend on the tile. The reference values
+  // (64 / 48 / 18 pt at a 171 pt tile) live in gridLayout.ts as the ratio source.
   logoSlot: {
-    width: 64,
-    height: 64,
+    // Fixed, like TILE_RADIUS — it degrades to a circle if the plate ever gets small
+    // enough for that to bite, which is a graceful failure rather than a broken one.
     borderRadius: 12,
     backgroundColor: 'rgba(255,255,255,0.16)',
     justifyContent: 'center',
     alignItems: 'center'
   },
   brandAbbreviation: {
-    fontWeight: '700',
-    fontSize: 18
+    fontWeight: '700'
   },
   avatarCircle: {
-    width: 48,
-    height: 48,
     borderRadius: 999,
     backgroundColor: 'rgba(255,255,255,0.28)',
     alignItems: 'center',
     justifyContent: 'center'
   },
   avatarText: {
-    fontSize: 18,
     fontWeight: '700'
   },
   cardName: {

--- a/features/cards/utils/gridLayout.test.ts
+++ b/features/cards/utils/gridLayout.test.ts
@@ -12,14 +12,22 @@
  */
 
 import {
+  AVATAR_SIZE,
+  BADGE_CLEARANCE,
+  BADGE_INSET,
+  BADGE_KEEP_OUT,
+  BADGE_SIZE,
+  FALLBACK_TEXT_SIZE,
   GUTTER,
   LIST_CONTENT_PADDING,
+  LOGO_SLOT_SIZE,
   NUM_COLUMNS,
   SCREEN_MARGIN,
   SINGLE_TILE_HEIGHT,
   SINGLE_TILE_WIDTH,
   TILE_HEIGHT,
   TILE_WIDTH,
+  getFallbackChildMetrics,
   getGridTileHeight,
   getGridTileWidth,
   getSingleTileHeight,
@@ -271,6 +279,323 @@ describe('card-grid layout contract (Story 16.22)', () => {
 
     it.each([0, -100])('never returns a width below 1 for %p', (input) => {
       expect(getSingleTileWidth(input)).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+/**
+ * Intra-tile geometry contract — follow-up to Story 16.22's QA finding 3.
+ *
+ * Story 16.22 made the tile track the viewport, which turned `CardTile`'s two FIXED
+ * centred children (`logoSlot` 64 pt, `avatarCircle` 48 pt) into the same species of
+ * frozen measurement the tile itself had been. A 3-column grid — 16.22's own flagged
+ * follow-up, already implemented in `CatalogueGrid.tsx` — reaches the collision at
+ * ≈116 pt on a 412 dp phone.
+ *
+ * As above, the invariant under test is the RELATIONSHIP ("a centred child clears the
+ * right-pinned badge"), swept across every tile a 2- OR 3-column grid can produce,
+ * rather than a spot check at whatever width happens to ship today.
+ */
+describe('intra-tile fallback geometry vs the favourite badge', () => {
+  /** Left edge (pt) of the right-pinned badge on a tile of the given width. */
+  const badgeLeftEdge = (tileWidth: number): number => tileWidth - BADGE_INSET - BADGE_SIZE;
+
+  /** Right edge (pt) of a centre-aligned child — it grows from the tile's middle. */
+  const centredRightEdge = (tileWidth: number, size: number): number => tileWidth / 2 + size / 2;
+
+  /** Gap (pt) between the two. Negative means they overlap. */
+  const gap = (tileWidth: number, size: number): number =>
+    badgeLeftEdge(tileWidth) - centredRightEdge(tileWidth, size);
+
+  /**
+   * Tile width a grid of `columns` columns yields at a viewport, generalising
+   * `getGridTileWidth` past its hardcoded `NUM_COLUMNS`. Transcribed rather than
+   * reused so a 3-column future is exercised before it is built.
+   */
+  const tileWidthFor = (windowWidth: number, columns: number): number =>
+    Math.floor((windowWidth - 2 * LIST_CONTENT_PADDING - columns * GUTTER) / columns);
+
+  /** The proportional size before any capping — the ideal the cap trims. */
+  const proportional = (tileWidth: number, referenceSize: number): number =>
+    Math.round((tileWidth * referenceSize) / TILE_WIDTH);
+
+  const REFERENCES = [
+    { name: 'logoSlot', referenceSize: LOGO_SLOT_SIZE },
+    { name: 'avatarCircle', referenceSize: AVATAR_SIZE }
+  ];
+
+  /** Worst gap across both children at a given tile width. */
+  const worstGap = (tileWidth: number): number =>
+    Math.min(
+      ...REFERENCES.map(({ referenceSize }) =>
+        gap(tileWidth, getFallbackChildMetrics(tileWidth, referenceSize).size)
+      )
+    );
+
+  describe('the keep-out constant', () => {
+    it('is derived from the badge geometry, doubled because the child is centred', () => {
+      expect(BADGE_SIZE).toBe(24);
+      expect(BADGE_INSET).toBe(6);
+      expect(BADGE_CLEARANCE).toBe(4);
+      // Derived, not 68 written down — the badge style and this arithmetic must not
+      // be able to drift apart, exactly as with LIST_CONTENT_PADDING above.
+      expect(BADGE_KEEP_OUT).toBe(2 * (BADGE_INSET + BADGE_SIZE + BADGE_CLEARANCE));
+      expect(BADGE_KEEP_OUT).toBe(68);
+    });
+
+    it('keeps the fallback design references at their 390 dp values', () => {
+      expect(LOGO_SLOT_SIZE).toBe(64);
+      expect(AVATAR_SIZE).toBe(48);
+      expect(FALLBACK_TEXT_SIZE).toBe(18);
+    });
+
+    it("cannot be satisfied by the tile's own 0.85 logo factor at any real width", () => {
+      // Guards the REASONING, not just the result. The obvious move is to copy
+      // `logoWidth = round(tileWidth * 0.85)` from the SVG branch. For a CENTRED
+      // child that needs 0.85·T ≤ T − 68, i.e. a tile wider than 450 pt — no phone is
+      // close. The SVG logo overlaps the badge today for exactly this reason, which
+      // is accepted there (opaque plate over a transparent logo) but would not be for
+      // two translucent plates.
+      const satisfied = widthRange(1, 450).filter(
+        (t) => Math.round(t * 0.85) <= t - BADGE_KEEP_OUT
+      );
+      expect(satisfied).toEqual([]);
+      expect(gap(TILE_WIDTH, Math.round(TILE_WIDTH * 0.85))).toBeLessThan(0);
+    });
+  });
+
+  describe('zero visual change at the design reference width', () => {
+    it.each(REFERENCES)('reproduces $name exactly at the 390 dp tile', ({ referenceSize }) => {
+      expect(getGridTileWidth(390)).toBe(TILE_WIDTH);
+      const metrics = getFallbackChildMetrics(TILE_WIDTH, referenceSize);
+      expect(metrics.size).toBe(referenceSize);
+      expect(metrics.fontSize).toBe(FALLBACK_TEXT_SIZE);
+    });
+  });
+
+  describe('applied sizes by device and column count', () => {
+    // Documents the visual change this makes, so a "my avatars look smaller" report
+    // from a 320 dp phone — or a larger one from a Pro Max — is recognisable as
+    // intended rather than mistaken for a regression.
+    const cases: {
+      width: number;
+      columns: number;
+      tileWidth: number;
+      slot: number;
+      avatar: number;
+      note: string;
+    }[] = [
+      { width: 320, columns: 2, tileWidth: 136, slot: 51, avatar: 38, note: 'small Android' },
+      { width: 360, columns: 2, tileWidth: 156, slot: 58, avatar: 44, note: 'common Android' },
+      {
+        width: 390,
+        columns: 2,
+        tileWidth: 171,
+        slot: 64,
+        avatar: 48,
+        note: 'reference — no change'
+      },
+      { width: 430, columns: 2, tileWidth: 191, slot: 71, avatar: 54, note: 'iPhone Pro Max' },
+      {
+        width: 412,
+        columns: 3,
+        tileWidth: 116,
+        slot: 43,
+        avatar: 33,
+        note: '3-col — was overlapping'
+      },
+      { width: 360, columns: 3, tileWidth: 98, slot: 30, avatar: 28, note: '3-col, cap binding' }
+    ];
+
+    it.each(cases)(
+      '$width dp x$columns → tile $tileWidth, slot $slot, avatar $avatar ($note)',
+      ({ width, columns, tileWidth, slot, avatar }) => {
+        expect(tileWidthFor(width, columns)).toBe(tileWidth);
+        expect(getFallbackChildMetrics(tileWidth, LOGO_SLOT_SIZE).size).toBe(slot);
+        expect(getFallbackChildMetrics(tileWidth, AVATAR_SIZE).size).toBe(avatar);
+      }
+    );
+  });
+
+  describe('clearance is arithmetically impossible to lose', () => {
+    it.each(REFERENCES)(
+      'keeps $name clear of the badge at every 2- and 3-column tile from 280–1024 dp',
+      ({ referenceSize }) => {
+        const violations: { columns: number; windowWidth: number; tile: number; gap: number }[] =
+          [];
+        for (const columns of [2, 3]) {
+          for (const windowWidth of widthRange(280, 1024)) {
+            const tile = tileWidthFor(windowWidth, columns);
+            const { size } = getFallbackChildMetrics(tile, referenceSize);
+            const measured = gap(tile, size);
+            if (measured < BADGE_CLEARANCE) {
+              violations.push({ columns, windowWidth, tile, gap: measured });
+            }
+          }
+        }
+        expect(violations).toEqual([]);
+      }
+    );
+
+    it('would have caught the shipped fixed sizes on a 3-column tile', () => {
+      // Guards the guard, as the 374 dp cliff test does above. Without this, the
+      // sweep could pass vacuously against sizes that were never at risk.
+      const tile = tileWidthFor(412, 3);
+      expect(tile).toBe(116);
+
+      // The defect: a fixed 64 pt slot overlaps the badge by 4 pt here.
+      expect(gap(tile, LOGO_SLOT_SIZE)).toBeLessThan(0);
+      // ...while a fixed 48 pt avatar still cleared, which is precisely why a single
+      // assertion at 116 pt was not enough — only the slot's was falsifiable.
+      expect(gap(tile, AVATAR_SIZE)).toBeGreaterThan(0);
+
+      // Both now clear by at least the nominal gap.
+      for (const { referenceSize } of REFERENCES) {
+        expect(gap(tile, getFallbackChildMetrics(tile, referenceSize).size)).toBeGreaterThanOrEqual(
+          BADGE_CLEARANCE
+        );
+      }
+    });
+
+    it('states all three clearance thresholds exactly', () => {
+      // ≥ BADGE_CLEARANCE wherever the cap is satisfiable — a 1 pt plate needs T ≥ 69.
+      expect(widthRange(69, 1024).filter((t) => worstGap(t) < BADGE_CLEARANCE)).toEqual([]);
+      // 61–68: the cap asks for a sub-1 pt plate, so toTileDimension's 1 pt floor
+      // takes over. Still no overlap, just less than the nominal gap.
+      expect(widthRange(61, 68).filter((t) => worstGap(t) < 0)).toEqual([]);
+      // 60 and below: the badge's own 30 pt footprint has crossed the tile's centre
+      // line, so NO centred child can clear it — the badge would have to change.
+      expect(worstGap(60)).toBeLessThan(0);
+      expect(worstGap(61)).toBe(0);
+    });
+  });
+
+  describe('how the cap and the proportion divide the range', () => {
+    it('is pure proportionality on every 2-column tile that ships today', () => {
+      // The cap is a guard for a grid nobody has built yet, not a change to the
+      // current one: at 320 dp (the narrowest width AC7 exercises) it is slack.
+      const narrowest = tileWidthFor(320, 2);
+      expect(narrowest).toBe(136);
+      for (const { referenceSize } of REFERENCES) {
+        expect(getFallbackChildMetrics(narrowest, referenceSize).size).toBe(
+          proportional(narrowest, referenceSize)
+        );
+      }
+    });
+
+    it('only overrides the proportion on tiles narrower than any 2-column phone', () => {
+      const capped = widthRange(1, 400).filter(
+        (t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).size !== proportional(t, LOGO_SLOT_SIZE)
+      );
+      // Non-empty, so the cap is not vacuous...
+      expect(capped.length).toBeGreaterThan(0);
+      // ...but never reached by a 2-column layout on a real phone.
+      expect(Math.max(...capped)).toBeLessThan(tileWidthFor(320, 2));
+    });
+
+    it.each(REFERENCES)('never shrinks $name as the tile grows', ({ referenceSize }) => {
+      const sizes = widthRange(1, 1024).map((t) => getFallbackChildMetrics(t, referenceSize).size);
+      expect(sizes.filter((size, i) => i > 0 && size < sizes[i - 1]!)).toEqual([]);
+    });
+  });
+
+  describe('the glyph inside the plate', () => {
+    const tilesFor = (columns: number, from: number, to: number): number[] =>
+      widthRange(from, to).map((windowWidth) => tileWidthFor(windowWidth, columns));
+
+    const shrunkAmong = (tiles: number[]): number[] =>
+      tiles.filter((tile) =>
+        REFERENCES.some(
+          ({ referenceSize }) =>
+            getFallbackChildMetrics(tile, referenceSize).fontSize !== FALLBACK_TEXT_SIZE
+        )
+      );
+
+    it('holds the design size on every 2-column tile from 280–1024 dp', () => {
+      // The plate scales; the type does NOT follow it down while the plate can still
+      // hold it. So on real hardware the abbreviation and the avatar letter stay at
+      // 18 pt and consistent with the rest of the app, even where the plate has shrunk
+      // by 20 % at 320 dp.
+      const tiles = tilesFor(2, 280, 1024);
+      expect(shrunkAmong(tiles)).toEqual([]);
+
+      // Non-vacuous: those same tiles carry a wide range of plate sizes, so the
+      // assertion above reads "type held while plates moved", not "nothing moved".
+      const plates = new Set(tiles.map((t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).size));
+      expect(plates.size).toBeGreaterThan(10);
+    });
+
+    it('holds it for 3 columns too, down to a 349 dp viewport', () => {
+      // 3 columns needs a 95 pt tile for the plate to still hold 18 pt, which is a
+      // 349 dp viewport. Above that, type is untouched...
+      expect(shrunkAmong(tilesFor(3, 349, 1024))).toEqual([]);
+      expect(tileWidthFor(349, 3)).toBe(95);
+
+      // ...and below it every width shrinks, so the boundary is exact rather than
+      // approximate. A 3-column grid on a sub-349 dp phone is a layout the column-count
+      // story should decline to produce (a minimum tile width); this records what the
+      // type would do if it did.
+      expect(shrunkAmong(tilesFor(3, 280, 348))).toEqual(tilesFor(3, 280, 348));
+    });
+
+    it('shrinks only once the plate can no longer hold 18 pt', () => {
+      // The fit rule engages at a 26 pt plate and below, which the badge cap only
+      // produces on a tile of ~94 pt — narrower than any 2- or 3-column grid above.
+      // 340 dp across 3 columns (a 92 pt tile) is the kind of layout that gets there.
+      const tile = tileWidthFor(340, 3);
+      expect(tile).toBe(92);
+      const { size, fontSize } = getFallbackChildMetrics(tile, LOGO_SLOT_SIZE);
+      expect(size).toBe(24);
+      expect(fontSize).toBe(16);
+      expect(fontSize).toBeLessThan(FALLBACK_TEXT_SIZE);
+    });
+
+    it('never scales the glyph above its design size', () => {
+      // The plate grows on a Pro Max; the type deliberately does not follow it up.
+      const oversized = widthRange(1, 1024).filter((t) =>
+        REFERENCES.some(
+          ({ referenceSize }) =>
+            getFallbackChildMetrics(t, referenceSize).fontSize > FALLBACK_TEXT_SIZE
+        )
+      );
+      expect(oversized).toEqual([]);
+      expect(getFallbackChildMetrics(tileWidthFor(430, 2), LOGO_SLOT_SIZE).size).toBe(71);
+      expect(getFallbackChildMetrics(tileWidthFor(430, 2), LOGO_SLOT_SIZE).fontSize).toBe(
+        FALLBACK_TEXT_SIZE
+      );
+    });
+
+    it('floors at the smallest size the type scale ships (TYPOGRAPHY.caption2)', () => {
+      // Reachable, unlike a plate floor: a 15 pt plate would want 10 pt type, and the
+      // floor outranks the fit ratio so it gets 11 pt and is allowed to overhang. Only
+      // degenerate tiles get here, but it keeps type from scaling to nothing.
+      const sizes = widthRange(1, 1024).map(
+        (t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).fontSize
+      );
+      expect(Math.min(...sizes)).toBe(11);
+      expect(getFallbackChildMetrics(83, LOGO_SLOT_SIZE).size).toBe(15);
+      expect(getFallbackChildMetrics(83, LOGO_SLOT_SIZE).fontSize).toBe(11);
+    });
+  });
+
+  describe('degenerate inputs', () => {
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 0, -100])(
+      'clamps to a finite, positive plate and glyph for %p',
+      (input) => {
+        for (const { referenceSize } of REFERENCES) {
+          const { size, fontSize } = getFallbackChildMetrics(input, referenceSize);
+          expect(Number.isFinite(size)).toBe(true);
+          expect(size).toBeGreaterThanOrEqual(1);
+          expect(Number.isFinite(fontSize)).toBe(true);
+          expect(fontSize).toBeGreaterThanOrEqual(1);
+        }
+      }
+    );
+
+    it('returns whole-pixel sizes for a fractional tile width', () => {
+      const { size, fontSize } = getFallbackChildMetrics(136.4, LOGO_SLOT_SIZE);
+      expect(Number.isInteger(size)).toBe(true);
+      expect(Number.isInteger(fontSize)).toBe(true);
     });
   });
 });

--- a/features/cards/utils/gridLayout.test.ts
+++ b/features/cards/utils/gridLayout.test.ts
@@ -21,6 +21,7 @@ import {
   GUTTER,
   LIST_CONTENT_PADDING,
   LOGO_SLOT_SIZE,
+  MIN_COMFORTABLE_TILE_WIDTH,
   NUM_COLUMNS,
   SCREEN_MARGIN,
   SINGLE_TILE_HEIGHT,
@@ -308,12 +309,16 @@ describe('intra-tile fallback geometry vs the favourite badge', () => {
     badgeLeftEdge(tileWidth) - centredRightEdge(tileWidth, size);
 
   /**
-   * Tile width a grid of `columns` columns yields at a viewport, generalising
-   * `getGridTileWidth` past its hardcoded `NUM_COLUMNS`. Transcribed rather than
-   * reused so a 3-column future is exercised before it is built.
+   * Tile width a grid of `columns` columns yields at a viewport.
+   *
+   * Delegates to the production helper rather than transcribing it, deliberately unlike
+   * `cellContentWidth` above: that one models a *third party* (FlashList), where an
+   * independent copy is the point, while this is the very function under test. Reusing
+   * it means these sweeps automatically follow any change to the tile arithmetic instead
+   * of silently testing a stale copy of it.
    */
   const tileWidthFor = (windowWidth: number, columns: number): number =>
-    Math.floor((windowWidth - 2 * LIST_CONTENT_PADDING - columns * GUTTER) / columns);
+    getGridTileWidth(windowWidth, columns);
 
   /** The proportional size before any capping — the ideal the cap trims. */
   const proportional = (tileWidth: number, referenceSize: number): number =>
@@ -596,6 +601,168 @@ describe('intra-tile fallback geometry vs the favourite badge', () => {
       const { size, fontSize } = getFallbackChildMetrics(136.4, LOGO_SLOT_SIZE);
       expect(Number.isInteger(size)).toBe(true);
       expect(Number.isInteger(fontSize)).toBe(true);
+    });
+  });
+});
+
+/**
+ * The floor a responsive column count must respect.
+ *
+ * Overlap is already impossible at every width — the sweeps above prove that — so this
+ * is not a correctness guard. It exists because "cannot overlap" and "still looks like
+ * the design" are different bars, and the gap between them is where a 2 → 3 column
+ * story would land if nobody wrote the number down. `MIN_COMFORTABLE_TILE_WIDTH` is that
+ * number; these tests pin the degradation stages behind it and the viewport each column
+ * count needs to clear it, so a breakpoint can be chosen from measurements rather than
+ * from taste.
+ *
+ * Deliberately NOT enforced by a runtime guard: the column count is still a constant, so
+ * there is nothing to guard yet. When it becomes responsive, the story should assert its
+ * chosen breakpoint against `MIN_COMFORTABLE_TILE_WIDTH` here.
+ */
+describe('minimum tile width for a responsive column count', () => {
+  /** The proportional plate size before the badge keep-out cap trims it. */
+  const proportional = (tileWidth: number, referenceSize: number): number =>
+    Math.round((tileWidth * referenceSize) / TILE_WIDTH);
+
+  /** True when the badge keep-out cap leaves the proportional size untouched. */
+  const capIsSlack = (tileWidth: number): boolean =>
+    [LOGO_SLOT_SIZE, AVATAR_SIZE].every(
+      (ref) => getFallbackChildMetrics(tileWidth, ref).size === proportional(tileWidth, ref)
+    );
+
+  /** Smallest viewport at which `columns` columns reach the comfortable floor. */
+  const smallestComfortableViewport = (columns: number): number =>
+    widthRange(100, 1400).find((w) => getGridTileWidth(w, columns) >= MIN_COMFORTABLE_TILE_WIDTH)!;
+
+  it('is derived from the badge keep-out, not written down', () => {
+    // Solving T·(LOGO_SLOT_SIZE / TILE_WIDTH) ≤ T − BADGE_KEEP_OUT for T. Deriving it
+    // means changing the badge or the plate ratio moves this floor automatically.
+    expect(MIN_COMFORTABLE_TILE_WIDTH).toBe(
+      Math.ceil((BADGE_KEEP_OUT * TILE_WIDTH) / (TILE_WIDTH - LOGO_SLOT_SIZE))
+    );
+    expect(MIN_COMFORTABLE_TILE_WIDTH).toBe(109);
+  });
+
+  it('carries exactly one point of headroom over the real cap boundary', () => {
+    // Math.round in getFallbackChildMetrics buys a point over the continuous solution
+    // (108.67…), so the cap is already slack at 108. Asserting the headroom rather than
+    // just the floor means it cannot silently vanish under a future rounding change.
+    const capBinds = widthRange(1, 400).filter((t) => !capIsSlack(t));
+    expect(Math.max(...capBinds)).toBe(107);
+    expect(capIsSlack(MIN_COMFORTABLE_TILE_WIDTH - 1)).toBe(true);
+    expect(capIsSlack(MIN_COMFORTABLE_TILE_WIDTH)).toBe(true);
+  });
+
+  it('is the width at and above which the plates are purely proportional', () => {
+    const capped = widthRange(MIN_COMFORTABLE_TILE_WIDTH, 1024).filter((t) => !capIsSlack(t));
+    expect(capped).toEqual([]);
+  });
+
+  describe('the degradation stages below it', () => {
+    // The table in MIN_COMFORTABLE_TILE_WIDTH's docs, made executable. Each stage is
+    // still correct — no overlap anywhere — but progressively further from the design.
+    it('95–108 pt: 18 pt type still fits everywhere in the band', () => {
+      const stage = widthRange(95, MIN_COMFORTABLE_TILE_WIDTH - 1);
+      expect(
+        stage.filter(
+          (t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).fontSize !== FALLBACK_TEXT_SIZE
+        )
+      ).toEqual([]);
+    });
+
+    it('95–107 pt: the cap trims the slot — and ONLY the slot', () => {
+      // The asymmetry is worth pinning: `avatarCircle`'s 48/171 share stays under the
+      // keep-out through this whole band, so the abbreviation slot is the only child the
+      // cap ever touches here. Any reasoning about "the plates" at these widths is really
+      // reasoning about the slot. (108 is excluded because it is the headroom point,
+      // where rounding leaves even the slot untrimmed — see the headroom test above.)
+      const band = widthRange(95, 107);
+      expect(
+        band.filter(
+          (t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).size === proportional(t, LOGO_SLOT_SIZE)
+        )
+      ).toEqual([]);
+      expect(
+        band.filter(
+          (t) => getFallbackChildMetrics(t, AVATAR_SIZE).size !== proportional(t, AVATAR_SIZE)
+        )
+      ).toEqual([]);
+    });
+
+    it('94 pt and below: the plate is too small for 18 pt, so the glyph shrinks too', () => {
+      const stage = widthRange(61, 94);
+      expect(
+        stage.filter(
+          (t) => getFallbackChildMetrics(t, LOGO_SLOT_SIZE).fontSize >= FALLBACK_TEXT_SIZE
+        )
+      ).toEqual([]);
+    });
+
+    it('85 pt: the plate collapses to 17 pt — correct, but visually poor', () => {
+      expect(getFallbackChildMetrics(85, LOGO_SLOT_SIZE).size).toBe(17);
+    });
+  });
+
+  describe('what each column count needs from the viewport', () => {
+    it.each([
+      { columns: 2, viewport: 266 },
+      { columns: 3, viewport: 391 },
+      { columns: 4, viewport: 516 }
+    ])('$columns columns are comfortable from $viewport dp', ({ columns, viewport }) => {
+      expect(smallestComfortableViewport(columns)).toBe(viewport);
+      expect(getGridTileWidth(viewport, columns)).toBeGreaterThanOrEqual(
+        MIN_COMFORTABLE_TILE_WIDTH
+      );
+      expect(getGridTileWidth(viewport - 1, columns)).toBeLessThan(MIN_COMFORTABLE_TILE_WIDTH);
+    });
+
+    it('leaves the shipped 2-column grid comfortable on every phone', () => {
+      // 266 dp is far below the narrowest width AC7 exercises, so this change asks
+      // nothing of the current layout — the floor only constrains a FUTURE column count.
+      const uncomfortable = widthRange(280, 1024).filter(
+        (w) => getGridTileWidth(w, 2) < MIN_COMFORTABLE_TILE_WIDTH
+      );
+      expect(uncomfortable).toEqual([]);
+    });
+
+    it('rules out 3 columns on the phones a naive breakpoint would catch', () => {
+      // The trap this test exists to close. Each is a plausible "large phone" breakpoint
+      // that still produces a sub-floor tile.
+      for (const viewport of [320, 360, 375, 384, 390]) {
+        expect(getGridTileWidth(viewport, 3)).toBeLessThan(MIN_COMFORTABLE_TILE_WIDTH);
+      }
+    });
+
+    it('splits the modern phone range one dp above the design reference', () => {
+      // The sharpest fact for a breakpoint decision, and not one anybody would guess:
+      // a 390 dp iPhone misses the floor by exactly ONE point, while a 393 dp Pixel
+      // clears it. So "3 columns on large phones" is decidable, but only just — which is
+      // the whole argument for stating the floor as a number instead of eyeballing it.
+      expect(getGridTileWidth(390, 3)).toBe(MIN_COMFORTABLE_TILE_WIDTH - 1);
+      expect(getGridTileWidth(391, 3)).toBe(MIN_COMFORTABLE_TILE_WIDTH);
+
+      // Everything from the Pixel up is comfortable, so a 3-column grid is genuinely
+      // available to most current hardware — it is the narrow tail that must stay at 2.
+      for (const viewport of [393, 402, 412, 430]) {
+        expect(getGridTileWidth(viewport, 3)).toBeGreaterThanOrEqual(MIN_COMFORTABLE_TILE_WIDTH);
+      }
+    });
+
+    it("clears 3 columns at CatalogueGrid's existing 600 dp breakpoint", () => {
+      // features/cards/components/CatalogueGrid.tsx:27 — the in-folder precedent a
+      // future story is most likely to copy. Confirmed safe, with room to spare.
+      const CATALOGUE_COLUMN_BREAKPOINT = 600;
+      expect(getGridTileWidth(CATALOGUE_COLUMN_BREAKPOINT, 3)).toBeGreaterThanOrEqual(
+        MIN_COMFORTABLE_TILE_WIDTH
+      );
+      expect(CATALOGUE_COLUMN_BREAKPOINT).toBeGreaterThanOrEqual(smallestComfortableViewport(3));
+    });
+
+    it('needs a wider viewport for every column it adds', () => {
+      const needed = [2, 3, 4, 5].map(smallestComfortableViewport);
+      expect(needed).toEqual([...needed].sort((a, b) => a - b));
+      expect(new Set(needed).size).toBe(needed.length);
     });
   });
 });

--- a/features/cards/utils/gridLayout.ts
+++ b/features/cards/utils/gridLayout.ts
@@ -45,6 +45,19 @@
  * The slack can only ever ADD clearance, never remove it, so the no-overlap
  * invariant holds for any real viewport. Both bounds are asserted in
  * `gridLayout.test.ts` so neither can silently grow.
+ *
+ * ## The second invariant: inside the tile
+ *
+ * Letting the tile track the viewport moved the same class of bug one level down.
+ * `CardTile`'s fallback children were *also* frozen measurements — `logoSlot` 64 pt
+ * and `avatarCircle` 48 pt, both centre-aligned — while `favouriteBadge` is pinned
+ * to the right edge. At a fixed 171 pt tile they could never meet; on a narrower
+ * tile they can, and a 3-column grid (≈116 pt at 412 dp) would reach it.
+ *
+ * So this module owns a second relationship, `getFallbackChildMetrics`: a centred
+ * child is sized *from* the tile and capped so it cannot reach the badge. Same
+ * lesson as above — the invariant is "the child clears the badge", not "the child
+ * is 64 pt".
  */
 
 /** Fixed column count. Deliberately not responsive — see the story's Out of scope. */
@@ -143,3 +156,161 @@ export const getSingleTileWidth = (windowWidth: number): number =>
  */
 export const getSingleTileHeight = (tileWidth: number): number =>
   toTileDimension(Math.round((tileWidth * SINGLE_TILE_HEIGHT) / SINGLE_TILE_WIDTH));
+
+// ─── Intra-tile geometry: the centred fallback children vs the pinned badge ───
+
+/**
+ * Favourite-badge geometry (pt), mirrored from `CardTile`'s `favouriteBadge` style.
+ *
+ * Deliberately **not** proportional to the tile, and that is a design decision
+ * rather than an oversight. The badge is an affordance, not decoration: it wraps a
+ * 16 pt star in a near-opaque white plate so the amber glyph stays legible on any
+ * brand colour, including the light and yellow ones. Shrinking it with the tile
+ * would attack the legibility it exists to provide, and 24 pt is already at the
+ * small end of a comfortable target. So the badge holds its size and the *centred*
+ * children give way around it — see `getFallbackChildMetrics`.
+ */
+export const BADGE_SIZE = 24;
+export const BADGE_INSET = 6;
+
+/**
+ * Smallest gap (pt) we leave between a centred child's right edge and the badge.
+ *
+ * Not zero: "does not overlap" and "reads as two separate elements" are different
+ * bars. It also carries more weight than it looks, because the two stop being
+ * *vertically* separated as the tile shrinks. At the 390 dp reference the 64 pt slot
+ * starts 38 pt down and the badge ends at 30 pt, so they miss on both axes; on a
+ * ≈116 pt tile the slot starts around 26 pt and the vertical ranges genuinely
+ * overlap. Below roughly a 150 pt tile, horizontal clearance is the *only* thing
+ * keeping them apart.
+ */
+export const BADGE_CLEARANCE = 4;
+
+/**
+ * Horizontal room (pt) a centre-aligned child must leave free so it cannot reach
+ * the right-pinned badge.
+ *
+ * Derived rather than written as 68, for the same reason as `LIST_CONTENT_PADDING`:
+ * the badge's style constants and this arithmetic must not be able to drift apart.
+ * The doubling is not a safety margin — a centred child grows from its middle, so
+ * every point of width costs half a point of clearance on *each* side. That factor
+ * of two is exactly what makes the tile's own `0.85` logo factor unusable here:
+ * `0.85 × T < T − 68` would need a tile wider than 450 pt.
+ */
+export const BADGE_KEEP_OUT = 2 * (BADGE_INSET + BADGE_SIZE + BADGE_CLEARANCE);
+
+/**
+ * Design-reference sizes (pt) of the two centred fallback children, measured at
+ * `TILE_WIDTH`. Like `TILE_WIDTH` itself these are the *ratio source*, not applied
+ * layout values — `getFallbackChildMetrics` produces those.
+ */
+export const LOGO_SLOT_SIZE = 64;
+export const AVATAR_SIZE = 48;
+
+/**
+ * Glyph size (pt) inside those plates. Unlike the plate itself this is a *target*
+ * rather than a ratio source: the type holds its design size wherever the plate can
+ * contain it, so the abbreviation and the avatar letter stay consistent with the rest
+ * of the app on every device that ships today, and shrink only where a capped plate
+ * genuinely cannot hold them.
+ */
+export const FALLBACK_TEXT_SIZE = 18;
+
+/**
+ * Plate needed per point of type, as a multiple of the font size.
+ *
+ * React Native offers no synchronous text-measurement API, so this is a deliberately
+ * conservative estimate rather than a measurement. Two components: the widest case is
+ * the brand abbreviation's *two* uppercase glyphs at ≈0.65 em of advance each (≈1.3 em
+ * total, wider than the ≈1.2 em line box), plus a little padding so the glyph is not
+ * flush against the plate's edge. Erring high only shrinks type a step early; erring
+ * low would let it spill outside the plate, which is the visible failure.
+ */
+const FALLBACK_TEXT_FIT_RATIO = 1.45;
+
+/**
+ * Floor for the glyph — `TYPOGRAPHY.caption2`, the smallest size the design system
+ * ships. Taken from the scale rather than invented, though not imported: this module
+ * is deliberately dependency-free pure arithmetic. It outranks the fit ratio, so a
+ * degenerately small plate gets unreadably-but-honestly clipped type rather than type
+ * scaled below the point of being type.
+ *
+ * There is deliberately **no matching floor on the plate itself**, and that is a
+ * finding rather than an omission. A size floor could never bind: it would need the
+ * proportional size to fall under it (a tile below ~63 pt) while the badge keep-out
+ * still permitted it (a tile above 92 pt), and those ranges do not intersect. Adding
+ * one would be unreachable code that also, where it *did* apply, ate the very
+ * clearance the cap exists to protect — at an 85 pt tile a 24 pt floor leaves a
+ * 0.5 pt gap instead of 4. The keep-out cap is therefore the effective minimum, and
+ * keeping plates from getting absurdly small in the first place is the job of
+ * whoever chooses the column count (a minimum *tile* width), not of this function.
+ */
+const MIN_FALLBACK_TEXT_SIZE = 11;
+
+/** Applied size of one centred fallback child, plus the glyph size that fits it. */
+export interface FallbackChildMetrics {
+  /** Side length (pt) of the plate. */
+  size: number;
+  /** Glyph size (pt) for the text centred inside it. */
+  fontSize: number;
+}
+
+/**
+ * Size a centred fallback child (`logoSlot` or `avatarCircle`) for a tile of the
+ * given width, so that it tracks the tile and can never reach the favourite badge.
+ *
+ * Two constraints:
+ *
+ * 1. **Proportional** — `round(tileWidth × referenceSize / TILE_WIDTH)`, so the child
+ *    keeps its share of the tile at every width and reproduces the reference size
+ *    *exactly* at 390 dp (64 and 48), leaving that viewport pixel-identical.
+ * 2. **Capped** at `tileWidth − BADGE_KEEP_OUT`, so it cannot reach the badge.
+ *
+ * The cap is the whole point, because proportionality alone is *not* sufficient:
+ * `logoSlot`'s 64/171 share only clears the badge above a ≈96 pt tile, and a
+ * 3-column grid on a 320 dp phone (85 pt) breaches it. Clamping makes the clearance
+ * hold by construction rather than holding for as long as nobody picks an unlucky
+ * column count — the same reason `getGridTileWidth` floors rather than trusting 171.
+ *
+ * The cap is slack at every width that ships today: it binds only below a ≈109 pt
+ * tile, so on real 2-column phones (136 pt at 320 dp and up) pure proportionality is
+ * what you see.
+ *
+ * Clearance is at least `BADGE_CLEARANCE` for any tile of 69 pt or more — below that
+ * the cap would ask for a sub-1 pt plate and `toTileDimension`'s 1 pt floor takes
+ * over, which still clears down to 61 pt but by less than the nominal gap. At 60 pt
+ * and below the badge's own 30 pt footprint has crossed the tile's centre line, so
+ * *no* centred child can clear it and the badge itself would have to change — see
+ * `BADGE_SIZE`. That is a ≈168 dp 2-column viewport: unreachable, and swept in
+ * `gridLayout.test.ts` so all three thresholds are stated contracts rather than
+ * discovered surprises.
+ *
+ * The **glyph** follows a different rule from the plate on purpose: it holds
+ * `FALLBACK_TEXT_SIZE` wherever the plate can contain it and shrinks only when the cap
+ * has taken the plate below that, so type stays consistent with the rest of the app on
+ * every device that ships today. It never scales *up* either — a wider tile gets a
+ * larger plate with the same 18 pt letters in it.
+ *
+ * The plate's corner radius is deliberately left fixed, consistent with the same
+ * decision for `TILE_RADIUS`.
+ */
+export const getFallbackChildMetrics = (
+  tileWidth: number,
+  referenceSize: number
+): FallbackChildMetrics => {
+  const proportional = Math.round((tileWidth * referenceSize) / TILE_WIDTH);
+  const size = toTileDimension(Math.min(proportional, tileWidth - BADGE_KEEP_OUT));
+
+  // The glyph keeps its design size wherever the plate can hold it, and shrinks to fit
+  // only once the badge cap has taken the plate below that. It is measured against the
+  // PLATE rather than the tile, because the plate is what has to contain it.
+  return {
+    size,
+    fontSize: toTileDimension(
+      Math.min(
+        FALLBACK_TEXT_SIZE,
+        Math.max(MIN_FALLBACK_TEXT_SIZE, Math.floor(size / FALLBACK_TEXT_FIT_RATIO))
+      )
+    )
+  };
+};

--- a/features/cards/utils/gridLayout.ts
+++ b/features/cards/utils/gridLayout.ts
@@ -60,7 +60,14 @@
  * is 64 pt".
  */
 
-/** Fixed column count. Deliberately not responsive — see the story's Out of scope. */
+/**
+ * Fixed column count. Deliberately not responsive — see the story's Out of scope.
+ *
+ * If you are here to make it responsive: `getGridTileWidth` already takes a column
+ * count, so no new geometry is needed — but the resulting tile must stay at or above
+ * `MIN_COMFORTABLE_TILE_WIDTH`, which is a hard floor rather than a preference. Read
+ * that constant's docs before choosing a breakpoint; 3 columns needs a 391 dp viewport.
+ */
 export const NUM_COLUMNS = 2;
 
 /** Horizontal screen margin (pt) either side of the grid. */
@@ -115,18 +122,25 @@ const toTileDimension = (value: number): number =>
   Number.isFinite(value) ? Math.max(MIN_TILE_DIMENSION, value) : MIN_TILE_DIMENSION;
 
 /**
- * Width (pt) for one tile in the 2-column grid at the given window width.
+ * Width (pt) for one tile in the grid at the given window width.
  *
- * `floor((W − 48) / 2)` — exactly the space FlashList leaves inside a cell once
- * `LIST_CONTENT_PADDING` and the wrapper's `GUTTER / 2` are spent. Flooring
- * guarantees the fit can never fail to a sub-pixel.
+ * `floor((W − 2 × LIST_CONTENT_PADDING − columns × GUTTER) / columns)` — exactly the
+ * space FlashList leaves inside a cell once `LIST_CONTENT_PADDING` and the wrapper's
+ * `GUTTER / 2` are spent. Flooring guarantees the fit can never fail to a sub-pixel.
  *
- * Returns exactly `TILE_WIDTH` (171) at the 390 dp reference width, so the grid
- * is visually unchanged there.
+ * Returns exactly `TILE_WIDTH` (171) at the 390 dp reference width, so the grid is
+ * visually unchanged there.
+ *
+ * `columns` defaults to `NUM_COLUMNS`, so every current caller is unchanged. It is a
+ * parameter rather than a hardcode because the margin arithmetic generalises exactly:
+ * adjacent wrappers contribute `GUTTER` and the outer edges `SCREEN_MARGIN` at *any*
+ * column count, so a responsive grid needs no new geometry — only a column count and
+ * the `MIN_COMFORTABLE_TILE_WIDTH` check below. Passing it also lets the tests assert
+ * the 3-column case against this function instead of a transcription of it.
  */
-export const getGridTileWidth = (windowWidth: number): number =>
+export const getGridTileWidth = (windowWidth: number, columns: number = NUM_COLUMNS): number =>
   toTileDimension(
-    Math.floor((windowWidth - 2 * LIST_CONTENT_PADDING - NUM_COLUMNS * GUTTER) / NUM_COLUMNS)
+    Math.floor((windowWidth - 2 * LIST_CONTENT_PADDING - columns * GUTTER) / columns)
   );
 
 /**
@@ -314,3 +328,38 @@ export const getFallbackChildMetrics = (
     )
   };
 };
+
+/**
+ * Narrowest tile (pt) at which the grid still looks the way it was designed — the
+ * floor any responsive column count must respect.
+ *
+ * **This is a constraint on the column count, not on this module.** Overlap is already
+ * impossible at every width (`getFallbackChildMetrics` caps the plates), so a narrower
+ * tile is never *broken* — it degrades, in stages that are worth knowing before picking
+ * a breakpoint:
+ *
+ * | tile      | what happens                                                          |
+ * | --------- | --------------------------------------------------------------------- |
+ * | ≥ 109 pt  | pure proportionality; the badge keep-out never engages. The target.    |
+ * | 95–107 pt | the cap trims the abbreviation slot — and only it; the avatar's        |
+ * |           | smaller share stays clear. The 18 pt glyph still fits either way.      |
+ * | ≤ 94 pt   | the plate is too small for 18 pt type, so the glyph shrinks too.       |
+ * | 85 pt     | plate collapses to 17 pt. Still correct, but visually poor.            |
+ *
+ * Derived rather than written as 109: it is the tile at which the proportional plate
+ * stops exceeding its keep-out, `T·(LOGO_SLOT_SIZE / TILE_WIDTH) ≤ T − BADGE_KEEP_OUT`
+ * solved for `T`. Deriving it means a change to the badge or the plate ratio moves this
+ * floor automatically instead of leaving a stale number behind. `Math.round` in
+ * `getFallbackChildMetrics` actually buys one point over the continuous solution, so the
+ * cap is already slack at 108 — the extra point is headroom, and `gridLayout.test.ts`
+ * pins both numbers so the headroom cannot silently disappear.
+ *
+ * With `getGridTileWidth`'s generalised arithmetic, 2 columns clear this from 266 dp up
+ * (so every shipped phone, with room to spare), **3 columns need 391 dp** and 4 need
+ * 516 dp. 391 is the number a responsive breakpoint has to beat: `CatalogueGrid.tsx`'s
+ * existing 600 dp is comfortably safe, but a naive "3 columns above 360 dp" is not — it
+ * would hand a 360 dp phone a 98 pt tile.
+ */
+export const MIN_COMFORTABLE_TILE_WIDTH = Math.ceil(
+  (BADGE_KEEP_OUT * TILE_WIDTH) / (TILE_WIDTH - LOGO_SLOT_SIZE)
+);


### PR DESCRIPTION
Spun off from the card-tile overlap fix (#173), which flagged this as follow-up work rather than fixing it: scaling the tile's fallback children is a visual design change, not a bug fix.

## The problem

That fix made the tile width viewport-derived. Its two centred fallback children stayed **fixed** — the brand-abbreviation slot at 64 pt and the first-letter avatar at 48 pt — while `favouriteBadge` is pinned to the right edge. A centred child only clears that badge while its width stays under `tileWidth − 60`, so the plates had quietly become the same species of frozen measurement the tile itself had been.

Nothing overlaps on any shipping device today. But a 3-column grid — flagged as a follow-up by that same story, and already the pattern in `CatalogueGrid.tsx` — gives a ~116 pt tile on a 412 dp phone, where a 64 pt slot overlaps the star by 4 pt.

## What changed

**Plates are derived from the tile and capped clear of the badge.** `getFallbackChildMetrics` in `features/cards/utils/gridLayout.ts` takes `round(tileWidth × ref / TILE_WIDTH)` and caps it at `tileWidth − BADGE_KEEP_OUT`. Proportionality alone is not sufficient — the slot's 64/171 share only clears the badge above a ~96 pt tile — so the cap is what makes no-overlap structural rather than a happy accident of the column count.

**The badge deliberately stays fixed.** It is a legibility floor for a 16 pt star on any brand colour, including the light and yellow ones. Its own constants now feed `BADGE_KEEP_OUT`, so the style and the arithmetic cannot drift apart — same reasoning as the existing derived `LIST_CONTENT_PADDING`.

**Glyphs hold their 18 pt design size** wherever the plate can contain them, and shrink to fit only where a capped plate cannot. They never scale up either.

**A column-count floor, derived not invented.** `MIN_COMFORTABLE_TILE_WIDTH` solves `T × (LOGO_SLOT_SIZE / TILE_WIDTH) ≤ T − BADGE_KEEP_OUT` for `T`, landing on 109 pt. `getGridTileWidth` now takes an optional column count (defaulting to `NUM_COLUMNS`, so every current caller is unchanged), because the margin arithmetic already generalises exactly.

## Visual change — please sanity-check on device

The 390 dp design reference is **pixel-identical** (64 / 48 / 18 pt). Every other width now scales, which ifero approved after reviewing a rendered comparison:

| viewport | tile | slot | note |
| --- | --- | --- | --- |
| 320 dp, 2 col | 136 | 64 → 51 | shrinks ~20 % |
| 390 dp, 2 col | 171 | 64 | unchanged |
| 430 dp, 2 col | 191 | 64 → 71 | grows ~11 % |
| 412 dp, 3 col | 116 | 64 → 43 | was a 4 pt overlap |

Two options were considered and declined: shrink-only (never larger than designed) and cap-only (zero change until a 3-column grid exists). Scaling both ways was chosen to keep the composition constant, consistent with the SVG logo path which already scales both ways.

## Notable findings

- **The obvious approach would have guaranteed the overlap.** Copying `logoWidth`'s `× 0.85` needs a tile wider than 450 pt to clear the badge. The same arithmetic shows the **SVG logo path already overlaps the badge at every width** (145 pt of logo against a badge edge at 141 pt on the reference). That is pre-existing and intentional — an opaque plate over a mostly-transparent logo reads fine — and is now documented in code rather than changed.
- **A size floor was deliberately omitted.** It can never bind: the range where the proportion falls below it and the range where the cap would permit it do not intersect. It would have been unreachable code that, where it did apply, ate the clearance the cap exists to protect. `gridLayout.ts` is at 100 % branch coverage, which confirms nothing unreachable remains.
- **A 390 dp iPhone misses the column floor by exactly one point** while a 393 dp Pixel clears it — so 3 columns are available to most current hardware and it is the narrow tail that must stay at 2. That one-point margin is the argument for a stated number over eyeballing.

## Tests

The exhaustive sweep lives in `gridLayout.test.ts`, across every tile a 2- or 3-column grid can produce from 280–1024 dp, plus the three clearance thresholds and the four degradation stages behind the column floor. The two guard tests in `CardTile.test.tsx` are tightened from a single 136 pt case to a table including the 116 pt and 98 pt tiles a 3-column grid produces — 136 pt alone was **not falsifiable**, since the old fixed sizes cleared there, and neither is 116 pt for the avatar, which is why the 98 pt row is present.

Mutation-checked: restoring the fixed plate sizes fails 20 tests, removing the glyph fit rule fails 3, hardcoding the column floor fails 8, and ignoring the new `columns` argument fails 10.

`170 suites / 1947 tests` green, `gridLayout.ts` at 100 % on all four metrics, `typecheck` / `tokens:check` / `splash:check` / `lint` / `prettier` clean. The one remaining lint warning (`import/order` in `CardTile.test.tsx`) is pre-existing on main and only shifted line number.

## Why the `design` label

This is a code change with no story behind it: the overlap fix spun it off as a separate task, and no story has been drafted because choosing a responsive breakpoint is a product decision. The `design` label is the story-exempt fast-path for exactly this — a UX/visual change. Happy to draft a story instead if you would rather it went through the normal spec-first route.

## Follow-up

When the responsive-column story is drafted it must fix a **minimum tile width**, not only a viewport breakpoint. The numbers are now in `MIN_COMFORTABLE_TILE_WIDTH`'s docs and asserted in the tests: 3 columns need 391 dp, 4 need 516 dp, and the existing 600 dp breakpoint in `CatalogueGrid.tsx` is comfortably safe.
