### PR TITLE
docs(sprint): correct the "never run gates in a worktree" guidance

### DIFF
--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -463,5 +463,7 @@ Before submitting code, verify:
 - [ ] Tests co-located; no `__tests__/` folder; no tests in `app/`
 - [ ] New strings added to **both** `shared/i18n/locales/en.ts` and `it.ts` (no parity test exists)
 - [ ] Sync messages include `version` where versioned
-- [ ] `yarn lint` / `typecheck` / `test` / `tokens:check` run from the **main checkout**, not a
-      `.claude` worktree
+- [ ] `yarn lint` / `typecheck` / `test` / `tokens:check` run in a checkout with its own
+      `node_modules` (a `.claude` worktree qualifies after `yarn install`); native builds
+      (`yarn watch:build`, `yarn ios`) still need the **main checkout**, and `--no-verify` is forbidden
+      everywhere

--- a/docs/sprint-artifacts/stories/10-1-create-wear-os-project-structure.md
+++ b/docs/sprint-artifacts/stories/10-1-create-wear-os-project-structure.md
@@ -8,9 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree** — `jest.config.js` sets
-> `modulePathIgnorePatterns: ['/.claude/']`, so `yarn test` there finds zero tests and passes
-> vacuously.
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **This is the enabling story for all of Epic 10.** 10-2 … 10-6 build directly on the module layout,
 > `applicationId` and Gradle setup decided here. Get the Open Decisions right; they are binding.
@@ -256,7 +259,8 @@ approach has drifted — re-read [Why this cannot mirror watchOS](#why-this-cann
 ### Testing requirements
 
 - **Phone-app gates are the regression guard**: `yarn lint`, `yarn typecheck`, `yarn test`,
-  `yarn tokens:check`, `yarn splash:check`, plus `yarn watch:build`, all from the **main checkout**.
+  `yarn tokens:check`, `yarn splash:check` — any checkout with its own `node_modules`, worktree
+  included — plus `yarn watch:build`, which needs the **main checkout** for its prebuilt `ios/`.
 - **Kotlin unit tests are not required by this story** — there is no logic yet beyond a placeholder.
   Do not manufacture tests for a scaffold. 10-2 onward carry real testable logic, and the repo already
   has a precedent for cheap cross-platform guards: `targets/watch/__tests__/watch-layout-contract.test.ts`

--- a/docs/sprint-artifacts/stories/10-2-generate-catalogue-for-wear-os.md
+++ b/docs/sprint-artifacts/stories/10-2-generate-catalogue-for-wear-os.md
@@ -8,7 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree.**
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **Depends on 10-1** — needs `watch-android/` to exist. Do not start before it merges.
 >
@@ -198,7 +203,8 @@ generator and its artifact are untouched.
 - [ ] **Task 5 — Tests and docs (AC: 9, 10, 11)**
   - [ ] Write the AC9 tests.
   - [ ] Update `watch-android/README.md` and the add-a-brand documentation.
-  - [ ] Run the full gate suite from the main checkout.
+  - [ ] Run the full gate suite (JS gates in any installed checkout; native builds from the main
+        checkout).
 
 ## Dev Notes
 
@@ -235,7 +241,7 @@ watchOS generator and its artifact.
 
 ### Testing requirements
 
-- Run from the **main checkout**. `features/**`, `core/**`, `shared/**` are coverage-measured at 80 %
+- `features/**`, `core/**`, `shared/**` are coverage-measured at 80 %
   global; `scripts/` is **not** in `collectCoverageFrom`, so these tests do not move the coverage
   number — write them for correctness, not for the gate.
 - The most valuable test is the **negative** one: mutate the committed artifact, assert `--check` fails.

--- a/docs/sprint-artifacts/stories/10-3-implement-card-list-carbon-ui.md
+++ b/docs/sprint-artifacts/stories/10-3-implement-card-list-carbon-ui.md
@@ -8,7 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree.**
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **Depends on 10-1** (module) and **10-2** (`Brands.kt`). Pairs with **10-5** (Room) and **10-6**
 > (sync) — this story renders a list; it must work against a local store it does not itself populate.
@@ -261,7 +266,8 @@ and the Kotlin unit tests pass in `watch-android/`.
 
 ### Testing requirements
 
-- Phone-app gates from the **main checkout**; Kotlin tests via Gradle in `watch-android/`.
+- Phone-app gates from any installed checkout (worktree included); Kotlin tests via Gradle in
+  `watch-android/`.
 - **Be honest about what CI runs.** The watchOS precedent is a trap worth naming: Swift XCTests in
   `watch-ios/Tests/` **do not run in CI** — the watch scheme has no `xcodebuild test` step, so
   `yarn watch:build` only proves it _compiles_. The project compensated with

--- a/docs/sprint-artifacts/stories/10-4-display-barcode-on-wear-os.md
+++ b/docs/sprint-artifacts/stories/10-4-display-barcode-on-wear-os.md
@@ -8,7 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree.**
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **Depends on 10-1** (module) and **10-3** (the list and its navigation seam).
 >
@@ -237,7 +242,8 @@ and the Kotlin tests pass in `watch-android/`.
 
 ### Testing requirements
 
-- Phone-app gates from the **main checkout**; Kotlin tests via Gradle in `watch-android/`.
+- Phone-app gates from any installed checkout (worktree included); Kotlin tests via Gradle in
+  `watch-android/`.
 - **The honest coverage caveat, again:** watchOS's Swift XCTests do not run in CI (the watch scheme has
   no `xcodebuild test` step), which is why `targets/watch/__tests__/watch-layout-contract.test.ts` — a
   TypeScript test that reads Swift source as text — carries the CI-enforced watch layout invariants.

--- a/docs/sprint-artifacts/stories/10-5-store-cards-locally.md
+++ b/docs/sprint-artifacts/stories/10-5-store-cards-locally.md
@@ -8,7 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree.**
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **Depends on 10-1** (module) and **10-3** (the read interface this story implements). Feeds **10-6**,
 > which writes into this store from the Data Layer.
@@ -207,7 +212,8 @@ and the Kotlin tests pass in `watch-android/`.
 
 ### Testing requirements
 
-- Phone-app gates from the **main checkout**; Kotlin/Room tests via Gradle in `watch-android/`.
+- Phone-app gates from any installed checkout (worktree included); Kotlin/Room tests via Gradle in
+  `watch-android/`.
 - **In-memory database for tests**, mirroring 5-9 AC2's `ModelContainer(for:)`-in-memory approach. Never
   touch a real device database in a test.
 - Room's migration testing helper is the reason AC4's test is cheap. Wire the exported schema now; it

--- a/docs/sprint-artifacts/stories/10-6-sync-cards-from-phone.md
+++ b/docs/sprint-artifacts/stories/10-6-sync-cards-from-phone.md
@@ -8,7 +8,12 @@ Status: ready-for-dev
 
 Epic: 10 — Wear OS App
 
-> **Run all gates from the main checkout, never a `.claude` worktree.**
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. Native builds (`yarn watch:build`, `./gradlew`) still need the **main checkout**:
+> `ios/`, `android/` and `.expo/` are gitignored and absent in a fresh worktree. `--no-verify` stays
+> forbidden either way.
 >
 > **Depends on 10-1, 10-3, 10-4 and 10-5.** Last in the chain; nothing else in Epic 10 depends on it.
 >

--- a/docs/sprint-artifacts/stories/16-16-adopt-formatjs-intl-polyfill.md
+++ b/docs/sprint-artifacts/stories/16-16-adopt-formatjs-intl-polyfill.md
@@ -55,7 +55,7 @@ Place these in a dedicated module (recommend `shared/i18n/intl-polyfill.ts`) imp
 5. A lint rule (`no-restricted-properties` or equivalent) **fails** on any not-yet-polyfilled `Intl.*` API (e.g. `Intl.ListFormat`, `Intl.DisplayNames`, `Intl.Segmenter`) with a message pointing to this story. `yarn lint` fails on a deliberately-added offending line and passes once removed.
 6. A startup/guard test asserts the polyfilled APIs (`Intl.RelativeTimeFormat`, `Intl.PluralRules`) are defined at runtime, so removing the polyfill entry import fails CI.
 7. Existing behaviour is preserved: all current `relative-time` tests (EN + IT, 1-vs-N boundaries) stay green; no user-facing copy changes unless Open decision #3 explicitly approves the migration.
-8. `yarn lint` / `typecheck` / `test` / `test:coverage` pass from the **main checkout** (not a `.claude` worktree); coverage maintained. A remaining-`Intl`-usage audit (grep) confirms no unguarded consumer is left outside the polyfill guarantee.
+8. `yarn lint` / `typecheck` / `test` / `test:coverage` pass from any checkout that has its own `node_modules` (a `.claude` worktree qualifies after `yarn install`); coverage maintained. A remaining-`Intl`-usage audit (grep) confirms no unguarded consumer is left outside the polyfill guarantee.
 
 ## Tasks / Subtasks
 
@@ -65,7 +65,7 @@ Place these in a dedicated module (recommend `shared/i18n/intl-polyfill.ts`) imp
 - [ ] (AC 5) Add the `no-restricted-properties` lint rule for not-yet-polyfilled `Intl.*` APIs with a pointer message; prove it fails on an offending line and passes when removed.
 - [ ] (AC 6) Add a guard test asserting `Intl.RelativeTimeFormat`/`Intl.PluralRules` are defined (fails if the polyfill entry import is removed).
 - [ ] (AC 7,8) Run the remaining-`Intl`-usage audit (`grep -rn "Intl\\." app core shared features`); confirm every consumer is covered by the polyfill or the lint ban.
-- [ ] (AC 7,8) Run `yarn lint`/`typecheck`/`test`/`test:coverage` from the main checkout.
+- [ ] (AC 7,8) Run `yarn lint`/`typecheck`/`test`/`test:coverage` (any installed checkout; `--no-verify` stays forbidden).
 - [ ] (Open decision #3, if approved) Migrate `core/utils/relative-time.ts` to `Intl.RelativeTimeFormat` — only with an explicit copy sign-off, updating the tests to the new strings; otherwise leave 16.15's implementation untouched.
 
 ## Dev Notes

--- a/docs/sprint-artifacts/stories/16-23-fix-silent-barcode-scan-failures.md
+++ b/docs/sprint-artifacts/stories/16-23-fix-silent-barcode-scan-failures.md
@@ -8,9 +8,11 @@ Status: ready-for-dev
 
 Epic: 16 — Platform & Tech Debt
 
-> **Run all gates from the main checkout, never a `.claude` worktree.** `jest.config.js` sets
-> `modulePathIgnorePatterns: ['/.claude/']` and `testPathIgnorePatterns: [… '/.claude/' …]`, so
-> `yarn test` inside a worktree finds **zero tests** and passes vacuously.
+> **Gates run inside a `.claude` worktree too, once you `yarn install` there.** `jest.config.js`
+> anchors its `.claude` ignore patterns to `<rootDir>`, so a worktree runs its own suite instead of
+> finding zero tests. A worktree with no `node_modules` fails on missing dependencies instead — a
+> different problem. A native iOS build still needs the **main checkout**: `ios/` and `.expo/` are
+> gitignored and absent in a fresh worktree. `--no-verify` stays forbidden either way.
 >
 > **🔴 iOS-only, and input-specific.** Android (Samsung, ifero 2026-07-30) decodes this card via both
 > the camera and the image path, and on iOS **only this one card** fails — every other card has always
@@ -446,7 +448,7 @@ demonstrably an EAN-13 brand and the hint is missing.
      rescue every image, and AC2–AC6 are what make the remaining failures honest.
 
 8. **Regression-safe.** `yarn lint`, `yarn typecheck`, `yarn test`, and `yarn tokens:check` pass from
-   the **main checkout** (see [Testing](#testing)). **Android must not regress** — it is the known-good
+   any installed checkout (see [Testing](#testing)). **Android must not regress** — it is the known-good
    platform; re-verify the Penny card on Android after any change to the shared JS path. No change to
    the successful single-code, multi-code, or cancel paths of `useImageScan`; no change to
    `normalizeBarcode` / `applyExpectedFormat` semantics (both are documented as idempotent and have
@@ -488,7 +490,7 @@ demonstrably an EAN-13 brand and the hint is missing.
         revisions, crop-and-retry, or ML Kit on iOS — all measured and rejected, reasons in AC7
 
 - [ ] **Task 7 — Gates + Android non-regression (AC: 8)**
-  - [ ] `yarn lint && yarn typecheck && yarn test && yarn tokens:check` from the main checkout
+  - [ ] `yarn lint && yarn typecheck && yarn test && yarn tokens:check` (any installed checkout)
   - [ ] Re-verify the Penny card on **Android** after any shared-JS change — it is the known-good
         platform and must not regress
 
@@ -534,8 +536,9 @@ demonstrably an EAN-13 brand and the hint is missing.
   `expo-image-picker` and `react-native-image-code-scanner`, including the `BarcodeFormat` enum — reuse
   that mock shape), `core/utils/inferBarcodeFormat.test.ts`, `catalogue/italy.test.ts`.
 - Coverage gate is **80 % global** over `features/**`, `core/**`, `shared/**`.
-- ⚠️ **Run the gates from the main checkout, not this `.claude` worktree** — a bare `yarn test` inside a
-  worktree finds 0 tests (no `node_modules`), which reads as a pass.
+- ⚠️ **`yarn install` in this worktree before trusting any gate** — the suite runs here now, but without
+  `node_modules` every gate fails on missing dependencies rather than passing vacuously. Never reach for
+  `--no-verify`.
 - ⚠️ **A green Jest run does not prove the fix.** Jest never executes the native decoder; both
   `expo-camera` and `react-native-image-code-scanner` are mocked. AC1's device evidence is the only
   proof that matters here — this is the Story 16.15 lesson (green CI, fatal production crash).


### PR DESCRIPTION
> **Stacked on `chore/anchor-jest-claude-worktree-ignores`.** The base is that branch, not `main`, so
> this diff shows only the docs commit. Merge the Jest PR first; GitHub then retargets this one to
> `main`. Landing this before it would leave the docs describing behaviour `main` does not have.

## Problem

Once Jest's `.claude` ignore patterns are anchored to `<rootDir>`, a plain `yarn test` runs the real
suite inside a `.claude` worktree that has its own `node_modules`. The standing guidance says the
opposite, and gives a reason that no longer holds — "finds zero tests and passes vacuously".

## Changes

- **The dev-env banner in the eight pending stories.** All six Wear OS stories, plus the Intl-polyfill
  story and the barcode-scan story. Statuses were read from `sprint-status.yaml`, not assumed: six are
  `ready-for-dev`, one is `drafted`.
- **Their secondary gate instructions**, in the Testing and Definition-of-Done sections, which
  repeated the rule outside the banner.
- **The final checklist item in `docs/project-context.md`.** That item is not present in any
  `bmad-generate-project-context` template, so the output file is the only place it lives. Worth
  knowing: since it was added to the output by hand, a future regeneration may drop it rather than
  preserve this edit.

The replacement guidance states what actually gates a worktree: it needs its own `yarn install` first
(dependency absence is a separate failure from the old path bug), native builds still require the main
checkout because `ios/`, `android/` and `.expo/` are gitignored, and `--no-verify` stays forbidden.

## What was deliberately left alone

- **Every already-`done` story.** Their notes record how those stories were actually validated;
  rewriting them would falsify the record.
- **The `yarn watch:build` / `./gradlew` sentences**, six of them. Those genuinely do still need the
  main checkout for its prebuilt `ios/` — verified that `ios/`, `android/` and `.expo/` are gitignored
  and absent from a fresh worktree. Rewriting them would have replaced one false instruction with
  another, so the new banner splits the rule rather than inverting it: JS gates in any installed
  checkout, native builds in the main checkout.
- **The SDK upgrade acceptance criterion in `docs/epics.md`** that asks for gates from the main
  checkout. It is not false — that story is a native upgrade, where the main checkout is the right
  place — and `epics.md` is the drifted plan doc, with the tracker authoritative.
- **Two banners that sit in completed stories** (the launch-experience and card-grid stories). Unlike
  the other survivors these are instructions rather than validation records, so they are stale text;
  they were left per the explicit "leave completed stories alone" rule and are flagged here instead.
  Happy to fold them in if you would rather.

## Verification

`grep -rn "claude. worktree" --include="*.md"` leaves nothing stale outside the completed-story
records, confirmed with a broader sweep that also catches phrasings not containing the word "claude".
Prettier is clean on all nine files, and the full `pre-push` chain passes from inside the worktree:
**170 suites / 1890 tests**, `All checks passed!`.
