### PR TITLE
chore(test): anchor Jest's .claude ignore patterns to rootDir

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,10 +25,25 @@ module.exports = {
     '^@bwip-js/react-native$': '<rootDir>/__mocks__/@bwip-js/react-native.js'
   },
   testMatch: ['**/*.test.[jt]s?(x)'],
-  testPathIgnorePatterns: ['/node_modules/', '/.claude/', 'babel.config.test.js', 'targets/watch/'],
-  // Nested Claude Code worktrees (.claude/worktrees/*) are full repo copies; their
-  // duplicate package.json/modules otherwise crash Jest with Haste name collisions.
-  modulePathIgnorePatterns: ['/.claude/'],
+  // Nested Claude Code worktrees (.claude/worktrees/*) are full repo copies. Left
+  // visible they duplicate every `__mocks__/` and module in the tree, so Jest's Haste
+  // map warns `duplicate manual mock found: svgMock` and discovery balloons from ~170
+  // test files to ~2100 — this checkout would run other branches' suites as its own.
+  //
+  // The `<rootDir>` anchor is load-bearing. Both options are regexes matched against
+  // ABSOLUTE paths, so a bare `/.claude/` also matched the path of the worktree Jest was
+  // running *inside* — every test path under `.claude/worktrees/<branch>/` was ignored,
+  // giving "No tests found" and exit 1, which made `.husky/pre-push` (it runs `yarn test`)
+  // impossible to pass from a worktree and pushed developers toward the forbidden
+  // `--no-verify`. Anchored, the patterns exclude only a `.claude/` nested *under this
+  // rootDir*, wherever the checkout itself happens to live.
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/.claude/',
+    'babel.config.test.js',
+    'targets/watch/'
+  ],
+  modulePathIgnorePatterns: ['<rootDir>/.claude/'],
   collectCoverageFrom: [
     'features/**/*.{ts,tsx}',
     'core/**/*.{ts,tsx}',


### PR DESCRIPTION
## Problem

`jest.config.js` excluded nested Claude Code worktrees with two **unanchored** regexes:

```js
testPathIgnorePatterns: ['/node_modules/', '/.claude/', …],
modulePathIgnorePatterns: ['/.claude/'],
```

Both options are matched against **absolute** paths, so a bare `/.claude/` also matched the path of the
worktree Jest was running *inside*. Every test path under `.claude/worktrees/<branch>/` was ignored:

```
No tests found, exiting with code 1
Pattern:  - 0 matches
```

`.husky/pre-push` runs `yarn test`, so it could never pass from inside a worktree — which pushes
developers toward the `--no-verify` that CONTRIBUTING strictly forbids. This reproduces with a
**complete** `node_modules` present, so it is a distinct problem from dependency absence.

## Fix

Anchor both patterns to `<rootDir>`, so they exclude only a `.claude/` nested *under the current
rootDir*, wherever the checkout itself lives. The existing explanatory comment is kept and extended
with why the anchor is load-bearing.

## Verification

**The guard is still load-bearing.** With it removed from the main checkout, discovery balloons from
**170** test files to **2148**, and a real run prints `jest-haste-map: duplicate manual mock found`
for `svgMock` and `@bwip-js/react-native` (on stdout, not stderr). The retained comment now describes
that measured symptom instead of the crash it never caused.

**Main checkout unchanged.** Full run under the current config and under the anchored config: both
**170 suites / 1890 tests, exit 0**, with zero haste/duplicate/collision lines across both streams —
checked with a freshly created nested worktree present, giving twelve duplicate `svgMock.js` copies
on disk.

**Exclusion sets are provably identical where it matters.** Comparing which paths each pattern
excludes, over every one of the 3383 tracked paths:

| rootDir | old excludes | new excludes | identical? |
| --- | --- | --- | --- |
| CI runner | 1068 / 1040 | 1068 / 1040 | **yes** |
| main checkout | 1068 / 1040 | 1068 / 1040 | **yes** |
| inside a worktree | **3383 / 3383** (everything) | 1068 / 1040 | no — recovers exactly the 170 test files, gains none |

The repo tracks over a thousand files under `.claude/` (the compiled BMAD skills), so a clean CI
checkout does contain a `<rootDir>/.claude/`; the anchor is not a silent no-op there, it matches the
same set as before. CI behaviour is therefore identical. The excluded `*.test.*` paths are unchanged:
`babel.config.test.js` plus the four allowlisted `targets/watch/__tests__/` contract tests.

**Coverage untouched.** `yarn test:coverage` from inside a worktree exits 0 and clears every
threshold, instrumenting the same 178 files as an unmodified main-checkout run — set-compared
path-by-path — with identical global percentages. `collectCoverageFrom` is not modified.

**End to end.** `git push --dry-run` from inside a worktree fires git's real hook path and reports
`All checks passed!`, then `* [new branch]`. No `--no-verify` anywhere.

## Notes for the reviewer

- The main-checkout probes ran via `--config` with an explicit `rootDir`, so no tracked file in that
  checkout was modified at any point.
- A follow-up docs PR corrects the standing guidance that says gates cannot run in a worktree; it is
  stacked on this branch and should merge after it.
