### PR TITLE
chore(git): ignore .claude/worktrees in the committed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,13 @@ fastlane/.env.default
 # Claude Code local (personal) settings
 .claude/settings.local.json
 
+# Claude Code git worktrees — full nested checkouts of this repo, one per in-flight branch
+# (hundreds of thousands of duplicate files). Ignored here rather than only in .git/info/exclude,
+# which is local to one clone and never committed: tools that read .gitignore but cannot see
+# info/exclude — prettier among them — otherwise walk every copy. Tools that read neither carry
+# their own entry instead (see eslint.config.mjs `ignores` and jest.config.js path guards).
+.claude/worktrees/
+
 # BMAD personal install answers (installer-regenerated per developer; shared config lives in
 # _bmad/config.toml and _bmad/custom/config.toml, which ARE committed)
 _bmad/config.user.toml


### PR DESCRIPTION
## What

Adds `.claude/worktrees/` to the committed `.gitignore`.

## Why

Claude Code creates a git worktree per in-flight branch under `.claude/worktrees/`. Each one is a full nested checkout of this repo — currently fourteen of them, on the order of a quarter of a million files.

Until now that directory was excluded from git **only** via `.git/info/exclude`. That file lives inside a single clone's git directory: it is never committed, never cloned, and never present in a fresh CI checkout. The exclusion therefore existed on exactly one machine.

The cost lands not on git itself but on every tool that reads `.gitignore` and cannot see `info/exclude`. Prettier is one: `prettier --check .` in the main checkout did not finish in six minutes, and `prettier --write .` descends into all the nested worktrees and rewrites files belonging to other in-flight branches. That instance was handled with a `.prettierignore` entry on a separate branch. This change fixes the class rather than the instance, so the next such tool — a bundler, a search indexer, anything that treats `.gitignore` as the project's ignore contract — needs no second patch.

It also makes an existing comment true: `eslint.config.mjs` already ignores `.claude/**` and describes those worktrees as "gitignored", which up to now was accurate only by way of a local, uncommitted file.

## Scope and safety

- **No change to git's own behaviour.** `git ls-files .claude/worktrees` returns nothing, so no tracked path is shadowed. Ignore rules never apply to paths already in the index; this governs untracked paths only.
- **Nothing else under `.claude/` is affected.** The pattern contains a slash, so it is anchored to the repo root, and the trailing slash restricts the match to directories. Confirmed that the roughly one thousand tracked files under `.claude/skills/` and the tracked `.claude/settings.json` stay visible to git.
- **The `.git/info/exclude` entry is deliberately left in place.** It is shared by every worktree through the common git directory, so dropping it now would expose `.claude/worktrees/` as untracked in the main checkout on every revision predating this commit — including any worktree parked on an older branch, where a broad `git add` would then sweep in the whole nested tree. Keeping it costs nothing and it becomes genuinely redundant once this change is everywhere.

## Verification

- `git check-ignore -v` names `.gitignore` as the matching source, taking precedence over `info/exclude` as expected.
- Reproduced in a throwaway repo initialised with **no** `info/exclude` entry — a faithful stand-in for a fresh clone or a CI checkout — containing a nested `.claude/worktrees/<branch>/` tree alongside sibling `.claude/skills/` and `.claude/settings.json` files. The worktrees path is ignored; the siblings still report as untracked.
- Full pre-push gate run (typecheck, design-token sync, splash sync, lint, jest) is green, with every suite and every test passing.

## Notes

Config only, no product code. `chore:` title, so the spec-first story requirement does not apply.
