### PR TITLE
chore(ci): enforce the story catalogue ↔ sprint tracker 1:1 mapping

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -100,6 +100,20 @@ jobs:
       - name: Check tests are co-located (no __tests__ folders)
         run: yarn check:no-tests-folders
 
+      # docs/sprint-artifacts/README.md states that every `### Story N.M` in
+      # docs/epics.md maps 1:1 to a `development_status` key in sprint-status.yaml.
+      # Nothing enforced it, and it broke twice in a row: a drafting PR added the
+      # tracker key and the story file but not the catalogue section (Story 16.24,
+      # fixed by PR #190; Story 16.25, fixed by PR #198). Both gaps were found by
+      # hand. The failure is quiet and downstream — `create-story` happily reads a
+      # tracker key with no content behind it and drafts against a story whose
+      # goal and acceptance criteria exist nowhere. This also pins the
+      # `totalStories` frontmatter field to the literal `### Story ` heading count,
+      # the rule epics.md records inline, after three different counting rules let
+      # the number drift.
+      - name: Check the story catalogue matches the sprint tracker
+        run: yarn check:story-catalogue-sync
+
       - name: Run tests (with coverage)
         run: yarn test:coverage --watchAll=false --runInBand
 

--- a/docs/sprint-artifacts/README.md
+++ b/docs/sprint-artifacts/README.md
@@ -18,6 +18,18 @@ for those extensions — it is loaded as a persistent fact by the customized spr
 `development_status` key here). The **tracker is source of truth** for live status; `epics.md` is
 regenerated _from_ the tracker, never the reverse.
 
+That 1:1 mapping is **enforced in CI** by `yarn check:story-catalogue-sync`
+([`scripts/check-story-catalogue-sync.mjs`](../../scripts/check-story-catalogue-sync.mjs)), which
+reports gaps in both directions and also pins `epics.md`'s `totalStories` frontmatter to the literal
+`### Story ` heading count. It exists because the invariant broke twice in a row — a drafting PR added
+the tracker key and the story file but not the catalogue section, leaving `create-story` reading a key
+with no content behind it.
+
+A heading whose id does **not** derive from its tracker key — today `### Story 12.IC:` and
+`### Story 12.FI:`, whose keys are `12-icon-doc-cleanup` and `12-figma-icon-update` — declares the
+mapping in its own section body on a `Tracker key:` line (see either section for the exact form). Add
+that line for any future oddity rather than special-casing the script.
+
 ## Why story files live in `stories/`
 
 The story-status automation hardcodes this path — `scripts/lib/story-refs.mjs`,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:no-tests-folders": "node scripts/check-no-tests-folders.mjs",
     "check:native-patches": "node scripts/verify-native-patches.mjs",
     "check:native-strings": "node scripts/verify-native-strings.mjs",
+    "check:story-catalogue-sync": "node scripts/check-story-catalogue-sync.mjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/scripts/check-story-catalogue-sync.mjs
+++ b/scripts/check-story-catalogue-sync.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Enforce the catalogue ↔ tracker invariant from `docs/sprint-artifacts/README.md`:
+ * every `### Story N.M` heading in `docs/epics.md` maps 1:1 to a
+ * `development_status` key in `docs/sprint-artifacts/sprint-status.yaml`.
+ *
+ * Also checks the `totalStories` frontmatter field against the literal
+ * `### Story ` heading count — the counting rule the file itself records, and one
+ * that has been redefined three times while the number drifted.
+ *
+ * The comparison lives in `scripts/lib/story-catalogue.mjs` (pure, unit-tested);
+ * this file only resolves paths, prints, and sets the exit code.
+ */
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { checkStoryCatalogueSync } from './lib/story-catalogue.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const EPICS = 'docs/epics.md';
+const TRACKER = 'docs/sprint-artifacts/sprint-status.yaml';
+
+const read = (relative) => {
+  try {
+    return readFileSync(path.join(repoRoot, relative), 'utf8');
+  } catch (error) {
+    console.error(`[check-story-catalogue-sync] cannot read ${relative}: ${error.message}`);
+    process.exit(1);
+  }
+};
+
+const { problems, stats } = checkStoryCatalogueSync({
+  epicsMarkdown: read(EPICS),
+  trackerYaml: read(TRACKER)
+});
+
+const writeSummary = (markdown) => {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryFile) return;
+  try {
+    appendFileSync(summaryFile, markdown);
+  } catch {
+    /* summary is best-effort */
+  }
+};
+
+if (problems.length === 0) {
+  console.log(
+    `[check-story-catalogue-sync] OK — ${stats.headings} catalogue section(s) ↔ ` +
+      `${stats.trackerStoryKeys} tracker key(s), totalStories: ${stats.totalStories}.`
+  );
+  writeSummary(
+    '### ✅ Story catalogue in sync with the tracker\n\n' +
+      `${stats.headings} \`### Story\` section(s) in \`${EPICS}\` map 1:1 to ` +
+      `${stats.trackerStoryKeys} \`development_status\` key(s).\n`
+  );
+  process.exit(0);
+}
+
+console.error(`[check-story-catalogue-sync] ${problems.length} problem(s):`);
+for (const { code, message } of problems) {
+  console.error(`  ✘ [${code}] ${message}`);
+  // Single-line GitHub annotation — the multi-line fix hints stay in the log.
+  console.error(`::error::${code}: ${message.split('\n')[0]}`);
+}
+console.error(
+  `\nThe catalogue and the tracker must agree in both directions: ${TRACKER} is the\n` +
+    `source of truth for status, and ${EPICS} is where \`create-story\` reads a story's\n` +
+    'goal and acceptance criteria. A tracker key with no section is a story that can be\n' +
+    'picked up with no content behind it.'
+);
+
+writeSummary(
+  '### ❌ Story catalogue out of sync with the tracker\n\n' +
+    `Every \`### Story N.M\` in \`${EPICS}\` must map 1:1 to a \`development_status\` key in \`${TRACKER}\`.\n\n` +
+    problems.map(({ code, message }) => `- **${code}** — ${message.split('\n')[0]}`).join('\n') +
+    '\n'
+);
+process.exit(1);

--- a/scripts/lib/story-catalogue.mjs
+++ b/scripts/lib/story-catalogue.mjs
@@ -1,0 +1,271 @@
+/**
+ * Pure checker for the catalogue ↔ tracker invariant documented in
+ * `docs/sprint-artifacts/README.md`:
+ *
+ *   > every `### Story N.M` there maps 1:1 to a `development_status` key here
+ *
+ * Nothing in here touches the filesystem — it takes the two file bodies as
+ * strings and returns structured problems, so the test can drive it with inline
+ * fixtures and `scripts/check-story-catalogue-sync.mjs` stays a thin CLI.
+ *
+ * WHY THIS EXISTS: the invariant has been broken twice in a row (Story 16.24,
+ * fixed in PR #190; Story 16.25, fixed in PR #198) and both gaps were found by
+ * hand. Each time the drafting PR added the tracker key and the story file but
+ * not the catalogue section, which leaves `create-story` reading a tracker key
+ * with no content behind it — it drafts against a story that has no acceptance
+ * criteria and no goal recorded anywhere the skill looks.
+ *
+ * WHY IDENTITIES, NOT REGEX PAIRS: the obvious implementation greps
+ * `^  (\d+)-(\d+[a-z]?)-([a-z0-9-]+):` out of the tracker, which silently drops
+ * the two keys that predate the numeric convention (`12-icon-doc-cleanup`,
+ * `12-figma-icon-update`) — the exact failure mode this gate is meant to remove.
+ * So both sides are parsed permissively and *then* classified, and anything that
+ * cannot be classified is reported rather than skipped.
+ */
+
+/** A top-level YAML mapping key — ends the `development_status:` block. */
+const TOP_LEVEL_KEY = /^[A-Za-z_][A-Za-z0-9_]*:/;
+
+/** `  16-25-map-upce…:` — a `development_status` entry (exactly two spaces). */
+const TRACKER_ENTRY = /^ {2}([A-Za-z0-9][A-Za-z0-9._-]*):/;
+
+/** `epic-16:` / `epic-16-retrospective:` — not stories, no catalogue section. */
+const EPIC_KEY = /^epic-\d+(-retrospective)?$/;
+
+/** `16-25-map-upce-instead-of-storing-as-code128` → epic 16, story `25`. */
+const NUMERIC_TRACKER_KEY = /^(\d+)-(\d+[a-z]?)-[a-z0-9-]+$/;
+
+/** Any catalogue section heading, whatever its identifier looks like. */
+const HEADING = /^### Story (.+?):/;
+
+/** The literal heading marker — used to cross-check the permissive parse. */
+const HEADING_MARKER = /^### Story /;
+
+/** `12.IC` is a heading id; `16.25` and `13.7a` are numeric heading ids. */
+const NUMERIC_HEADING_ID = /^(\d+)\.(\d+[a-z]?)$/;
+
+/**
+ * `_Tracker key: \`12-icon-doc-cleanup\` (…)._` — an in-document escape hatch for
+ * a section whose heading id does not derive from its tracker key. Declaring it
+ * in the prose keeps the mapping where a human reading the catalogue will see it,
+ * and means a future oddity is fixed by editing the doc rather than this script.
+ */
+const DECLARED_KEY = /_Tracker key:\s*`([^`]+)`/;
+
+/** `totalStories: 169` inside the epics.md frontmatter. */
+const TOTAL_STORIES = /^totalStories:\s*(\d+)/;
+
+/**
+ * Split epics.md into `### Story …` sections.
+ *
+ * Section bodies run to the next `###`/`##` heading so a `_Tracker key:_`
+ * declaration can only ever be claimed by the section it sits in.
+ */
+export function parseCatalogue(markdown) {
+  const lines = markdown.split('\n');
+
+  // Frontmatter only — a `totalStories:` mention in the prose must not count.
+  let totalStories = null;
+  if (lines[0]?.trim() === '---') {
+    const end = lines.findIndex((line, i) => i > 0 && line.trim() === '---');
+    for (const line of lines.slice(1, end === -1 ? lines.length : end)) {
+      const match = line.match(TOTAL_STORIES);
+      if (match) totalStories = Number(match[1]);
+    }
+  }
+
+  const sections = [];
+  let current = null;
+  const closeCurrent = () => {
+    if (!current) return;
+    current.declaredKey = current.body.join('\n').match(DECLARED_KEY)?.[1] ?? null;
+    delete current.body;
+    sections.push(current);
+    current = null;
+  };
+
+  let markerCount = 0;
+  lines.forEach((line, i) => {
+    if (HEADING_MARKER.test(line)) markerCount += 1;
+
+    const heading = line.match(HEADING);
+    if (heading) {
+      closeCurrent();
+      current = { id: heading[1].trim(), line: i + 1, body: [] };
+      return;
+    }
+    // Any other heading at h2/h3 closes the section — `#### …` stays inside it.
+    if (/^#{2,3} /.test(line)) closeCurrent();
+    else if (current) current.body.push(line);
+  });
+  closeCurrent();
+
+  return { sections, totalStories, markerCount };
+}
+
+/** Pull the `development_status:` keys out of sprint-status.yaml. */
+export function parseTracker(yamlText) {
+  const lines = yamlText.split('\n');
+  const start = lines.findIndex((line) => /^development_status:/.test(line));
+  if (start === -1) return { entries: [], blockFound: false };
+
+  const entries = [];
+  for (const [offset, line] of lines.slice(start + 1).entries()) {
+    if (TOP_LEVEL_KEY.test(line)) break; // next top-level key ends the block
+    const match = line.match(TRACKER_ENTRY);
+    if (match) entries.push({ key: match[1], line: start + offset + 2 });
+  }
+
+  return { entries, blockFound: true };
+}
+
+/**
+ * The shared identity both sides are compared on.
+ *
+ * Numeric stories reduce to `N.M` (so `16-25-map-upce…` and `### Story 16.25:`
+ * meet), and anything else is identified by its literal tracker key. The two
+ * shapes cannot collide: an `N.M` identity always contains a `.` and never a `-`.
+ */
+const numericIdentity = (epic, story) => `${epic}.${story}`;
+
+/**
+ * Compare the catalogue against the tracker.
+ *
+ * @returns {{problems: Array<{code: string, message: string}>, stats: object}}
+ *   `problems` is empty exactly when the invariant holds.
+ */
+export function checkStoryCatalogueSync({ epicsMarkdown, trackerYaml }) {
+  const problems = [];
+  const fail = (code, message) => problems.push({ code, message });
+
+  const { sections, totalStories, markerCount } = parseCatalogue(epicsMarkdown);
+  const { entries, blockFound } = parseTracker(trackerYaml);
+
+  // --- Vacuity guards: a gate that parsed nothing must not report success. ---
+  if (!blockFound) {
+    fail(
+      'no-tracker-block',
+      'sprint-status.yaml has no `development_status:` block — nothing could be checked.'
+    );
+  }
+  if (sections.length === 0) {
+    fail(
+      'no-headings-parsed',
+      'epics.md yielded no `### Story <id>: <title>` sections — nothing could be checked.'
+    );
+  }
+  if (markerCount !== sections.length) {
+    fail(
+      'heading-unparsed',
+      `epics.md has ${markerCount} \`### Story \` line(s) but only ${sections.length} parsed as ` +
+        '`### Story <id>: <title>`. Every heading needs an id followed by a colon.'
+    );
+  }
+
+  const storyEntries = entries.filter(({ key }) => !EPIC_KEY.test(key));
+  if (blockFound && storyEntries.length === 0) {
+    fail(
+      'no-tracker-keys-parsed',
+      '`development_status:` yielded no story keys (only `epic-N` entries) — nothing could be checked.'
+    );
+  }
+
+  // --- Tracker side: key → identity. ---
+  const trackerByIdentity = new Map();
+  for (const entry of storyEntries) {
+    const numeric = entry.key.match(NUMERIC_TRACKER_KEY);
+    const identity = numeric ? numericIdentity(numeric[1], numeric[2]) : entry.key;
+    const existing = trackerByIdentity.get(identity);
+    if (existing) {
+      fail(
+        'duplicate-tracker-identity',
+        `tracker keys \`${existing.key}\` (line ${existing.line}) and \`${entry.key}\` ` +
+          `(line ${entry.line}) both resolve to story ${identity}.`
+      );
+      continue;
+    }
+    trackerByIdentity.set(identity, entry);
+  }
+
+  // --- Catalogue side: heading → identity. A declaration always wins, so a
+  //     section whose id does not derive from its key can still be matched. ---
+  const catalogueByIdentity = new Map();
+  for (const section of sections) {
+    const numeric = section.id.match(NUMERIC_HEADING_ID);
+    let identity;
+
+    if (section.declaredKey) {
+      // Reduce a declared key through the same rule as the tracker side, so
+      // declaring the numeric key of a numeric section is a no-op, not a mismatch.
+      const declaredNumeric = section.declaredKey.match(NUMERIC_TRACKER_KEY);
+      identity = declaredNumeric
+        ? numericIdentity(declaredNumeric[1], declaredNumeric[2])
+        : section.declaredKey;
+    } else if (numeric) {
+      identity = numericIdentity(numeric[1], numeric[2]);
+    } else {
+      fail(
+        'heading-needs-tracker-key-declaration',
+        `epics.md:${section.line} \`### Story ${section.id}:\` has a non-numeric id and no ` +
+          'tracker-key declaration, so it cannot be matched. Add a line to the section body:\n' +
+          '        _Tracker key: `<the-development_status-key>` (…)._'
+      );
+      continue;
+    }
+
+    const existing = catalogueByIdentity.get(identity);
+    if (existing) {
+      fail(
+        'duplicate-catalogue-identity',
+        `epics.md sections \`### Story ${existing.id}:\` (line ${existing.line}) and ` +
+          `\`### Story ${section.id}:\` (line ${section.line}) both claim story ${identity}.`
+      );
+      continue;
+    }
+    catalogueByIdentity.set(identity, section);
+  }
+
+  // --- Both directions. ---
+  for (const [identity, entry] of trackerByIdentity) {
+    if (catalogueByIdentity.has(identity)) continue;
+    fail(
+      'tracker-key-missing-section',
+      `tracker key \`${entry.key}\` (sprint-status.yaml:${entry.line}) has no catalogue section.\n` +
+        `        Add a \`### Story ${identity}: <title>\` section to docs/epics.md, or drop the key.`
+    );
+  }
+
+  for (const [identity, section] of catalogueByIdentity) {
+    if (trackerByIdentity.has(identity)) continue;
+    fail(
+      'section-missing-tracker-key',
+      `epics.md:${section.line} \`### Story ${section.id}:\` has no \`development_status\` key.\n` +
+        `        Add \`${identity}-<slug>: backlog\` to sprint-status.yaml, or drop the section.`
+    );
+  }
+
+  // --- `totalStories` frontmatter, against the rule recorded in the file. ---
+  if (totalStories === null) {
+    fail(
+      'total-stories-missing',
+      'epics.md frontmatter has no `totalStories:` field. It must equal the number of ' +
+        '`### Story ` headings.'
+    );
+  } else if (totalStories !== markerCount) {
+    fail(
+      'total-stories-mismatch',
+      `epics.md frontmatter says \`totalStories: ${totalStories}\` but the file has ` +
+        `${markerCount} \`### Story \` heading(s). Update the frontmatter to ${markerCount}.`
+    );
+  }
+
+  return {
+    problems,
+    stats: {
+      headings: sections.length,
+      trackerStoryKeys: storyEntries.length,
+      totalStories,
+      declaredKeys: sections.filter((s) => s.declaredKey).length
+    }
+  };
+}

--- a/scripts/lib/story-catalogue.test.js
+++ b/scripts/lib/story-catalogue.test.js
@@ -1,0 +1,350 @@
+/**
+ * @jest-environment node
+ */
+// Unit tests for checkStoryCatalogueSync() — the comparison behind
+// `yarn check:story-catalogue-sync`, which enforces that every `### Story N.M`
+// heading in docs/epics.md maps 1:1 to a `development_status` key in
+// docs/sprint-artifacts/sprint-status.yaml.
+//
+// WHY A SUBPROCESS: story-catalogue.mjs is a plain Node ESM module in scripts/,
+// and Jest compiles through babel.config.test.js, which targets Hermes/React
+// Native and emits CommonJS. `moduleFileExtensions` also omits `mjs`. Rather than
+// change the transform for every app test to reach a build script, each fixture is
+// evaluated in one real `node --input-type=module` child — the same approach
+// story-refs.test.js takes, and the same ESM semantics CI runs. All cases share a
+// single spawn, resolved in beforeAll.
+//
+// WHY SYNTHETIC FIXTURES, NOT THE REAL DOCS: asserting that the checked-in
+// epics.md and sprint-status.yaml are in sync is the CI gate's job, and doing it
+// here too would red the whole test suite on any docs drift — the wrong signal in
+// the wrong place. These fixtures pin the *rules* instead.
+//
+// Assertions are on problem `code`s, never prose, so the messages stay editable.
+
+const { execFileSync } = require('node:child_process');
+const { pathToFileURL } = require('node:url');
+
+const MODULE_URL = pathToFileURL(require.resolve('./story-catalogue.mjs')).href;
+
+/** epics.md is frontmatter + prose; only `totalStories` matters to the checker. */
+const epics = (totalStories, body) =>
+  [
+    '---',
+    "project_name: 'myLoyaltyCards'",
+    ...(totalStories === null ? [] : [`totalStories: ${totalStories}`]),
+    '---',
+    '',
+    '## Epic 1: Test',
+    '',
+    body
+  ].join('\n');
+
+/** sprint-status.yaml, reduced to the block the checker reads. */
+const tracker = (...lines) =>
+  ['generated: 2026-01-03', 'development_status:', ...lines, 'action_items: []'].join('\n');
+
+const SECTION_1_1 = '### Story 1.1: Do the thing\n\n**As a** user…\n';
+const SECTION_1_2 = '### Story 1.2: Do the other thing\n\n**As a** user…\n';
+
+// [name, epicsMarkdown, trackerYaml] — evaluated in order by the child process.
+const CASES = [
+  [
+    'in sync',
+    epics(2, `${SECTION_1_1}\n${SECTION_1_2}`),
+    tracker('  epic-1: done', '  1-1-do-the-thing: done', '  1-2-do-the-other-thing: backlog')
+  ],
+
+  // The regression this gate exists for: PR #186 and #189 each added a tracker
+  // key and a story file but no catalogue section (Story 16.24, then 16.25).
+  [
+    'tracker key with no catalogue section',
+    epics(1, SECTION_1_1),
+    tracker('  1-1-do-the-thing: done', '  1-2-do-the-other-thing: ready-for-dev')
+  ],
+  [
+    'catalogue section with no tracker key',
+    epics(2, `${SECTION_1_1}\n${SECTION_1_2}`),
+    tracker('  1-1-do-the-thing: done')
+  ],
+
+  // Problem 1 in the brief: `### Story 12.IC:` / `### Story 12.FI:` have
+  // non-numeric ids and tracker keys (`12-icon-doc-cleanup`,
+  // `12-figma-icon-update`) that do not derive from them. They are matched by the
+  // `_Tracker key:` declaration already present in each section's prose.
+  [
+    'non-numeric heading matched by its declared tracker key',
+    epics(
+      2,
+      `${SECTION_1_1}\n### Story 1.IC: Icon doc cleanup\n\n` +
+        '_Tracker key: `1-icon-doc-cleanup` (non-numeric `IC` identifier)._\n'
+    ),
+    tracker('  1-1-do-the-thing: done', '  1-icon-doc-cleanup: done')
+  ],
+  [
+    'declared tracker key that does not exist in the tracker',
+    epics(
+      1,
+      '### Story 1.IC: Icon doc cleanup\n\n_Tracker key: `1-icon-doc-cleanup` (non-numeric)._\n'
+    ),
+    tracker('  1-1-do-the-thing: done')
+  ],
+  // A section whose id cannot be derived AND carries no declaration must be
+  // reported, never skipped. The trailing section proves a later declaration is
+  // not leaked backwards into an earlier section.
+  [
+    'non-numeric heading with no declaration at all',
+    epics(
+      2,
+      '### Story 1.IC: Icon doc cleanup\n\nNo declaration here.\n\n' +
+        '### Story 1.FI: Figma icon update\n\n_Tracker key: `1-figma-icon-update` (non-numeric)._\n'
+    ),
+    tracker('  1-icon-doc-cleanup: done', '  1-figma-icon-update: done')
+  ],
+  // The other half of problem 1: a naive `^  (\d+)-(\d+[a-z]?)-…` tracker regex
+  // drops this key entirely, so an orphaned non-numeric key would pass unnoticed.
+  [
+    'non-numeric tracker key claimed by nothing',
+    epics(1, SECTION_1_1),
+    tracker('  1-1-do-the-thing: done', '  1-icon-doc-cleanup: done')
+  ],
+
+  // Problem 2 in the brief: totalStories has drifted repeatedly under three
+  // different counting rules. Pinned to the literal `### Story ` count, which is
+  // the rule epics.md now records inline.
+  [
+    'totalStories disagrees with the heading count',
+    epics(7, `${SECTION_1_1}\n${SECTION_1_2}`),
+    tracker('  1-1-do-the-thing: done', '  1-2-do-the-other-thing: done')
+  ],
+  ['totalStories absent', epics(null, SECTION_1_1), tracker('  1-1-do-the-thing: done')],
+  // `totalStories` is read from the frontmatter only — a prose mention of the
+  // field must not be picked up as the declared value.
+  [
+    'totalStories mentioned in prose after the frontmatter',
+    `${epics(1, SECTION_1_1)}\n> Note: totalStories: 999 is counted from headings.\n`,
+    tracker('  1-1-do-the-thing: done')
+  ],
+
+  [
+    'letter-suffixed story id',
+    epics(1, '### Story 13.7a: Import data\n'),
+    tracker('  13-7a-import-data-from-json: done')
+  ],
+  [
+    'epic and retrospective keys are not stories',
+    epics(1, SECTION_1_1),
+    tracker(
+      '  # Epic 1: Foundation',
+      '  epic-1: done # completed 2026-01-07',
+      '  1-1-do-the-thing: done',
+      '  epic-1-retrospective: optional'
+    )
+  ],
+  // The real tracker carries multi-hundred-word inline `#` comments on story
+  // lines, comment-only lines, and blank lines inside the block.
+  [
+    'inline comments and blank lines inside the block',
+    epics(1, SECTION_1_1),
+    tracker(
+      '  # ============================================',
+      '',
+      '  1-1-do-the-thing: done # 2026-08-02: a very long note about: colons, `backticks`, 1-2-3 refs.',
+      '    nested-not-a-story-key: ignored'
+    )
+  ],
+
+  // Vacuity guards — a checker that parsed nothing must not report success.
+  ['empty development_status block', epics(1, SECTION_1_1), tracker()],
+  ['no development_status block at all', epics(1, SECTION_1_1), 'generated: 2026-01-03\n'],
+  [
+    'no story headings at all',
+    epics(0, '## Epic 1: Test\n\nNo stories here.\n'),
+    tracker('  1-1-do-the-thing: done')
+  ],
+  [
+    'heading with no colon after the id',
+    epics(2, `${SECTION_1_1}\n### Story 1.2 Missing its colon\n`),
+    tracker('  1-1-do-the-thing: done', '  1-2-do-the-other-thing: done')
+  ],
+
+  [
+    'two sections claiming one story',
+    epics(2, `${SECTION_1_1}\n### Story 1.1: Duplicated\n`),
+    tracker('  1-1-do-the-thing: done')
+  ],
+  [
+    'two tracker keys resolving to one story',
+    epics(1, SECTION_1_1),
+    tracker('  1-1-do-the-thing: done', '  1-1-do-the-thing-again: backlog')
+  ]
+];
+
+/** Evaluate every case in one child process; return name -> {codes, stats}. */
+const runCases = () => {
+  const harness = `
+    import { checkStoryCatalogueSync } from ${JSON.stringify(MODULE_URL)};
+    const cases = JSON.parse(process.env.CASES_JSON);
+    process.stdout.write(
+      JSON.stringify(
+        cases.map(([, epicsMarkdown, trackerYaml]) => {
+          const { problems, stats } = checkStoryCatalogueSync({ epicsMarkdown, trackerYaml });
+          return { codes: problems.map((p) => p.code).sort(), messages: problems.map((p) => p.message), stats };
+        })
+      )
+    );
+  `;
+
+  let stdout;
+  try {
+    stdout = execFileSync(process.execPath, ['--input-type=module', '-e', harness], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, CASES_JSON: JSON.stringify(CASES) }
+    });
+  } catch (err) {
+    throw new Error(`story-catalogue harness failed:\n${err.stderr || err.message}`);
+  }
+
+  const results = JSON.parse(stdout);
+  return Object.fromEntries(CASES.map(([name], i) => [name, results[i]]));
+};
+
+describe('checkStoryCatalogueSync', () => {
+  let resolved;
+
+  beforeAll(() => {
+    resolved = runCases();
+  });
+
+  const codes = (name) => resolved[name].codes;
+
+  it('reports nothing when the catalogue and the tracker agree', () => {
+    expect(codes('in sync')).toEqual([]);
+    expect(resolved['in sync'].stats).toMatchObject({
+      headings: 2,
+      trackerStoryKeys: 2,
+      totalStories: 2
+    });
+  });
+
+  describe('both directions of the 1:1 mapping', () => {
+    it('flags a tracker key with no catalogue section', () => {
+      expect(codes('tracker key with no catalogue section')).toEqual([
+        'tracker-key-missing-section'
+      ]);
+    });
+
+    it('names the story to add, so the fix needs no further digging', () => {
+      expect(resolved['tracker key with no catalogue section'].messages[0]).toContain(
+        '### Story 1.2:'
+      );
+    });
+
+    it('flags a catalogue section with no tracker key', () => {
+      expect(codes('catalogue section with no tracker key')).toEqual([
+        'section-missing-tracker-key'
+      ]);
+    });
+  });
+
+  describe('non-numeric ids are matched, never dropped', () => {
+    it('matches a non-numeric heading via its declared tracker key', () => {
+      expect(codes('non-numeric heading matched by its declared tracker key')).toEqual([]);
+      expect(
+        resolved['non-numeric heading matched by its declared tracker key'].stats.declaredKeys
+      ).toBe(1);
+    });
+
+    it('still checks a declared key against the tracker', () => {
+      expect(codes('declared tracker key that does not exist in the tracker')).toEqual([
+        'section-missing-tracker-key',
+        'tracker-key-missing-section'
+      ]);
+    });
+
+    it('demands a declaration when the id cannot be derived', () => {
+      expect(codes('non-numeric heading with no declaration at all')).toEqual([
+        'heading-needs-tracker-key-declaration',
+        'tracker-key-missing-section'
+      ]);
+    });
+
+    it('flags a non-numeric tracker key that no section claims', () => {
+      expect(codes('non-numeric tracker key claimed by nothing')).toEqual([
+        'tracker-key-missing-section'
+      ]);
+    });
+
+    it('accepts a letter-suffixed story id', () => {
+      expect(codes('letter-suffixed story id')).toEqual([]);
+    });
+  });
+
+  describe('totalStories is pinned to the literal heading count', () => {
+    it('flags a stale count', () => {
+      expect(codes('totalStories disagrees with the heading count')).toEqual([
+        'total-stories-mismatch'
+      ]);
+    });
+
+    it('flags a missing field', () => {
+      expect(codes('totalStories absent')).toEqual(['total-stories-missing']);
+    });
+
+    it('reads the frontmatter only, not a prose mention', () => {
+      expect(codes('totalStories mentioned in prose after the frontmatter')).toEqual([]);
+    });
+  });
+
+  describe('tracker parsing', () => {
+    it('ignores epic and retrospective keys', () => {
+      expect(codes('epic and retrospective keys are not stories')).toEqual([]);
+    });
+
+    it('survives inline comments, comment-only lines and deeper indentation', () => {
+      expect(codes('inline comments and blank lines inside the block')).toEqual([]);
+    });
+  });
+
+  describe('it never passes vacuously', () => {
+    it('fails when the block holds no story keys', () => {
+      expect(codes('empty development_status block')).toEqual([
+        'no-tracker-keys-parsed',
+        'section-missing-tracker-key'
+      ]);
+    });
+
+    it('fails when there is no development_status block', () => {
+      expect(codes('no development_status block at all')).toEqual([
+        'no-tracker-block',
+        'section-missing-tracker-key'
+      ]);
+    });
+
+    it('fails when no headings parse', () => {
+      expect(codes('no story headings at all')).toEqual([
+        'no-headings-parsed',
+        'tracker-key-missing-section'
+      ]);
+    });
+
+    it('fails when a `### Story` line does not parse as a heading', () => {
+      expect(codes('heading with no colon after the id')).toEqual([
+        'heading-unparsed',
+        'tracker-key-missing-section'
+      ]);
+    });
+  });
+
+  describe('ambiguity is a failure, not a coin flip', () => {
+    it('flags two sections claiming one story', () => {
+      expect(codes('two sections claiming one story')).toEqual(['duplicate-catalogue-identity']);
+    });
+
+    it('flags two tracker keys resolving to one story', () => {
+      expect(codes('two tracker keys resolving to one story')).toEqual([
+        'duplicate-tracker-identity'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

`docs/sprint-artifacts/README.md` states that every `### Story N.M` heading in `docs/epics.md` maps 1:1 to a `development_status` key in `sprint-status.yaml`. Nothing enforced it, and it broke twice in a row — the drafting PR added the tracker key and the story file but not the catalogue section, so `create-story` could read a tracker key with no content behind it. Both gaps were found by hand and fixed after the fact: #190 (for 16.24, drafted in #186) and #198 (for 16.25, drafted in #189).

This adds the gate.

## What

| File | |
| --- | --- |
| `scripts/lib/story-catalogue.mjs` | Pure checker — two file bodies in, structured problems out. No filesystem access. |
| `scripts/lib/story-catalogue.test.js` | 20 unit tests, co-located per the repo convention. |
| `scripts/check-story-catalogue-sync.mjs` | Thin CLI: reads the two files, prints, sets the exit code. GitHub annotations + step summary. |
| `package.json` | `yarn check:story-catalogue-sync` |
| `.github/workflows/ci-quality-gates.yml` | New step, after the co-located-tests check. |
| `docs/sprint-artifacts/README.md` | The invariant now names its enforcement. |

Gaps are reported in **both** directions, with the fix spelled out in the message:

```
✘ [tracker-key-missing-section] tracker key `16-25-map-upce-instead-of-storing-as-code128`
  (sprint-status.yaml:482) has no catalogue section.
  Add a `### Story <id>: <title>` section to docs/epics.md, or drop the key.
```

## Two decisions worth reviewing

**1. The non-numeric headings are matched from the document, not an allowlist.** `### Story 12.IC:` and `### Story 12.FI:` have tracker keys (`12-icon-doc-cleanup`, `12-figma-icon-update`) that don't derive from their ids — but both sections *already* declare their key inline as ``_Tracker key: `…`_``. The checker parses that declaration and prefers it over deriving from the heading id, so a future oddity is fixed by editing the doc rather than this script. A non-numeric heading with **no** declaration is a hard failure, so nothing can drop out quietly.

Relatedly, the obvious tracker-side regex (`^  (\d+)-(\d+[a-z]?)-([a-z0-9-]+):`) silently skips those two keys — meaning an *orphaned* non-numeric key would pass unnoticed, which is the failure class this gate exists to remove. So both sides are parsed permissively and *then* classified, and anything unclassifiable is reported.

**2. `totalStories` is pinned to the literal `### Story ` heading count.** That field has drifted repeatedly under three different counting rules (#190 used "all headings minus the 7 lowercase sub-lettered ones"; #192 the numeric-only count; #196 switched to the literal heading count and recorded it inline). The check enforces the rule the file currently records. Note #198 independently bumped it to 170 under that same rule, so the check agrees with what was already done by hand.

## Verification

- 20/20 new tests pass; full suite green (172 suites, 2046 tests). `lint`, `format:check`, `typecheck` clean.
- **The tests are real guards**, confirmed by mutation testing: reverting the tracker parse to the numeric-only regex fails 3 tests; disabling the `totalStories` check fails 1; silently skipping undeclared non-numeric headings fails 1.
- Against this branch's tree: `OK — 170 catalogue section(s) ↔ 170 tracker key(s), totalStories: 170`.
- Against `main` *before* #198 merged, the gate correctly reported the then-live 16.25 gap and exited 1 — so it was verified failing as well as passing.

The checker never passes vacuously: a missing `development_status:` block, zero parsed headings, zero story keys, a `### Story` line that doesn't parse, or a duplicate identity on either side all fail rather than quietly checking nothing.

## Follow-up (not in this PR)

`CONTRIBUTING.md`'s "CI — quality" gates row lists about half of what `ci-quality-gates.yml` actually runs — four gates were already undocumented there before this one. Left alone deliberately; being handled separately.
