### PR TITLE
chore(lint): enable react-hooks rules-of-hooks and exhaustive-deps

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import tsParser from '@typescript-eslint/parser';
 import importPlugin from 'eslint-plugin-import';
 import boundariesPlugin from 'eslint-plugin-boundaries';
 import i18nextPlugin from 'eslint-plugin-i18next';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
 export default [
   eslint.configs.recommended,
@@ -21,7 +22,8 @@ export default [
       '@typescript-eslint': tseslint,
       import: importPlugin,
       boundaries: boundariesPlugin,
-      i18next: i18nextPlugin
+      i18next: i18nextPlugin,
+      'react-hooks': reactHooksPlugin
     },
     settings: {
       'import/resolver': {
@@ -46,6 +48,28 @@ export default [
       // (core/utils/logger.ts) is the single sanctioned logging sink so that
       // production errors are routed to Sentry and dev noise is gated.
       'no-console': 'error',
+      // React hook correctness. Until now NEITHER of these ran, so `yarn lint`
+      // and CI gave zero assurance about the ~178 dependency-array hook call
+      // sites across 66 files.
+      //
+      // Motivating incident (Story 16.22, card-grid tile overlap): the fix
+      // hinged on `renderItem`'s useCallback deps in
+      // features/cards/components/CardList.tsx including the derived tile size.
+      // A narrowed dep array silently reintroduces the overlap for the whole
+      // lifetime of the mounted screen — `useFocusEffect` keeps that screen
+      // alive rather than remounting it, so a stale closure never gets flushed.
+      // It was caught by manual review plus a hand-written regression test;
+      // `exhaustive-deps` flags it mechanically.
+      //
+      // We register only these two rules rather than spreading the plugin's
+      // `recommended` config: v7 bundles ~30 React Compiler lints
+      // (set-state-in-effect, purity, immutability, …) that are a separate,
+      // much larger migration.
+      'react-hooks/rules-of-hooks': 'error',
+      // Starts at 'warn' on purpose: there is a pre-existing backlog and CI's
+      // `lint` step must stay green while it is worked down. Promote to 'error'
+      // once the count reaches zero.
+      'react-hooks/exhaustive-deps': 'warn',
       // Feature boundary enforcement
       'boundaries/element-types': [
         'error',

--- a/features/auth/components/PasswordStrengthIndicator.tsx
+++ b/features/auth/components/PasswordStrengthIndicator.tsx
@@ -32,12 +32,22 @@ export const PasswordStrengthIndicator = ({
   password,
   testID = 'password-strength-indicator'
 }: PasswordStrengthIndicatorProps) => {
+  // Hooks must run before any early return: NewPasswordScreen renders this
+  // component unconditionally, so `password` goes '' -> non-empty on the first
+  // keystroke. With the early return above the hooks, the empty render
+  // allocated zero hooks, which left `fiber.memoizedState` null and made React
+  // pick the *mount* dispatcher on the following render instead of throwing
+  // "Rendered more hooks than during the previous render". That masked the
+  // violation but silently remounted useTranslation's language subscription on
+  // every empty<->non-empty transition, and any hook added above the return
+  // would have turned it into a hard crash.
+  const { theme, typography, spacing } = useTheme();
+  const { t } = useTranslation();
+
   if (!password.trim()) {
     return null;
   }
 
-  const { theme, typography, spacing } = useTheme();
-  const { t } = useTranslation();
   const strength = getPasswordStrength(password);
 
   const width = strength === 'weak' ? '33%' : strength === 'fair' ? '66%' : '100%';

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-boundaries": "^5.3.1",
     "eslint-plugin-i18next": "^6.1.4",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "husky": "^9.1.7",
     "jest": "~29.7.0",
     "jest-expo": "~55.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,7 +63,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.28.0", "@babel/core@^7.29.0":
+"@babel/core@^7.24.4", "@babel/core@^7.28.0", "@babel/core@^7.29.0":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
@@ -335,7 +335,7 @@
   dependencies:
     "@babel/types" "^7.29.0"
 
-"@babel/parser@^7.29.7":
+"@babel/parser@^7.24.4", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -5676,6 +5676,17 @@ eslint-plugin-import@^2.32.0:
     string.prototype.trimend "^1.0.9"
     tsconfig-paths "^3.15.0"
 
+eslint-plugin-react-hooks@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz#e6742cad75d970c0a3f30d7d3fa80a4784f55927"
+  integrity sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==
+  dependencies:
+    "@babel/core" "^7.24.4"
+    "@babel/parser" "^7.24.4"
+    hermes-parser "^0.25.1"
+    zod "^3.25.0 || ^4.0.0"
+    zod-validation-error "^3.5.0 || ^4.0.0"
+
 eslint-scope@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.4.0.tgz#88e646a207fad61436ffa39eb505147200655c82"
@@ -6599,6 +6610,11 @@ hermes-compiler@0.14.1:
   resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.14.1.tgz#5381d2bb88454027d16736b8cb7fddaaf1556538"
   integrity sha512-+RPPQlayoZ9n6/KXKt5SFILWXCGJ/LV5d24L5smXrvTDrPS4L6dSctPczXauuvzFP3QEJbD1YO7Z3Ra4a+4IhA==
 
+hermes-estree@0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
+  integrity sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==
+
 hermes-estree@0.32.0:
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.32.0.tgz#bb7da6613ab8e67e334a1854ea1e209f487d307b"
@@ -6646,6 +6662,13 @@ hermes-parser@0.36.1:
   integrity sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==
   dependencies:
     hermes-estree "0.36.1"
+
+hermes-parser@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.25.1.tgz#5be0e487b2090886c62bd8a11724cd766d5f54d1"
+  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
+  dependencies:
+    hermes-estree "0.25.1"
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
@@ -11346,6 +11369,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+"zod-validation-error@^3.5.0 || ^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
+  integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
+
+"zod@^3.25.0 || ^4.0.0":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
 
 zod@^3.25.76:
   version "3.25.76"


### PR DESCRIPTION
## Why

`eslint.config.mjs` configured `@typescript-eslint`, `eslint-plugin-import`, `eslint-plugin-boundaries` and `eslint-plugin-i18next` — but **not** `eslint-plugin-react-hooks`. Neither `react-hooks/rules-of-hooks` nor `react-hooks/exhaustive-deps` ran, so `yarn lint` and CI gave **zero** automated assurance about the ~178 dependency-array hook call sites across 66 files (83 `useCallback`, 67 `useEffect`, 22 `useMemo`, plus `useFocusEffect`/`useLayoutEffect`).

The plugin was absent entirely — not merely disabled, and not available transitively: this repo hand-rolls its flat config and does not extend `eslint-config-expo`.

The motivating incident was the card-grid tile-overlap fix (#173), where correctness hinged on `renderItem`'s `useCallback` dependency array including the derived tile size. A narrowed dep array silently reintroduces the overlap for the whole lifetime of the mounted screen, because `useFocusEffect` keeps that screen alive rather than remounting it, so the stale closure is never flushed. It was caught by manual review and pinned with a hand-written regression test.

**That protection is now mechanical.** Verified against the merged code on `main`: as written it lints clean, and with the deps narrowed back to `[highlightCardId]` the rule reports *"missing dependencies: 'gridTile.height' and 'gridTile.width'"*.

## What changed

- Added `eslint-plugin-react-hooks` (v7) as a devDependency.
- Registered **only** `rules-of-hooks` (error) and `exhaustive-deps` (warn). v7 is no longer the small two-rule plugin — it also ships ~30 React Compiler lints (`purity`, `immutability`, `set-state-in-effect`, `preserve-manual-memoization`, …). Spreading `configs.recommended` would light up the whole repo; those are a separate, much larger migration.
- No `additionalHooks` regex needed: all three `useFocusEffect` sites use the canonical `useFocusEffect(useCallback(…))` form, so the inner `useCallback` is already checked.

## The one genuine bug this surfaced (fixed here)

`PasswordStrengthIndicator` called `useTheme()` and `useTranslation()` **after** an early `return null`. `CreateAccountScreen` guards the component (`password.trim().length > 0 ? … : null`), but `NewPasswordScreen` renders it **unconditionally** with `password` starting `''` — so it flipped 0 hooks → 2 hooks on the first keystroke.

It did not crash, and the reason is worth recording. Verified in the installed React source, the dispatcher choice is:

```js
null !== current && null !== current.memoizedState ? OnUpdate : OnMount
```

The empty render allocates *zero* hooks, so `memoizedState` stays `null`, React picks the **mount** dispatcher, and the "Rendered more hooks than during the previous render" invariant is never reached. So the violation was masked — but it was one hook away from fatal: add any hook above that early return and the empty render allocates a slot, the update dispatcher is selected, and the next keystroke throws. Meanwhile `useTranslation`'s language-change subscription was being torn down and remounted on every empty↔non-empty transition.

Fix is the canonical one: hooks above the early return. Render output is unchanged (still `null` for an empty password), which the existing tests confirm.

## Remaining warnings: 3, and two must NOT be auto-fixed

`exhaustive-deps` stays at **`warn`** so CI's `lint` step is unaffected. Full triage — 410 files linted, **173 of them test files**, and the 284 `renderHook` call sites produced **zero** false positives:

| Site | Warning | Assessment |
|---|---|---|
| `features/cards/components/BarcodeScanner.tsx:84` | missing `handlePermissionDenied` | ⚠️ **Do not obey the autofix.** It's a plain per-render function; adding it makes `handleRequestPermission` change identity every render, and the effect below has deps `[permission, handleRequestPermission]` → repeated `requestCameraPermission()` while permission is null. Correct fix is to `useCallback` the alert helper. There is a narrow real stale-closure bug (a changing `onManualEntry` isn't picked up). |
| `app/_layout.tsx:530` | missing `t` on a `[]` effect | ⚠️ **`[]` is correct.** Adding `t` re-runs DB init and re-establishes watch subscriptions on every language change. `t` is used once, for a boot-failure message. Clean fix is to store an error *code* and translate at render. |
| `features/auth/CreateAccountScreen.tsx:124` | unnecessary `fieldErrors` | Benign. Used only in a *type* position (`typeof fieldErrors`), erased at compile time. Harmless over-invalidation. |

Because the backlog is only three, promoting `exhaustive-deps` to `error` is within easy reach — but the `BarcodeScanner` refactor should land first. Note that at `warn` ESLint still exits 0, so this is advisory until either that promotion or a `--max-warnings` ceiling.

## Verification

Rebased onto latest `main` and run from a **real checkout with deps installed** (not a `.claude/worktrees/*` copy). Full pre-push hook ran on push and reported `All checks passed!`:

| Gate | Result |
|---|---|
| `yarn typecheck` | ✅ |
| `yarn tokens:check` | ✅ |
| `yarn splash:check` | ✅ |
| `yarn lint` | ✅ 0 errors, 3 warnings |
| `yarn format:check` | ✅ (the new gate from #181) |
| `yarn test` | ✅ 170 suites, 1947 tests |

The rebase conflicted only on the trailing comma removed by the `eslint.config.mjs` reformat (#180); the addition is prettier-clean and `lint-staged` now formats `.mjs` thanks to the widened glob.

## Scope note

No product code beyond the single hook-ordering fix. The three warnings are deliberately left for follow-ups rather than mass-fixed in a tooling PR.
