### PR TITLE
chore(ci): scope adhoc builds to binary-affecting paths, trigger releases on publish

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,17 +1,45 @@
 # Android AdHoc Build
-# Triggers on main branch push (if app/core/features/shared/android change)
-# Also available as manual workflow_dispatch on any branch
+# Triggers on main branch push when something that can change the shipped binary
+# changes — see the annotated path list below.
+# Also available as manual workflow_dispatch on any branch.
 name: Android AdHoc Build
 
 on:
   push:
     branches: [main]
     paths:
+      # Source that reaches the JS bundle.
       - 'app/**'
       - 'core/**'
       - 'features/**'
       - 'shared/**'
+      # Native project. The watch companion is iOS-only, so targets/ and
+      # watch-ios/ are deliberately absent here — see ios-release.yml.
       - 'android/**'
+      # Data and assets compiled into the binary.
+      - 'catalogue/**'
+      - 'assets/**'
+      - 'tokens/**'
+      # Build inputs: Expo config (incl. the app version), dependencies, the
+      # patch-package patches applied into node_modules, and the Fastlane lanes.
+      - 'app.json'
+      - 'app.config.ts'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'babel.config.js'
+      - 'metro.config.js'
+      - 'patches/**'
+      - 'fastlane/**'
+      # So a change to this pipeline is exercised on merge (as watchos-tests.yml does).
+      - '.github/workflows/android-release.yml'
+      # …but never for files that cannot reach the binary: tests are co-located
+      # beside their subject and stories are Storybook-only (Chromatic covers
+      # those, and there is no web target). Order is load-bearing — a negative
+      # pattern after a positive match excludes that path, while a commit that
+      # ALSO touches real source still matches and still builds.
+      - '!**/*.test.ts'
+      - '!**/*.test.tsx'
+      - '!**/*.stories.tsx'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -1,9 +1,32 @@
 name: Beta Releases (RC)
 
 on:
+  # A published release is the reliable trigger. GitHub honours `[skip ci]` and
+  # friends ONLY for the push and pull_request events, and mark-story-done.yml
+  # lands `chore(sprint): mark story done after merge [skip ci]` on main after
+  # most merges — so tagging that tip and pushing the tag creates no run at all.
+  # Publishing the release cannot be skipped, whatever the tagged commit says.
+  release:
+    types: [published]
+  # Kept so a habitual `git push --tags` is never a silent no-op. When both
+  # events fire for one tag the concurrency group below collapses them to one run.
   push:
     tags:
       - 'v*.*.*-rc.*' # RC tags for beta builds
+  # Manual re-run, e.g. after a flaky upload. Not skippable either.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'RC tag to build (e.g. v1.0.0-rc.18)'
+        required: true
+
+# github.ref_name is the bare tag name for BOTH the release and the tag-push
+# event, so a tag that fires both collapses to a single run. The loser is
+# cancelled seconds after queuing — during runner setup, ~20 minutes before any
+# upload — so no partial build ever reaches TestFlight or Play.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -12,6 +35,10 @@ jobs:
   ios-testflight-beta:
     name: Build iOS TestFlight (RC)
     runs-on: macos-latest
+    # `on.release` cannot filter by tag pattern, so the RC selection that used to
+    # live entirely in `on.push.tags` is enforced here for release events. Push
+    # runs are already scoped by the tag pattern; dispatch is deliberate.
+    if: github.event_name != 'release' || contains(github.event.release.tag_name, '-rc.')
     env:
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
@@ -32,6 +59,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # release → refs/tags/<tag> (GITHUB_SHA is already the tagged commit);
+          # push → the tag; workflow_dispatch → the tag typed by the operator.
+          # `github.event.inputs` is null for the first two, so `||` falls through.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Select Xcode (latest stable for iOS 26 SDK)
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -81,6 +113,8 @@ jobs:
   android-beta:
     name: Build Android Alpha (RC)
     runs-on: ubuntu-latest
+    # See ios-testflight-beta above for why this guard exists.
+    if: github.event_name != 'release' || contains(github.event.release.tag_name, '-rc.')
     env:
       ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
       PLAY_STORE_API_KEY: ${{ secrets.PLAY_STORE_API_KEY }}
@@ -100,6 +134,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # See ios-testflight-beta above.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,17 +1,48 @@
 # iOS AdHoc Build
-# Triggers on main branch push (if app/core/features/shared/ios change)
-# Also available as manual workflow_dispatch on any branch
+# Triggers on main branch push when something that can change the shipped binary
+# changes — see the annotated path list below.
+# Also available as manual workflow_dispatch on any branch.
 name: iOS AdHoc Build
 
 on:
   push:
     branches: [main]
     paths:
+      # Source that reaches the JS bundle.
       - 'app/**'
       - 'core/**'
       - 'features/**'
       - 'shared/**'
+      # Native projects, plus the watch companion embedded in the iOS binary.
       - 'ios/**'
+      - 'targets/**'
+      - 'watch-ios/**'
+      # Data and assets compiled into the binary. catalogue/italy.json is read by
+      # watch-ios/Scripts/generate-catalogue.swift during this very build, so a
+      # brand added to the catalogue alone still changes what ships.
+      - 'catalogue/**'
+      - 'assets/**'
+      - 'tokens/**'
+      # Build inputs: Expo config (incl. the app version), dependencies, the
+      # native patches this workflow verifies below, and the Fastlane lanes.
+      - 'app.json'
+      - 'app.config.ts'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'babel.config.js'
+      - 'metro.config.js'
+      - 'patches/**'
+      - 'fastlane/**'
+      # So a change to this pipeline is exercised on merge (as watchos-tests.yml does).
+      - '.github/workflows/ios-release.yml'
+      # …but never for files that cannot reach the binary: tests are co-located
+      # beside their subject and stories are Storybook-only (Chromatic covers
+      # those, and there is no web target). Order is load-bearing — a negative
+      # pattern after a positive match excludes that path, while a commit that
+      # ALSO touches real source still matches and still builds.
+      - '!**/*.test.ts'
+      - '!**/*.test.tsx'
+      - '!**/*.stories.tsx'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/store-upload.yml
+++ b/.github/workflows/store-upload.yml
@@ -1,13 +1,39 @@
 # Store Upload (Final Release)
 # Uploads builds to App Store Connect and Play Console on final release tags.
-# Uses negative lookahead pattern to exclude RC tags (v1.2.3-rc.1).
+# Publishing a non-prerelease GitHub Release is the intended trigger; the tag
+# patterns are kept as a fallback. RC tags (v1.2.3-rc.1) are excluded both by the
+# negative tag pattern and by the job guards below.
 name: Store Upload (Final Release)
 
 on:
+  # A published release is the reliable trigger. GitHub honours `[skip ci]` and
+  # friends ONLY for the push and pull_request events, and mark-story-done.yml
+  # lands `chore(sprint): mark story done after merge [skip ci]` on main after
+  # most merges — so tagging that tip and pushing the tag creates no run at all.
+  # Publishing the release cannot be skipped, whatever the tagged commit says.
+  release:
+    types: [published]
+  # Kept so a habitual `git push --tags` is never a silent no-op. When both
+  # events fire for one tag the concurrency group below collapses them to one run.
   push:
     tags:
       - 'v*.*.*'
       - '!v*.*.*-*' # Exclude pre-release tags (e.g. v1.2.3-rc.1)
+  # Manual re-run, e.g. after a flaky upload. Not skippable either.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Final release tag to upload (e.g. v1.0.0)'
+        required: true
+
+# github.ref_name is the bare tag name for BOTH the release and the tag-push
+# event, so a tag that fires both collapses to a single run. The loser is
+# cancelled seconds after queuing — during runner setup, long before any store
+# upload begins. Note the corollary: deliberately re-running the same tag
+# supersedes a run already in flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -16,6 +42,15 @@ jobs:
   upload-ios-release:
     name: Upload iOS Release Build
     runs-on: macos-latest
+    # `on.release` cannot filter by tag pattern, so the exclusion that used to
+    # live entirely in `on.push.tags` is enforced here for release events. Belt
+    # and braces before anything reaches production: the release must be flagged
+    # non-prerelease AND carry a bare vX.Y.Z tag, so a mis-flagged release cannot
+    # ship. Push runs are already scoped; dispatch is a deliberate override.
+    if: >-
+      github.event_name != 'release' ||
+      (github.event.release.prerelease == false &&
+      !contains(github.event.release.tag_name, '-'))
     env:
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
@@ -36,6 +71,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # release → refs/tags/<tag> (GITHUB_SHA is already the tagged commit);
+          # push → the tag; workflow_dispatch → the tag typed by the operator.
+          # `github.event.inputs` is null for the first two, so `||` falls through.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Select Xcode (latest stable for iOS 26 SDK)
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -85,6 +125,11 @@ jobs:
   upload-android-release:
     name: Upload Android Release Build
     runs-on: ubuntu-latest
+    # See upload-ios-release above for why this guard exists.
+    if: >-
+      github.event_name != 'release' ||
+      (github.event.release.prerelease == false &&
+      !contains(github.event.release.tag_name, '-'))
     env:
       ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
       PLAY_STORE_API_KEY: ${{ secrets.PLAY_STORE_API_KEY }}
@@ -104,6 +149,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # See upload-ios-release above.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,6 +354,7 @@ Run `yarn lint` and `yarn typecheck` to catch most violations automatically.
 
 - **Do not merge your own PR.** A maintainer reviews and merges to `main`.
 - **Status update is automated.** When a PR is **merged**, the [`mark-story-done`](.github/workflows/mark-story-done.yml) workflow reads the story referenced in the PR and commits its status → `done` (in both `sprint-status.yaml` and the story file) directly to the default branch. The commit is tagged `[skip ci]` so it doesn't re-run any pipelines. This works for fork PRs too. _(Maintainers can also apply it by hand: `node scripts/mark-story-done.mjs <story-id>`.)_
+  - **Consequence for releases:** because that commit is usually `main`'s tip, a bare `git tag && git push --tags` will silently create no workflow run — GitHub applies the skip marker to tag pushes too. Cut releases with `gh release create` instead; see [Why releases are published, not just tagged](docs/cicd.md#why-releases-are-published-not-just-tagged).
 - When an epic completes, run a **retrospective** and capture lessons in `docs/sprint-artifacts/`.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -412,15 +412,15 @@ Key documentation points for watchOS:
 
 ### Environment Strategy (Dev + Production)
 
-| Aspect                   | Dev                        | Production                    |
-| ------------------------ | -------------------------- | ----------------------------- |
-| **Purpose**              | Testing, PR previews       | App Store releases            |
-| **Supabase**             | `myloyaltycards-dev`       | `myloyaltycards-prod`         |
-| **iOS Distribution**     | TestFlight                 | App Store                     |
-| **Android Distribution** | Internal Track             | Google Play                   |
-| **Trigger**              | Push to main, PRs          | Manual / git tags (v\*)       |
-| **Approval**             | None                       | Required (GitHub Environment) |
-| **Logging**              | Verbose (console + Sentry) | Errors only (Sentry)          |
+| Aspect                   | Dev                        | Production                     |
+| ------------------------ | -------------------------- | ------------------------------ |
+| **Purpose**              | Testing, PR previews       | App Store releases             |
+| **Supabase**             | `myloyaltycards-dev`       | `myloyaltycards-prod`          |
+| **iOS Distribution**     | TestFlight                 | App Store                      |
+| **Android Distribution** | Internal Track             | Google Play                    |
+| **Trigger**              | Push to main, PRs          | Published GitHub Release (v\*) |
+| **Approval**             | None                       | Required (GitHub Environment)  |
+| **Logging**              | Verbose (console + Sentry) | Errors only (Sentry)           |
 
 **CI/CD Workflow Files:**
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline & Quality Gates
 
-_Last updated: 2026-04-16_
+_Last updated: 2026-08-03_
 
 This document describes the current GitHub Actions and Fastlane CI/CD pipeline for the myLoyaltyCards repository. It is the single source of truth for how builds, tests, tags, and deploys run across iOS, Android, and watchOS.
 
@@ -16,6 +16,7 @@ This document describes the current GitHub Actions and Fastlane CI/CD pipeline f
   - [Store Upload (Final Release)](#store-upload-final-release)
 - [Fastlane & Native Build Notes](#fastlane--native-build-notes)
 - [Release Runbooks](#release-runbooks)
+  - [Why releases are published, not just tagged](#why-releases-are-published-not-just-tagged)
   - [Ship to TestFlight](#ship-to-testflight)
   - [Release to Production](#release-to-production)
   - [Manual / AdHoc Build](#manual--adhoc-build)
@@ -30,10 +31,10 @@ This document describes the current GitHub Actions and Fastlane CI/CD pipeline f
 flowchart LR
   PR["PR opened / updated"] -->|checks| QG["ci-quality-gates.yml"]
   PR -->|watchOS path changes| WT["watchos-tests.yml"]
-  PUSH["Push to main"] -->|app/core/features/shared/ios changes| IOSA["ios-release.yml"]
-  PUSH -->|app/core/features/shared/android changes| ANDA["android-release.yml"]
-  RCTAG["RC tag v*.*.*-rc.*"] --> BETA["beta-releases.yml"]
-  RELTAG["Release tag v*.*.*"] --> STORE["store-upload.yml"]
+  PUSH["Push to main"] -->|binary-affecting paths change| IOSA["ios-release.yml"]
+  PUSH -->|binary-affecting paths change| ANDA["android-release.yml"]
+  RCREL["Published pre-release v*.*.*-rc.*"] --> BETA["beta-releases.yml"]
+  RELREL["Published release v*.*.*"] --> STORE["store-upload.yml"]
   BETA -->|builds| TF["TestFlight + Android Beta"]
   STORE -->|uploads| STORE2["App Store + Play Store"]
 ```
@@ -108,13 +109,16 @@ File: `.github/workflows/ios-release.yml`
 
 Triggers:
 
-- `push` to `main` when any of these paths change:
-  - `app/**`
-  - `core/**`
-  - `features/**`
-  - `shared/**`
-  - `ios/**`
+- `push` to `main` when any path that can change the shipped binary changes:
+  - JS bundle source — `app/**`, `core/**`, `features/**`, `shared/**`
+  - native + watch companion — `ios/**`, `targets/**`, `watch-ios/**`
+  - compiled-in data and assets — `catalogue/**`, `assets/**`, `tokens/**`
+  - build inputs — `app.json`, `app.config.ts`, `package.json`, `yarn.lock`, `babel.config.js`, `metro.config.js`, `patches/**`, `fastlane/**`
+  - this workflow itself — `.github/workflows/ios-release.yml`
+- …but **not** for files that cannot reach the binary, excluded with negative patterns: `!**/*.test.ts`, `!**/*.test.tsx`, `!**/*.stories.tsx`. Tests are co-located beside their subject and stories are Storybook-only, so a test- or story-only change no longer costs a native build. A commit that _also_ touches real source still builds.
 - `workflow_dispatch` for manual runs on any branch
+
+Note: `catalogue/italy.json` is in the trigger list because `watch-ios/Scripts/generate-catalogue.swift` reads it during this build — a brand added to the catalogue alone still changes what ships.
 
 What it runs:
 
@@ -133,12 +137,13 @@ File: `.github/workflows/android-release.yml`
 
 Triggers:
 
-- `push` to `main` when any of these paths change:
-  - `app/**`
-  - `core/**`
-  - `features/**`
-  - `shared/**`
-  - `android/**`
+- `push` to `main` when any path that can change the shipped binary changes:
+  - JS bundle source — `app/**`, `core/**`, `features/**`, `shared/**`
+  - native — `android/**` (the watch companion is iOS-only, so `targets/**` and `watch-ios/**` are deliberately absent)
+  - compiled-in data and assets — `catalogue/**`, `assets/**`, `tokens/**`
+  - build inputs — `app.json`, `app.config.ts`, `package.json`, `yarn.lock`, `babel.config.js`, `metro.config.js`, `patches/**`, `fastlane/**`
+  - this workflow itself — `.github/workflows/android-release.yml`
+- …but **not** `!**/*.test.ts`, `!**/*.test.tsx`, `!**/*.stories.tsx` — see the iOS section above for the rationale.
 - `workflow_dispatch` for manual runs on any branch
 
 What it runs:
@@ -157,7 +162,11 @@ File: `.github/workflows/beta-releases.yml`
 
 Triggers:
 
-- `push` tags matching `v*.*.*-rc.*`
+- a **published GitHub Release** whose tag contains `-rc.` — the intended trigger, see [Why releases are published, not just tagged](#why-releases-are-published-not-just-tagged)
+- `push` tags matching `v*.*.*-rc.*` — kept as a fallback so a bare `git push --tags` is not a silent no-op
+- `workflow_dispatch` with a required `tag` input, for a manual re-run
+
+Because `on.release` cannot filter by tag pattern, the RC selection lives in a job-level `if:`. A published release whose tag is not an RC therefore produces a run whose jobs are all `skipped` — that is expected, not a failure. A `concurrency` group keyed on the tag name collapses the release and tag-push events into a single run, so one tag never produces two uploads.
 
 Jobs:
 
@@ -175,8 +184,11 @@ File: `.github/workflows/store-upload.yml`
 
 Triggers:
 
-- `push` tags matching `v*.*.*`
-- excludes pre-release tags via `!v*.*.*-*`
+- a **published GitHub Release** that is _not_ flagged as a pre-release and whose tag is a bare `vX.Y.Z` — the intended trigger
+- `push` tags matching `v*.*.*`, excluding pre-release tags via `!v*.*.*-*` — kept as a fallback
+- `workflow_dispatch` with a required `tag` input, for a manual re-run
+
+Both conditions — the `prerelease` flag **and** the tag shape — are checked in the job-level `if:`, so a release mis-flagged in the GitHub UI cannot reach production.
 
 Jobs:
 
@@ -219,18 +231,27 @@ Android lanes summary:
 
 ## Release Runbooks
 
+### Why releases are published, not just tagged
+
+**Do not cut a release with a bare `git tag && git push --tags`.** It silently does nothing most of the time.
+
+After nearly every merge, [`mark-story-done.yml`](../.github/workflows/mark-story-done.yml) pushes `chore(sprint): mark story done after merge [skip ci]` straight to `main`, so `main`'s tip usually carries a skip marker. GitHub honours `[skip ci]` (and `[ci skip]`, `[no ci]`, `[skip actions]`, `[actions skip]`, and the `skip-checks: true` trailer) for the `push` and `pull_request` events, and it evaluates them against the **commit the pushed ref points at** — including a pushed tag. Tag that tip, push the tag, and no workflow run is created at all: no red X, no notification, just silence.
+
+Publishing a GitHub Release avoids this entirely, because the `release` event is not a `push` event and cannot be skipped. That is why both release workflows trigger on `release: [published]`, and why the runbooks below use `gh release create`.
+
+The `push: tags` triggers are still in place as a fallback, so an out-of-habit tag push is not a silent no-op when the tip happens to be clean. If you ever _do_ end up with a tag that fired nothing, you have two ways out: publish a release for the existing tag (`gh release create <tag> --verify-tag …`), or run the workflow manually from the Actions tab and pass the tag as the `tag` input.
+
 ### Ship to TestFlight
 
 1. Confirm `main` is green with passing CI.
 2. Decide the release version.
-3. Create an RC tag:
+3. Create and publish the RC as a **pre-release**:
 
 ```bash
-git tag v1.0.0-rc.1
-git push --tags
+gh release create v1.0.0-rc.1 --prerelease --generate-notes --target main
 ```
 
-4. Monitor `.github/workflows/beta-releases.yml` in GitHub Actions.
+4. Monitor `.github/workflows/beta-releases.yml` in GitHub Actions. `Store Upload (Final Release)` will also appear with all jobs `skipped` — that is the pre-release guard working, not a failure.
 5. Verify the iOS build appears in App Store Connect → TestFlight.
 6. Verify the Android build appears in the Play Console alpha (testing) track.
 7. Distribute to testers.
@@ -238,14 +259,13 @@ git push --tags
 ### Release to Production
 
 1. Validate the RC/TestFlight build.
-2. Create a final release tag:
+2. Create and publish the final release (**no** `--prerelease`, and a bare `vX.Y.Z` tag — the workflow checks both):
 
 ```bash
-git tag v1.0.0
-git push --tags
+gh release create v1.0.0 --generate-notes --target main
 ```
 
-3. Monitor `.github/workflows/store-upload.yml` in GitHub Actions.
+3. Monitor `.github/workflows/store-upload.yml` in GitHub Actions. `Beta Releases (RC)` will appear with all jobs `skipped`.
 4. After upload completes, submit the build for App Store / Play Store review.
 
 ### Manual / AdHoc Build


### PR DESCRIPTION
## Why

Two independent CI problems, reported together.

**1. Useless native builds.** The two AdHoc workflows already had a path allowlist, so docs-only merges were skipped — but the allowlist leaked in both directions.

Tests are co-located beside their subject and the Storybook files live under `shared/`, so **163 test files and 7 gallery files matched `app/core/features/shared`** and cost a full iOS + Android native build apiece. #179 changed a single test file and built twice.

The opposite leak is worse: `catalogue/`, `assets/`, `patches/`, `targets/`, `watch-ios/`, `fastlane/`, `app.json`, `app.config.ts`, `package.json` and `yarn.lock` all change the shipped binary yet matched **nothing** — so `main` could go green with no binary reflecting the change. `catalogue/italy.json` is the sharpest case: `watch-ios/Scripts/generate-catalogue.swift` reads it during the iOS build itself, so adding a brand changed what ships and built nothing.

**2. A tag pushed onto a marker commit produced no release build.** The mark-story-done workflow lands a skip-ci marker on `main`'s tip after most merges (31 such commits on `main`, 10 in the last 60). GitHub applies those markers to tag pushes too, evaluating them against the commit the pushed ref points at — so `git tag && git push --tags` created **no workflow run at all**: no red X, no notification, just silence. Neither release workflow had a `workflow_dispatch`, so the only recovery was deleting and re-pointing the tag.

## What

### AdHoc builds

Both allowlists now cover every binary-affecting path and exclude `*.test.ts`, `*.test.tsx` and `*.stories.tsx` via negative patterns. `paths` and `paths-ignore` cannot coexist on one event, so negation inside `paths` is the only available mechanism.

Order is load-bearing: the filter runs when *at least one* path matches, so a commit touching source **and** its test still builds — only test- or gallery-only commits skip. `targets/` and `watch-ios/` are iOS-only on purpose; the watch companion is not in the Android binary.

### Releases

Both release workflows now also trigger on `release: [published]`, which cannot be suppressed — the markers apply only to `push` and `pull_request`. `push: tags` stays as a fallback so an out-of-habit tag push is not a silent no-op, and a `concurrency` group keyed on the tag name collapses the two events so one tag never yields two uploads.

Because `on.release` cannot filter by tag pattern, the rc-vs-final split moved into job-level `if:` guards. The production guard demands **both** a non-prerelease flag and a bare `vX.Y.Z` tag, so a release mis-flagged in the UI skips rather than ships. Each workflow also gains `workflow_dispatch` with a tag input, and every checkout is now ref-explicit so a manual run builds the tag rather than the branch.

Nothing was removed — the existing tag triggers still work exactly as before.

## Verification

Real commits replayed through a reimplementation of GitHub's path-filter semantics:

| commit | iOS | Android | note |
| --- | --- | --- | --- |
| `c02183e` test-only lint fix (#179) | **skip** | **skip** | built twice before |
| `df309ae` docs (#199) | skip | skip | unchanged |
| `7859006` the marker commit | skip | skip | unchanged |
| `41b2b5b` catalogue: add Upim (#188) | BUILD | BUILD | unchanged |
| `8aa4be9` fix(scanner) (#187) | BUILD | BUILD | unchanged |

All 12 synthetic checks pass, including `CardTile.tsx` + `CardTile.test.tsx` together still building, and `catalogue/italy.json` / `app.json` / `yarn.lock` / `patches/**` alone now building where they previously did not.

`prettier --check .` is clean repo-wide and all 9 workflows parse.

**Not verified locally:** `actionlint` is a Go binary and unavailable here, so Actions expression syntax gets validated on GitHub. GitHub's docs also don't state which ref's workflow file a `release` event loads, so the release trigger can only be exercised once this is on `main` — both readings work post-merge.

Because each AdHoc workflow now watches its own file, merging this will kick off one iOS and one Android build. That is the deliberate positive test of the new filters.

## Follow-up, deliberately not in this PR

A PR body that merely *discusses* the marker suppresses its own quality-gates run on `main`, because squash-merge folds the body into the commit message — `115709d` and `0a4a018` already hit this. `scripts/check-pr-conventions.mjs` should reject those markers in PR bodies; that is being handled separately.

_This PR's own body avoids the literal marker for exactly that reason._
