### PR TITLE
fix(scripts): require the "story" keyword in the story-ref numeric fallback

### DIFF
--- a/scripts/lib/story-refs.mjs
+++ b/scripts/lib/story-refs.mjs
@@ -23,12 +23,38 @@ export const findStoryByPrefix = (prefix, dir = STORIES_DIR) => {
   return hit ? hit.replace(/\.md$/, '') : null;
 };
 
+// A story reference spelled out in prose: "Story 16.24", "story 13-7a".
+//
+// The `story` keyword is REQUIRED. Without it this matched any `N.M` / `N-M`
+// token anywhere in the input, and since the only other check is "does a story
+// file with that prefix exist", ordinary PR prose could silently resolve to a
+// real story: a version bump ("16.24"), a coverage number ("13.7%"), a date
+// fragment, a run id. `scripts/mark-story-done.mjs` then advanced any such story
+// sitting at `Status: review` straight to `done` and committed it to the default
+// branch — so an unrelated PR could close someone else's in-flight story.
+//
+// `(?![.-]\d)` rejects a third dotted/dashed segment, so "story 1.2.3" (a version
+// that merely follows the word) is not read as story 1.2. Story ids are always
+// two segments — `16-24`, `13-7a` — never three.
+//
+// `\b` keeps "backstory 5.9" from matching on the "story" substring.
+const STORY_REF_RE = /\bstory\s+(\d+)[.-](\d+[a-z]?)(?![.-]\d)/gi;
+
+// The same reference with the `story` keyword optional, i.e. a bare "16-24".
+// Only ever applied to explicit CLI arguments, where the whole input is a story
+// id a human deliberately typed (`node scripts/mark-story-done.mjs 5-9`, which
+// CONTRIBUTING.md documents) rather than prose that happens to contain digits.
+const BARE_STORY_REF_RE = /\b(?:story\s+)?(\d+)[.-](\d+[a-z]?)(?![.-]\d)/gi;
+
 // Resolve all story slugs referenced by `text`, returning only slugs whose story
 // file actually exists. Resolution order:
 //   0. an exact slug (e.g. "5-9-edit-card")
 //   1. story-file paths: stories/<slug>.md
-//   2. a "Story X.Y" / "X-Y" reference, matched against the stories dir
-export const resolveStorySlugs = (text, dir = STORIES_DIR) => {
+//   2. a "Story X.Y" reference, matched against the stories dir
+//
+// `allowBareNumeric` additionally accepts a keyword-less "X-Y" at step 2. Pass it
+// only for trusted, deliberate input (CLI args) — never for PR title/body text.
+export const resolveStorySlugs = (text, dir = STORIES_DIR, { allowBareNumeric = false } = {}) => {
   const slugs = new Set();
   const trimmed = (text ?? '').trim();
 
@@ -43,7 +69,9 @@ export const resolveStorySlugs = (text, dir = STORIES_DIR) => {
   }
 
   if (slugs.size === 0) {
-    const numRe = /(?:story\s+)?(\d+)[.-](\d+[a-z]?)/gi;
+    // Fresh copy: these are module-level /g regexes, so a shared `lastIndex`
+    // would leak between calls.
+    const numRe = new RegExp(allowBareNumeric ? BARE_STORY_REF_RE : STORY_REF_RE);
     while ((m = numRe.exec(text ?? ''))) {
       const found = findStoryByPrefix(`${m[1]}-${m[2]}`, dir);
       if (found) slugs.add(found);

--- a/scripts/lib/story-refs.test.js
+++ b/scripts/lib/story-refs.test.js
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment node
+ */
+// Unit tests for resolveStorySlugs() — in particular the numeric fallback that
+// scripts/mark-story-done.mjs uses to decide which story a merged PR completes.
+//
+// WHY A SUBPROCESS: story-refs.mjs is a plain Node ESM module that reads
+// `import.meta.url`. Jest compiles through babel.config.test.js, which targets
+// Hermes/React Native and emits CommonJS — where `import.meta` is a hard syntax
+// error ("Enable the polyfill unstable_transformImportMeta"). Turning that
+// polyfill on would change the transform for every app test just to reach a build
+// script, so instead each case is evaluated in one real `node --input-type=module`
+// child. That also runs the module under exactly the ESM semantics CI uses, with
+// no transform in between. All cases share a single spawn, resolved in beforeAll.
+//
+// WHY THESE FIXTURES: resolveStorySlugs only returns slugs whose file exists, so a
+// negative case is vacuous unless a matching file is present. Every decoy below is
+// paired with a fixture the OLD regex did resolve — remove the fix and these fail.
+
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, writeFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const MODULE_URL = pathToFileURL(require.resolve('./story-refs.mjs')).href;
+
+const FIXTURE_STORIES = [
+  '1-2-extend-semantic-error-colors.md', // matched by "v1.2.3"
+  '5-9-edit-card.md', // the legitimate "(Story 5.9)" target
+  '13-7-restyle-onboarding.md', // matched by "13.7%"
+  '13-7a-import-data-from-json.md', // letter-suffixed story id
+  '16-24-clear-exhaustive-deps.md', // matched by a bare "16-24"
+  '2026-07-decoy.md' // matched by the ISO date "2026-07-28"
+];
+
+// [name, input text, options] — evaluated in order by the child process.
+const CASES = [
+  ['version strings', 'Bumped the toolchain to v1.2.3 and pinned expo to 13.7.0.', {}],
+  ['iso dates', 'Regenerated on 2026-07-28 after the 2026-07-28 incident.', {}],
+  ['bare numeric in prose', 'Rebased onto 16-24 files changed; coverage moved 13.7% to 13.9%.', {}],
+  ['story-prefixed version', 'See the story 1.2.3 release notes for details.', {}],
+  ['backstory substring', 'The backstory 5.9 explains why this exists.', {}],
+  ['story suffix title', 'fix(watch): render the complication (Story 5.9)', {}],
+  ['story dashed ref', 'Implements Story 13-7a end to end.', {}],
+  [
+    'explicit story path',
+    'Implements docs/sprint-artifacts/stories/16-24-clear-exhaustive-deps.md',
+    {}
+  ],
+  [
+    'path suppresses fallback',
+    'Fixes the v1.2.3 regression — spec: docs/sprint-artifacts/stories/16-24-clear-exhaustive-deps.md',
+    {}
+  ],
+  ['exact slug', '5-9-edit-card', {}],
+  ['bare numeric without opt-in', '16-24', {}],
+  ['bare numeric with opt-in', '16-24', { allowBareNumeric: true }],
+  ['quoted cli reference with opt-in', 'Story 5.9', { allowBareNumeric: true }],
+  ['empty input', '', {}]
+];
+
+// Evaluate every case in one child process and return a name -> slugs[] map.
+const runCases = (dir) => {
+  const harness = `
+    import { resolveStorySlugs } from ${JSON.stringify(MODULE_URL)};
+    const dir = process.env.FIXTURE_DIR;
+    const cases = JSON.parse(process.env.CASES_JSON);
+    process.stdout.write(
+      JSON.stringify(cases.map(([, text, opts]) => resolveStorySlugs(text, dir, opts)))
+    );
+  `;
+
+  let stdout;
+  try {
+    stdout = execFileSync(process.execPath, ['--input-type=module', '-e', harness], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, FIXTURE_DIR: dir, CASES_JSON: JSON.stringify(CASES) }
+    });
+  } catch (err) {
+    throw new Error(`story-refs harness failed:\n${err.stderr || err.message}`);
+  }
+
+  const results = JSON.parse(stdout);
+  return Object.fromEntries(CASES.map(([name], i) => [name, results[i]]));
+};
+
+describe('resolveStorySlugs', () => {
+  let dir;
+  let resolved;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'story-refs-'));
+    for (const file of FIXTURE_STORIES) {
+      writeFileSync(join(dir, file), '**Status:** review\n');
+    }
+    resolved = runCases(dir);
+  });
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('the numeric fallback ignores incidental numbers in PR prose', () => {
+    it('does not treat a version string as a story reference', () => {
+      expect(resolved['version strings']).toEqual([]);
+    });
+
+    it('does not treat an ISO date as a story reference', () => {
+      expect(resolved['iso dates']).toEqual([]);
+    });
+
+    it('does not treat a bare N-M / N.M token as a story reference', () => {
+      expect(resolved['bare numeric in prose']).toEqual([]);
+    });
+
+    it('does not read a three-segment version following the word "story"', () => {
+      expect(resolved['story-prefixed version']).toEqual([]);
+    });
+
+    it('does not match "story" as a substring of another word', () => {
+      expect(resolved['backstory substring']).toEqual([]);
+    });
+  });
+
+  describe('legitimate references still resolve', () => {
+    it('resolves a title ending in "(Story X.Y)"', () => {
+      expect(resolved['story suffix title']).toEqual(['5-9-edit-card']);
+    });
+
+    it('resolves a dashed, letter-suffixed "Story 13-7a"', () => {
+      expect(resolved['story dashed ref']).toEqual(['13-7a-import-data-from-json']);
+    });
+
+    it('resolves an explicit stories/<slug>.md path', () => {
+      expect(resolved['explicit story path']).toEqual(['16-24-clear-exhaustive-deps']);
+    });
+
+    it('resolves an exact slug', () => {
+      expect(resolved['exact slug']).toEqual(['5-9-edit-card']);
+    });
+
+    it('lets an explicit path suppress the fallback entirely', () => {
+      expect(resolved['path suppresses fallback']).toEqual(['16-24-clear-exhaustive-deps']);
+    });
+
+    it('resolves nothing for empty input', () => {
+      expect(resolved['empty input']).toEqual([]);
+    });
+  });
+
+  describe('allowBareNumeric gates the keyword-less form', () => {
+    // The contrast pair: identical input, opposite outcome. Bare "16-24" is a
+    // deliberate CLI arg (`node scripts/mark-story-done.mjs 16-24`, documented in
+    // CONTRIBUTING.md) but must never resolve out of PR title/body prose.
+    it('rejects a bare "16-24" by default', () => {
+      expect(resolved['bare numeric without opt-in']).toEqual([]);
+    });
+
+    it('accepts a bare "16-24" when opted in', () => {
+      expect(resolved['bare numeric with opt-in']).toEqual(['16-24-clear-exhaustive-deps']);
+    });
+
+    it('still accepts the "Story X.Y" form when opted in', () => {
+      expect(resolved['quoted cli reference with opt-in']).toEqual(['5-9-edit-card']);
+    });
+  });
+});

--- a/scripts/mark-story-done.mjs
+++ b/scripts/mark-story-done.mjs
@@ -12,7 +12,12 @@
 // Story reference resolution (first that matches wins):
 //   0. An exact slug passed as an arg (e.g. "5-9-edit-card").
 //   1. Any `docs/sprint-artifacts/stories/<slug>.md` path found in the input.
-//   2. A "Story X.Y" / "X-Y" reference, resolved by globbing the stories dir.
+//   2. A "Story X.Y" reference, resolved by globbing the stories dir.
+//
+// A keyword-less "X-Y" is accepted ONLY from an explicit CLI arg, where the input
+// is a story id a human deliberately typed. PR title/body is prose: a bare "16.24"
+// there is far more likely to be a version, a percentage or a date fragment than a
+// story reference, and resolving it would mark an unrelated in-flight story done.
 //
 // Input comes from CLI args, or the PR_TITLE / PR_BODY env vars (used in CI).
 // Set DRY_RUN=1 to preview changes without writing.
@@ -100,11 +105,12 @@ const markSprintStatus = (slug) => {
 
 // ---- main -------------------------------------------------------------------
 
-const input =
-  process.argv.slice(2).join(' ').trim() ||
-  `${process.env.PR_TITLE ?? ''}\n${process.env.PR_BODY ?? ''}`;
+const argvInput = process.argv.slice(2).join(' ').trim();
+const input = argvInput || `${process.env.PR_TITLE ?? ''}\n${process.env.PR_BODY ?? ''}`;
 
-const slugs = resolveStorySlugs(input);
+// Bare "5-9" is honoured for a CLI arg only — see the header note on why PR prose
+// must spell the reference out as "Story X.Y" or link the story file.
+const slugs = resolveStorySlugs(input, STORIES_DIR, { allowBareNumeric: argvInput !== '' });
 
 if (slugs.length === 0) {
   log('No story reference found in input — nothing to do.');


### PR DESCRIPTION
## Problem

`resolveStorySlugs` in `scripts/lib/story-refs.mjs` had a bare-numeric fallback:

```js
const numRe = /(?:story\s+)?(\d+)[.-](\d+[a-z]?)/gi;
```

It ran whenever the PR text contained no explicit `stories/<slug>.md` path, and matched **any** `N-M` / `N.M` token — version numbers, ISO date fragments, run ids, percentages, decimals. The only other check is "does a story file with that prefix exist", which is a filter, not a gate: it shrinks the false-positive rate without bounding it, and the blast radius grows with every story file added.

`scripts/mark-story-done.mjs` then advanced any resolved story whose file reads `Status: review` to `done`, and `.github/workflows/mark-story-done.yml` commits that straight to the default branch with `[skip ci]`. So an unrelated PR could silently close someone else's in-flight story.

This is live right now: 16 stories on `main` currently sit at `Status: review`.

### Demonstration

An innocuous dependency-bump PR, run against the real stories directory with `DRY_RUN=1`:

```
PR_TITLE="chore(deps): bump expo to 13.7.0 and drop the 12-5 shim"
PR_BODY="Coverage moved 9.2% -> 9.4%. Finishes the 6-9 cleanup. Regenerated 2026-07-28."
```

| | Resolved |
| --- | --- |
| before | `13-7-restyle-onboarding`, `12-5-auth-screens`, `9-2-mark-card-as-favorite`, `9-4-sync-sorting-to-watch`, `6-9-logout`, `15-1-github-pages-landing-page` — **five** of them in `review` and would have been marked `done` |
| after | nothing |

That PR references no story at all. Every hit came from a version number, a percentage or a date.

## Fix

Require a literal, word-boundaried `story` keyword before the number:

```js
const STORY_REF_RE = /\bstory\s+(\d+)[.-](\d+[a-z]?)(?![.-]\d)/gi;
```

- **`\bstory\s+` required** — this is the core change, and it subsumes the "reject `v`/`@` prefixes" idea for free: after `story\s+` the next character must be a digit, so `v1.2.3` can never match. `\b` stops `backstory 5.9` matching on the substring.
- **`(?![.-]\d)`** rejects a third dotted/dashed segment, so `story 1.2.3` (a version that merely follows the word) is not read as story 1.2. Story ids are always two segments — `16-24`, `13-7a` — never three.
- **The keyword-less form is kept behind an `allowBareNumeric` opt-in**, used only for explicit CLI args. Dropping it outright would have broken `node scripts/mark-story-done.mjs <story-id>`, which CONTRIBUTING.md documents. The distinction is a trust boundary: a CLI arg is a story id a human deliberately typed; PR title/body is prose that merely contains digits.

All four documented affordances still work — bare CLI id, quoted CLI reference, exact slug, `stories/<slug>.md` path, and a title ending in `(Story X.Y)`.

## Behaviour change for contributors

`scripts/check-pr-conventions.mjs` shares this resolver, so a `feat:`/`fix:` PR that referenced its story **only** as a bare `6-9` in the body now fails the spec-first check. That is a tightening toward the contract CONTRIBUTING.md and AGENTS.md already document, and the existing failure message names the two accepted forms, so it is self-correcting.

## Tests

`scripts/lib/story-refs.test.js` — 14 cases covering version strings, ISO dates, bare tokens in prose, a version following the word "story", the `backstory` substring, the legitimate `(Story X.Y)` title, letter-suffixed ids, explicit paths, exact slugs, and the `allowBareNumeric` contrast pair.

Two notes on how they are built:

- **They run in a subprocess.** `story-refs.mjs` is plain Node ESM and reads `import.meta.url`. Jest compiles through `babel.config.test.js`, which targets Hermes/React Native and emits CommonJS, where `import.meta` is a hard syntax error. Enabling Expo's `unstable_transformImportMeta` would change the transform for all ~170 app test suites just to reach a build script, so each case is instead evaluated in one real `node --input-type=module` child. That also runs the module under exactly the ESM semantics CI uses. One spawn for all cases; no Jest config change, no new dependency.
- **Every negative case is non-vacuous.** `resolveStorySlugs` only returns slugs whose file exists, so a decoy proves nothing unless a matching fixture is present. Each decoy is paired with a fixture the old regex did resolve. Verified by reverting the regex: the 6 hazard tests fail, and the 8 legitimate-resolution tests pass both before and after — so this is a pure tightening with no collateral damage.

## Sequencing

Per the survey of all 135 story files, 94 use the line-initial `**Status:** x` / `Status: x` form, 32 use a markdown-table row `| **Status** | x |`, 9 have no status line, and 0 have both. The script's regex only reads the line-initial form, so those 32 report `unknown` and can never be advanced.

Deliberately **not** normalising the formats here. Doing so before this fix landed would have converted 32 currently-unreachable files into actionable ones in one step, while the fallback was still armed. Correct order is:

1. tighten the fallback ← this PR
2. backfill a status line in the 9 files that have none
3. then normalise the 32 table-form files

Also independent of #193, which removes the stale `review` fuel. That is worth landing too, but it only empties the magazine — this PR fixes the trigger, so the hazard does not return the moment a story legitimately enters `review`.

## Verification

- `yarn typecheck`, `yarn format:check`, `yarn lint` (0 errors; 3 pre-existing `exhaustive-deps` warnings, tracked by the Epic 16 backlog item 16.24), `yarn check:no-tests-folders`
- `yarn test` — 171 suites, 1961 tests, all passing

Spec: `docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md` (already `done`; cited so this PR's own body resolves through the explicit-path branch and cannot advance anything).
