### PR TITLE
docs(sprint): add readable Status lines to the six story files that lacked one

### DIFF
--- a/docs/sprint-artifacts/stories/11-2-build-on-main-app-changes-only.md
+++ b/docs/sprint-artifacts/stories/11-2-build-on-main-app-changes-only.md
@@ -1,6 +1,7 @@
 # Story 11-2: Build on main only if app code changes
 
 **Epic:** 11 (CI/CD & Quality Gates)
+**Status:** done
 
 ## Description
 

--- a/docs/sprint-artifacts/stories/3-1-create-italian-catalogue-data.md
+++ b/docs/sprint-artifacts/stories/3-1-create-italian-catalogue-data.md
@@ -1,5 +1,7 @@
 # Story 3.1: Create Italian Catalogue Data
 
+**Status:** done
+
 **As a** developer,
 **I want** a structured catalogue of Italian loyalty brands,
 **So that** users can add cards with recognizable logos.

--- a/docs/sprint-artifacts/stories/3-2-browse-catalogue-grid.md
+++ b/docs/sprint-artifacts/stories/3-2-browse-catalogue-grid.md
@@ -1,5 +1,7 @@
 # Story 3.2: Browse Catalogue Grid
 
+**Status:** done
+
 **As a** user,
 **I want** to browse Italian brands with their logos,
 **So that** I can quickly find and add my loyalty cards.

--- a/docs/sprint-artifacts/stories/3-3-add-card-from-catalogue.md
+++ b/docs/sprint-artifacts/stories/3-3-add-card-from-catalogue.md
@@ -1,5 +1,7 @@
 # Story 3.3: Add Card from Catalogue
 
+**Status:** done
+
 **As a** user,
 **I want** to select a brand and scan my card,
 **So that** my card is saved with the official brand logo.

--- a/docs/sprint-artifacts/stories/3-4-cache-catalogue-for-offline.md
+++ b/docs/sprint-artifacts/stories/3-4-cache-catalogue-for-offline.md
@@ -1,5 +1,7 @@
 # Story 3.4: Cache Catalogue for Offline
 
+**Status:** done
+
 **As a** user,
 **I want** the catalogue to work without internet,
 **So that** I can add cards from known brands anywhere.

--- a/docs/sprint-artifacts/stories/3-5-update-catalogue-via-ota.md
+++ b/docs/sprint-artifacts/stories/3-5-update-catalogue-via-ota.md
@@ -1,5 +1,7 @@
 # Story 3.5: Update Catalogue via OTA
 
+**Status:** done
+
 **As a** user,
 **I want** to receive new brands without updating the app,
 **So that** my catalogue stays current.


### PR DESCRIPTION
## What

Adds a line-initial `**Status:**` line to the six story files that had **no** status line
readable by `scripts/mark-story-done.mjs`.

That script reads a story's current status with `/^(?:\*\*Status:\*\*|Status:)[ \t]*(\S+)/m` —
line-initial only. A file with no matching line reports `unknown` and can never be advanced by
the merge automation.

Each value is taken verbatim from the `development_status` map in
`docs/sprint-artifacts/sprint-status.yaml`. No status was invented; all six are `done` there.

| Story file                                                            | yaml value | written |
| --------------------------------------------------------------------- | ---------- | ------- |
| `docs/sprint-artifacts/stories/3-1-create-italian-catalogue-data.md`    | `done`     | `done`  |
| `docs/sprint-artifacts/stories/3-2-browse-catalogue-grid.md`            | `done`     | `done`  |
| `docs/sprint-artifacts/stories/3-3-add-card-from-catalogue.md`          | `done`     | `done`  |
| `docs/sprint-artifacts/stories/3-4-cache-catalogue-for-offline.md`      | `done`     | `done`  |
| `docs/sprint-artifacts/stories/3-5-update-catalogue-via-ota.md`         | `done`     | `done`  |
| `docs/sprint-artifacts/stories/11-2-build-on-main-app-changes-only.md`  | `done`     | `done`  |

Census of `docs/sprint-artifacts/stories/` before → after: **95 → 101** line-initial,
**32 → 32** table-form (untouched), **9 → 3** with no status line.

## Why this is inert for the merge automation

`mark-story-done.mjs` only advances a story whose file currently reads exactly `review`.
Every line added here is `done`, the terminal state, so none of these files can be advanced by
a future PR as a result of this change. The change makes them *readable*, not *actionable*.

This PR body also cites `docs/sprint-artifacts/stories/11-7-contribution-infrastructure.md`
(status `done`) as an explicit story-path reference. Path references take priority over the
numeric fallback in `resolveStorySlugs`, so this PR resolves only to `done` stories and cannot
advance anything on merge.

## Deliberately out of scope

- **The 32 table-form files** (`| **Status** | x |`) are untouched. Normalising those converts 32
  currently-unreachable files into actionable ones in one step, so it lands separately.
- **Three files in the stories directory are not stories** and were left alone — they are QA
  validation reports with no `development_status` entry (`validation-report` appears zero times
  in the yaml), so there is no status to derive:
  - `validation-report-4-1-welcome-screen-2026-02-08T12:00:00Z.md`
  - `validation-report-4-2-first-card-guidance-2026-02-08T12:00:00Z.md`
  - `validation-report-4-3-help-faq-access-2026-02-08T12:00:00Z.md`

## Follow-ups noted, not fixed

- **A third status form exists** beyond line-initial and table: a trailing `## Status` section with
  a `- Status: x` bullet. Eight files use it; it is invisible to the regex (the line starts with
  `- `). Five of the six files in this PR had one; the other three are table-form and belong to the
  table normalisation.
- **`3-3-add-card-from-catalogue.md` disagrees with itself.** Its trailing bullet reads
  `- Status: Ready for Review` while the yaml says `done`. This PR follows the yaml, as specified.
  Worth a human decision on which is right, and on whether the trailing bullets should be removed
  once a canonical line-initial status exists.
- **`3-4-cache-catalogue-for-offline.md` has a decoy.** Line 135 reads `**Status**: ✅ Approved for
  production by Dev agent` — a code-review verdict, not a story status. It is unreadable by the
  regex anyway (the colon is outside the bold: `**Status**:` ≠ `**Status:**`), and the new line sits
  above it, so the first-match-wins `/m` lookup is unambiguous.

## Verification

- `DRY_RUN=1 PR_TITLE=… PR_BODY=… node scripts/mark-story-done.mjs` — resolves only `done` stories,
  advances nothing.
- Each file re-read through the script's exact regex: all six return `done`, matching the yaml.
- `npx prettier --check` clean on all changed files.
