### PR TITLE
docs(sprint): reconcile stale story Status lines with the sprint tracker

### DIFF
--- a/docs/sprint-artifacts/stories/11-1-block-pr-on-quality-gates.md
+++ b/docs/sprint-artifacts/stories/11-1-block-pr-on-quality-gates.md
@@ -4,7 +4,7 @@
 
 **Title:** Block PR merge if lint/typecheck/test/coverage fail
 
-**Status:** review
+**Status:** done
 
 **PR:** ready for review (branch: `feature/11-1-block-pr-on-quality-gates`)
 

--- a/docs/sprint-artifacts/stories/12-5-auth-screens.md
+++ b/docs/sprint-artifacts/stories/12-5-auth-screens.md
@@ -2,7 +2,7 @@
 
 **Epic:** 12 - App-Wide Design Overhaul
 **Type:** Design
-**Status:** review
+**Status:** done
 **Sprint:** 10
 **Depends On:** 12-1 (Design System Foundation)
 **Figma File:** https://www.figma.com/design/4PSsX8SyTUU0GCUdBAAEED/Test

--- a/docs/sprint-artifacts/stories/12-7-onboarding.md
+++ b/docs/sprint-artifacts/stories/12-7-onboarding.md
@@ -2,7 +2,7 @@
 
 **Epic:** 12 - App-Wide Design Overhaul
 **Type:** Design
-**Status:** review
+**Status:** done
 **Sprint:** 10
 **Depends On:** 12-1 (Design System Foundation)
 **Figma File:** https://www.figma.com/design/4PSsX8SyTUU0GCUdBAAEED/Test

--- a/docs/sprint-artifacts/stories/13-1-implement-design-system-tokens.md
+++ b/docs/sprint-artifacts/stories/13-1-implement-design-system-tokens.md
@@ -1,6 +1,6 @@
 # Story 13.1: Implement Design System Tokens & Components
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/13-3-restyle-card-detail.md
+++ b/docs/sprint-artifacts/stories/13-3-restyle-card-detail.md
@@ -1,6 +1,6 @@
 # Story 13.3: Restyle Card Detail Screen
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/13-5-restyle-auth-screens.md
+++ b/docs/sprint-artifacts/stories/13-5-restyle-auth-screens.md
@@ -1,6 +1,6 @@
 # Story 13.5: Restyle Auth Screens
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/13-6-implement-settings-screen.md
+++ b/docs/sprint-artifacts/stories/13-6-implement-settings-screen.md
@@ -1,6 +1,6 @@
 # Story 13.6: Implement Settings Screen (Absorbs Epic 8)
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/13-7-restyle-onboarding.md
+++ b/docs/sprint-artifacts/stories/13-7-restyle-onboarding.md
@@ -1,6 +1,6 @@
 # Story 13.7: Restyle Onboarding Flow
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/13-7a-import-data-from-json.md
+++ b/docs/sprint-artifacts/stories/13-7a-import-data-from-json.md
@@ -1,6 +1,6 @@
 # Story 13.7a: Import Data from JSON
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/15-1-github-pages-landing-page.md
+++ b/docs/sprint-artifacts/stories/15-1-github-pages-landing-page.md
@@ -2,7 +2,7 @@
 
 **Epic:** 15 - Internationalisation & Public Presence
 **Type:** User-Facing (Portfolio / Discovery)
-**Status:** review
+**Status:** done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/5-10-watch-barcode-legibility-list-density.md
+++ b/docs/sprint-artifacts/stories/5-10-watch-barcode-legibility-list-density.md
@@ -7,7 +7,7 @@
 | **Story ID** | 5-10                          |
 | **Epic**     | 5 - Apple Watch App           |
 | **Sprint**   | 14                            |
-| **Status**   | review                        |
+| **Status**   | done                          |
 | **Priority** | High                          |
 | **Estimate** | 2 points (Dev: ~1d, QA: 0.5d) |
 | **Owners**   | PM: Ifero · Dev: — · QA: —    |

--- a/docs/sprint-artifacts/stories/5-6a-watch-connectivity-payload-hardening.md
+++ b/docs/sprint-artifacts/stories/5-6a-watch-connectivity-payload-hardening.md
@@ -1,6 +1,6 @@
 # Story 5.6a: WatchConnectivity Payload Hardening
 
-Status: review
+Status: done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/5-7-create-watch-complication.md
+++ b/docs/sprint-artifacts/stories/5-7-create-watch-complication.md
@@ -7,7 +7,7 @@
 | **Story ID** | 5-7                        |
 | **Epic**     | 5 - Apple Watch App        |
 | **Sprint**   | 14                         |
-| **Status**   | review                     |
+| **Status**   | done                       |
 | **Priority** | Medium                     |
 | **Estimate** | 3 points                   |
 | **Owners**   | PM: Ifero · Dev: — · QA: — |

--- a/docs/sprint-artifacts/stories/6-16-user-profile-creation-on-signup.md
+++ b/docs/sprint-artifacts/stories/6-16-user-profile-creation-on-signup.md
@@ -2,7 +2,7 @@
 
 **Epic:** 6 - User Authentication & Privacy
 **Type:** Bug Fix + Enabling
-**Status:** review
+**Status:** done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/6-18-otp-email-verification-flow.md
+++ b/docs/sprint-artifacts/stories/6-18-otp-email-verification-flow.md
@@ -2,7 +2,7 @@
 
 **Epic:** 6 - User Authentication & Privacy
 **Type:** User-Facing
-**Status:** review
+**Status:** done
 
 ## Story
 

--- a/docs/sprint-artifacts/stories/6-9-logout.md
+++ b/docs/sprint-artifacts/stories/6-9-logout.md
@@ -2,7 +2,7 @@
 
 **Epic:** 6 - User Authentication & Privacy
 **Type:** User-Facing
-**Status:** review
+**Status:** done
 
 ## Goal
 

--- a/docs/sprint-artifacts/stories/7-6-resolve-sync-conflicts.md
+++ b/docs/sprint-artifacts/stories/7-6-resolve-sync-conflicts.md
@@ -2,7 +2,7 @@
 
 **Epic:** 7 - Cloud Synchronization
 **Type:** User-Facing
-**Status:** review
+**Status:** done
 **Sprint:** 9
 **FRs Covered:** FR52
 

--- a/docs/sprint-artifacts/stories/9-2-mark-card-as-favorite.md
+++ b/docs/sprint-artifacts/stories/9-2-mark-card-as-favorite.md
@@ -1,6 +1,6 @@
 # Story 9.2: Mark Card as Favorite
 
-Status: review
+Status: done
 
 ## Story
 


### PR DESCRIPTION
## Summary

Eighteen shipped stories still read `Status: review` in their story file while
`docs/sprint-artifacts/sprint-status.yaml` records them as `done`. This PR
reconciles the story files to the tracker. **Only the status token changed** —
18 files, 18 insertions, 18 deletions, one line each.

`sprint-status.yaml` is **not** modified.

## Why this is a live hazard, not untidiness

[`mark-story-done.yml`](.github/workflows/mark-story-done.yml) runs on every merged
PR and calls [`scripts/mark-story-done.mjs`](scripts/mark-story-done.mjs). Its
`resolveStorySlugs` helper ([`scripts/lib/story-refs.mjs`](scripts/lib/story-refs.mjs))
falls back to a bare numeric match — any `N-M` or `N.M` token — whenever the PR
body contains no explicit `stories/<slug>.md` path. The script then advances any
resolved story whose file reads `review` to `done`, and the workflow commits that
**straight to the default branch** with `[skip ci]`.

So a PR body mentioning a version number, a date fragment, or an unrelated
cross-reference was enough to silently rewrite a story file and push to `main`.
The `review` gate is designed to stop exactly this; the stale files defeated it.

Demonstrated against the pre-fix tree with an entirely innocuous CI PR:

```
PR_BODY="Routine bump. Also unblocks the flake we saw in run 13-1 and the 15.1 timeout."
```

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```
Resolved story slug(s): 13-1-…, 15-1-…
(dry-run) would write 13-1-….md
✓ story file → done: 13-1-….md
(dry-run) would write 15-1-….md
✓ story file → done: 15-1-….md
Done — files updated.
```

</td><td>

```
Resolved story slug(s): 13-1-…, 15-1-…
• skip 13-1-…: status is "done", not "review"
• skip 15-1-…: status is "done", not "review"
No changes (already up to date).
```

</td></tr>
</table>

Two story files would have been rewritten and pushed to `main` by a
`chore(ci)` dependency bump.

## Verification

Every story was checked against the tracker **before** its file was edited.
All eighteen are recorded `done` in `sprint-status.yaml`, each with a
corresponding shipping commit or merged PR. **No disagreements were found**, so
per project convention (story `.md` is the source of truth for `review`; the
yaml is the output) nothing in the tracker was touched.

| Story file | Tracker | Shipping evidence |
| --- | --- | --- |
| [`docs/sprint-artifacts/stories/5-6a-watch-connectivity-payload-hardening.md`](docs/sprint-artifacts/stories/5-6a-watch-connectivity-payload-hardening.md) | `done` | `5b496b9` harden watch sync payloads (#109) |
| [`docs/sprint-artifacts/stories/6-9-logout.md`](docs/sprint-artifacts/stories/6-9-logout.md) | `done` | `433124f`, PR #64 |
| [`docs/sprint-artifacts/stories/6-16-user-profile-creation-on-signup.md`](docs/sprint-artifacts/stories/6-16-user-profile-creation-on-signup.md) | `done` | PR #103 |
| [`docs/sprint-artifacts/stories/6-18-otp-email-verification-flow.md`](docs/sprint-artifacts/stories/6-18-otp-email-verification-flow.md) | `done` | `911c342` verify-email OTP flow (#108) |
| [`docs/sprint-artifacts/stories/7-6-resolve-sync-conflicts.md`](docs/sprint-artifacts/stories/7-6-resolve-sync-conflicts.md) | `done` | PR #76 |
| [`docs/sprint-artifacts/stories/9-2-mark-card-as-favorite.md`](docs/sprint-artifacts/stories/9-2-mark-card-as-favorite.md) | `done` | `23874d0` mark card as favorite (#124) |
| [`docs/sprint-artifacts/stories/11-1-block-pr-on-quality-gates.md`](docs/sprint-artifacts/stories/11-1-block-pr-on-quality-gates.md) | `done` | PR #48 |
| [`docs/sprint-artifacts/stories/12-5-auth-screens.md`](docs/sprint-artifacts/stories/12-5-auth-screens.md) | `done` | `7f74072` design — 14 Figma frames, PR #82 |
| [`docs/sprint-artifacts/stories/12-7-onboarding.md`](docs/sprint-artifacts/stories/12-7-onboarding.md) | `done` | PR #84 |
| [`docs/sprint-artifacts/stories/13-1-implement-design-system-tokens.md`](docs/sprint-artifacts/stories/13-1-implement-design-system-tokens.md) | `done` | PR #88 |
| [`docs/sprint-artifacts/stories/13-3-restyle-card-detail.md`](docs/sprint-artifacts/stories/13-3-restyle-card-detail.md) | `done` | PR #90 |
| [`docs/sprint-artifacts/stories/13-5-restyle-auth-screens.md`](docs/sprint-artifacts/stories/13-5-restyle-auth-screens.md) | `done` | PR #92 |
| [`docs/sprint-artifacts/stories/13-6-implement-settings-screen.md`](docs/sprint-artifacts/stories/13-6-implement-settings-screen.md) | `done` | PR #93 |
| [`docs/sprint-artifacts/stories/13-7-restyle-onboarding.md`](docs/sprint-artifacts/stories/13-7-restyle-onboarding.md) | `done` | PR #94 |
| [`docs/sprint-artifacts/stories/13-7a-import-data-from-json.md`](docs/sprint-artifacts/stories/13-7a-import-data-from-json.md) | `done` | `1d05e71`, PR #95 |
| [`docs/sprint-artifacts/stories/15-1-github-pages-landing-page.md`](docs/sprint-artifacts/stories/15-1-github-pages-landing-page.md) | `done` | `345dc74`, PR #104 |
| [`docs/sprint-artifacts/stories/5-7-create-watch-complication.md`](docs/sprint-artifacts/stories/5-7-create-watch-complication.md) | `done` | table-form — see below |
| [`docs/sprint-artifacts/stories/5-10-watch-barcode-legibility-list-density.md`](docs/sprint-artifacts/stories/5-10-watch-barcode-legibility-list-density.md) | `done` | table-form — see below |

## Scope note — 16 reported, 18 changed

The reported set was 16, found with the line-initial regex. Widening the same
query to the markdown-table convention surfaced two more files carrying the same
stale `review` against a `done` tracker entry:
`5-7-create-watch-complication.md` and
`5-10-watch-barcode-legibility-list-density.md`.

The script's regex cannot see the table form, so those two are not hazardous
*today* — but they are the same defect, and they would arm instantly if the two
formats were ever normalised. They are corrected here. **Only the status token
changed; neither file was converted to the other format.**

Happy to drop those two if you'd rather keep this to the reported 16.

## Deliberately not done: normalising the two Status formats

Census across 135 story files: **94** line-initial, **32** markdown-table, **9**
with no status line, **0** with both.

Normalising is *not* recommended as a follow-on to this PR, because it would make
things worse before better: converting 32 table-form files to the line-initial
form takes files the numeric fallback currently **cannot** reach and makes them
reachable. The format split is not the bug — the bare-numeric fallback is. It
should be tightened first (require an explicit story link, or at minimum refuse
tokens that look like versions or dates), and only then is normalisation safe.

Suggested follow-up order:

1. Tighten `resolveStorySlugs`' numeric fallback in `scripts/lib/story-refs.mjs`.
2. Backfill a status line in the 9 files that have none.
3. Then normalise the two formats.

## Testing

- `grep -lE "^(\*\*Status:\*\*|Status:)[ \t]*review" docs/sprint-artifacts/stories/*.md` → no matches
- Table-form equivalent → no matches
- `git diff --shortstat` → `18 files changed, 18 insertions(+), 18 deletions(-)`; every changed line is a `Status` line
- `prettier --check` on all changed files → clean
- This PR's own title and body dry-run clean (see below)

## `mark-story-done` dry-run of this PR

This body includes explicit `docs/sprint-artifacts/stories/<slug>.md` paths, so
the numeric fallback is suppressed and every referenced story resolves via the
path branch — where all eighteen now read `done` and are skipped by the gate.

```
$ PR_TITLE="…" PR_BODY="$(cat body.md)" DRY_RUN=1 node scripts/mark-story-done.mjs

Resolved story slug(s): 5-6a-…, 6-9-…, 6-16-…, 6-18-…, 7-6-…, 9-2-…, 11-1-…,
  12-5-…, 12-7-…, 13-1-…, 13-3-…, 13-5-…, 13-6-…, 13-7-…, 13-7a-…, 15-1-…,
  5-7-…, 5-10-…
• skip 5-6a-watch-connectivity-payload-hardening: status is "done", not "review"
• skip 6-9-logout:                                status is "done", not "review"
…
• skip 5-7-create-watch-complication:             status is "unknown", not "review"
• skip 5-10-watch-barcode-legibility-list-density: status is "unknown", not "review"
No changes (already up to date).
```

Zero files would be written.

Worth noting the last two lines: `5-7` and `5-10` resolve as **`"unknown"`**, not
`"done"` — the script cannot read the table form at all. That is the concrete
evidence for both claims above: it is why those two were not hazardous today,
and why normalising the formats before tightening the fallback would convert 32
files from unreadable to actionable in one step.
