### PR TITLE
chore(test): clear the import/order warning in the CardTile test

### DIFF
--- a/features/cards/components/CardTile.test.tsx
+++ b/features/cards/components/CardTile.test.tsx
@@ -11,6 +11,8 @@ import Animated from 'react-native-reanimated';
 
 import { LoyaltyCard } from '@/core/schemas';
 
+import { useTheme } from '@/shared/theme';
+
 import {
   CardTile,
   TILE_WIDTH,
@@ -20,6 +22,7 @@ import {
   SINGLE_TILE_HEIGHT,
   SINGLE_TILE_RADIUS
 } from './CardTile';
+import { useBrandLogo } from '../hooks/useBrandLogo';
 import {
   AVATAR_SIZE,
   BADGE_CLEARANCE,
@@ -39,9 +42,6 @@ jest.mock('@/shared/theme', () => ({
   useTheme: jest.fn()
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { useTheme } = require('@/shared/theme');
-
 // Mock CARD_COLORS
 jest.mock('@/shared/theme/colors', () => ({
   CARD_COLORS: {
@@ -57,8 +57,6 @@ jest.mock('@/shared/theme/colors', () => ({
 jest.mock('../hooks/useBrandLogo', () => ({
   useBrandLogo: jest.fn()
 }));
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { useBrandLogo } = require('../hooks/useBrandLogo');
 
 jest.mock('../utils/brandLogos', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Problem

`yarn lint` reported exactly one warning repo-wide:

```
features/cards/components/CardTile.test.tsx
  54:26  warning  There should be no empty line within import group  import/order
```

It is a warning, not an error, so no gate blocked it — but it was the only lint diagnostic in the
repo, so it cost the "clean lint output" signal for everyone.

## The obvious fixes do not work

`eslint.config.mjs` groups `['parent', 'sibling', 'index']` as **one** group. That group had two
members: the sibling `./CardTile` import at the top of the file, and a `require('../hooks/useBrandLogo')`
handle thirty lines below it. The rule was not objecting to a blank line inside a contiguous import
block — it was objecting that two members of one group were not adjacent. So there is no stray blank
line to delete, and `eslint --fix` changed zero bytes: its fixer will not move a statement across
intervening code.

Four candidate edits were each applied to the real file and linted:

| candidate | result |
| --- | --- |
| drop the blank line after the require | warning persists |
| drop the blank line after the `useTheme` require | warning persists |
| drop the blank line before the mock block | warning persists, shifts up one line |
| move the require next to the `./CardTile` import | **two** warnings — worse |

## Fix

Replace the two `jest.mock` + `require` handles with ordinary imports of `useTheme` and
`useBrandLogo`.

- **All nine call sites are unchanged** — they already used `(useTheme as jest.Mock)`, and that cast
  works identically on an imported binding.
- **Every `jest.mock` factory stays exactly where it was.** Babel hoists `jest.mock` above imports, so
  each imported binding still resolves to its mock.
- It **removes two `no-require-imports` suppressions** instead of adding a third `eslint-disable`.
- With the real imports in place `--fix` became actionable, and the layout it produced matches what
  sibling suites already use — compare the import block in `features/cards/screens/CardDetailScreen.test.tsx`.

The `jest.mocked()` style that three other suites use was considered and rejected for this change: the
`require`-handle pattern is the repo's dominant convention across fifteen files, so converting one
file would make it an outlier — a refactor, not a chore.

## Verification

- `yarn lint` reports **zero problems repo-wide**.
- `yarn typecheck` clean; prettier clean.
- The file's own **28 tests pass**; full suite stays at **170 suites / 1890 tests**, exit 0.

One caveat on how the tests were run: this branch is based on `main`, whose `jest.config.js` still has
the unanchored `.claude` ignore patterns, so a plain `yarn test` inside a worktree finds zero tests
there. The suite was verified through a `rootDir`-pinned config override — the documented pre-fix
workaround — and the gates were run individually. Once the separate Jest anchoring PR merges, a plain
`yarn test` works here with no override. No `--no-verify` was used.
