### PR TITLE
chore(ci): fail PRs whose title or body carries a CI-skip marker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,10 @@
 
   Title format:  <type>(<scope>): <summary> (Story X.Y)
   Example:       feat(watch): render barcode complication (Story 5.9)
+
+  No CI-skip marker anywhere in the title or body — a squash merge copies both into
+  main's commit message, where GitHub honours one and skips the quality gates. To
+  write about a marker, hyphenate it (skip-ci) or split it: `[skip` `ci]`.
 -->
 
 ## Summary

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -3,6 +3,8 @@ name: PR conventions
 # Fails the PR if it doesn't follow the machine-checkable rules in CONTRIBUTING.md:
 # Conventional Commit title, branch naming, and a spec-first story reference for
 # code changes (docs:/chore: titles, catalogue PRs, and design-labelled PRs are exempt).
+# It also rejects a CI-skip marker in the title or body — a squash merge copies both
+# into the commit message on main, where GitHub would honour it and skip the gates.
 
 on:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,13 +256,13 @@ feat(watch): render barcode complication on the watch face (Story 5.9)
 
 Quality is enforced at three levels. **All must pass — bypassing them is forbidden.**
 
-| Gate                    | When                                | What runs                                                                            |
-| ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
-| **pre-commit**          | `git commit`                        | `lint-staged` → ESLint `--fix` + Prettier on staged files                            |
-| **pre-push**            | `git push`                          | Typecheck, lint, format, drift checks, full test suite                               |
-| **CI — quality**        | every PR & push to `main`           | Everything `pre-push` runs, plus `check:no-tests-folders`, with coverage             |
-| **CI — watchOS**        | PR/push touching watch or iOS paths | Watch contract tests, `Brands.swift` catalogue sync, watch-target build              |
-| **CI — PR conventions** | every PR                            | Conventional-Commit title, branch naming, and spec-first story link (see note below) |
+| Gate                    | When                                | What runs                                                                                               |
+| ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **pre-commit**          | `git commit`                        | `lint-staged` → ESLint `--fix` + Prettier on staged files                                               |
+| **pre-push**            | `git push`                          | Typecheck, lint, format, drift checks, full test suite                                                  |
+| **CI — quality**        | every PR & push to `main`           | Everything `pre-push` runs, plus `check:no-tests-folders`, with coverage                                |
+| **CI — watchOS**        | PR/push touching watch or iOS paths | Watch contract tests, `Brands.swift` catalogue sync, watch-target build                                 |
+| **CI — PR conventions** | every PR                            | Conventional-Commit title, branch naming, spec-first story link, and no CI-skip marker (see note below) |
 
 ### Exactly what runs, in order
 
@@ -294,6 +294,8 @@ The pre-push hook and the quality-gates workflow run the **same set of checks in
 **CI — watchOS** ([`watchos-tests.yml`](.github/workflows/watchos-tests.yml)) is a **separate, path-filtered workflow** — it runs only when `targets/watch/**`, `watch-ios/**`, `ios/**`, `app.json`, `fastlane/Fastfile`, or the workflow itself changes, so most PRs never trigger it. It runs the watch catalogue Jest tests, then `expo prebuild`, regenerates `Brands.swift`, verifies it with `yarn check:catalogue-generated`, and builds the watch target via `yarn watch:build:ci`. Locally, `yarn test:all` covers the watch tests.
 
 The **PR conventions** check ([`pr-conventions.yml`](.github/workflows/pr-conventions.yml)) fails the PR if the title isn't a Conventional Commit, the branch doesn't use an allowed prefix, or a **code change** references no story. `docs:`/`chore:` titles and catalogue- or `design`-labelled PRs are exempt from the story requirement (the `design` label covers token/visual polish — see [Design / UI Changes](#design--ui-changes)).
+
+It also fails the PR if the **title or body** contains a CI-skip marker: any of GitHub's five bracketed instructions (`skip ci`, `ci skip`, `no ci`, `skip actions`, `actions skip` — written in square brackets) or a `skip-checks` trailer. A squash merge copies the PR title into the commit subject and the PR body into the commit body, and GitHub honours a skip instruction **anywhere** in a commit message — so a marker written as nothing more than prose silently suppresses the push-to-`main` run of the gates above. That is not hypothetical: `115709d` mentioned one in passing on body line 12, and its gate run never happened. Backticks are no protection — to GitHub's scanner they are ordinary adjacent characters. To write **about** a marker, hyphenate it (`skip-ci`) or split it across two code spans so a backtick lands between the words: `[skip` `ci]`.
 
 🚫 **`--no-verify` is strictly forbidden** for both `git commit` and `git push`. If a hook fails:
 
@@ -353,7 +355,7 @@ Run `yarn lint` and `yarn typecheck` to catch most violations automatically.
 ### Merging
 
 - **Do not merge your own PR.** A maintainer reviews and merges to `main`.
-- **Status update is automated.** When a PR is **merged**, the [`mark-story-done`](.github/workflows/mark-story-done.yml) workflow reads the story referenced in the PR and commits its status → `done` (in both `sprint-status.yaml` and the story file) directly to the default branch. The commit is tagged `[skip ci]` so it doesn't re-run any pipelines. This works for fork PRs too. _(Maintainers can also apply it by hand: `node scripts/mark-story-done.mjs <story-id>`.)_
+- **Status update is automated.** When a PR is **merged**, the [`mark-story-done`](.github/workflows/mark-story-done.yml) workflow reads the story referenced in the PR and commits its status → `done` (in both `sprint-status.yaml` and the story file) directly to the default branch. The commit carries a skip-ci marker so it doesn't re-run any pipelines — that marker belongs in the bot's own commit message and must never appear in a PR title or body, which a squash merge would copy onto `main` (see [Quality Gates](#quality-gates-never-bypass)). This works for fork PRs too. _(Maintainers can also apply it by hand: `node scripts/mark-story-done.mjs <story-id>`.)_
   - **Consequence for releases:** because that commit is usually `main`'s tip, a bare `git tag && git push --tags` will silently create no workflow run — GitHub applies the skip marker to tag pushes too. Cut releases with `gh release create` instead; see [Why releases are published, not just tagged](docs/cicd.md#why-releases-are-published-not-just-tagged).
 - When an epic completes, run a **retrospective** and capture lessons in `docs/sprint-artifacts/`.
 

--- a/scripts/check-pr-conventions.mjs
+++ b/scripts/check-pr-conventions.mjs
@@ -8,6 +8,9 @@
 //   3. Spec-first: code changes reference an existing story
 //      (docs:/chore: titles, catalogue PRs, and `design`-labelled PRs are exempt —
 //       the design label covers token/visual polish per docs/design/CONTRIBUTING-DESIGN.md)
+//   4. No CI-skip marker in the title or body — a squash merge copies both into the
+//      commit message on main, where GitHub honours a skip instruction anywhere, so
+//      the marker would silently skip the "never bypass" quality gates
 //
 // Inputs via env: PR_TITLE, PR_BODY, HEAD_REF, PR_LABELS (comma-separated).
 
@@ -21,6 +24,10 @@ const LABELS = (process.env.PR_LABELS ?? '')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
+
+// The surface a squash merge lands on main: the title becomes the commit subject and
+// the body becomes the commit body. Rules 3 and 4 both scan it.
+const TITLE_AND_BODY = `${PR_TITLE}\n${PR_BODY}`;
 
 const TYPES = ['feat', 'fix', 'refactor', 'docs', 'test', 'chore'];
 const BRANCH_PREFIXES = ['feature', 'fix', 'refactor', 'docs', 'chore'];
@@ -62,7 +69,7 @@ const storyExempt =
   LABELS.includes('catalogue') ||
   LABELS.includes('design');
 if (!storyExempt) {
-  const slugs = resolveStorySlugs(`${PR_TITLE}\n${PR_BODY}`);
+  const slugs = resolveStorySlugs(TITLE_AND_BODY);
   if (slugs.length === 0) {
     violations.push(
       [
@@ -72,6 +79,47 @@ if (!storyExempt) {
       ].join('\n')
     );
   }
+}
+
+// 4) No CI-skip marker in the title or body
+//
+// A squash merge folds the PR title into the subject and the PR body into the body of
+// the one commit that lands on main, and GitHub honours a skip instruction found
+// ANYWHERE in a commit message — not just the subject. ci-quality-gates.yml runs on
+// `push: branches: [main]` with no skip guard of its own, so a PR that merely *writes*
+// a marker silently suppresses the gate run CONTRIBUTING.md calls "never bypass".
+// Backticks do not help: to GitHub's scanner they are ordinary adjacent characters.
+// This has happened twice — 115709d (a marker in prose on body line 12) and 0a4a018.
+//
+// The brackets are load-bearing. Requiring them keeps innocent prose ("no CI guard")
+// clear of the check and leaves `skip-ci` free as the safe way to write about a
+// marker. `[ \t]` rather than `\s` between the words, so a line ending in "skip"
+// followed by one starting "ci]" cannot false-positive across the newline.
+//
+// The legitimate producer of skip-ci commits is mark-story-done.yml, which commits
+// straight to the default branch and never opens a PR (and this workflow skips Bot
+// authors regardless), so nothing here interferes with it.
+const CI_SKIP_MARKERS = [
+  ['[skip ci]', /\[[ \t]*skip[ \t]+ci[ \t]*\]/i],
+  ['[ci skip]', /\[[ \t]*ci[ \t]+skip[ \t]*\]/i],
+  ['[no ci]', /\[[ \t]*no[ \t]+ci[ \t]*\]/i],
+  ['[skip actions]', /\[[ \t]*skip[ \t]+actions[ \t]*\]/i],
+  ['[actions skip]', /\[[ \t]*actions[ \t]+skip[ \t]*\]/i],
+  ['skip-checks trailer', /\bskip-checks[ \t]*:[ \t]*true\b/i]
+];
+const foundMarkers = CI_SKIP_MARKERS.filter(([, re]) => re.test(TITLE_AND_BODY)).map(([l]) => l);
+if (foundMarkers.length > 0) {
+  violations.push(
+    [
+      'PR title/body must not contain a CI-skip marker.',
+      `  Found:    ${foundMarkers.join(', ')}`,
+      "  A squash merge copies the PR title and body into main's commit message, and GitHub",
+      '  honours a skip instruction anywhere in it — so merging this would silently skip the',
+      '  quality gates CONTRIBUTING.md marks "never bypass".',
+      '  To write ABOUT a marker, hyphenate it (skip-ci) or split it across two code spans so',
+      '  a backtick sits between the words — backticks alone do not help.'
+    ].join('\n')
+  );
 }
 
 // ---- report -----------------------------------------------------------------

--- a/scripts/check-pr-conventions.test.js
+++ b/scripts/check-pr-conventions.test.js
@@ -1,0 +1,250 @@
+/**
+ * @jest-environment node
+ */
+// Black-box tests for the PR-conventions gate — chiefly rule 4, which stops a PR from
+// carrying a CI-skip marker onto main. A squash merge copies the PR title into the
+// commit subject and the PR body into the commit body, and GitHub honours a skip
+// instruction found ANYWHERE in a commit message, so a marker written even as prose
+// silently suppresses the `push: branches: [main]` run of ci-quality-gates.yml — the
+// gate CONTRIBUTING.md calls "never bypass". Commit 115709d did exactly that with a
+// backticked mention on body line 12; the "backticked prose" case below is its shape
+// and is the regression this file guards.
+//
+// WHY BLACK BOX, ONE SPAWN PER CASE: check-pr-conventions.mjs reads process.env at
+// module scope and calls process.exit() at top level, so it cannot be imported and
+// re-invoked with different inputs. Jest also compiles through babel.config.test.js,
+// which targets Hermes/React Native and emits CommonJS, where the `import.meta` in its
+// ./lib/story-refs.mjs dependency is a hard syntax error — the same constraint
+// scripts/lib/story-refs.test.js documents. Each case therefore runs the real script in
+// a real node child, exactly as .github/workflows/pr-conventions.yml does. All spawns
+// happen once in beforeAll; the `it`s only read the resulting map.
+//
+// WHY chore(…) TITLES: a `chore:` title is story-exempt, so the rule-4 cases exercise
+// rule 4 alone. Asserting `issues: 1` on each of them proves that isolation held rather
+// than assuming it.
+//
+// WHY A MINIMAL ENV: process.env is deliberately NOT spread into the child. On a GitHub
+// runner that would leak the real GITHUB_STEP_SUMMARY and make every case append to the
+// live job summary, and would let an ambient PR_* variable bleed into the inputs.
+//
+// ASSERTIONS are on the exit code, the violation count, and whether the rule's FIRST
+// line appeared — the text GitHub surfaces as the ::error:: annotation and the
+// step-summary bullet. Never on the guidance prose, so the wording stays editable.
+
+const { execFileSync } = require('node:child_process');
+const { readdirSync } = require('node:fs');
+const { join } = require('node:path');
+
+const SCRIPT = join(__dirname, 'check-pr-conventions.mjs');
+const STORIES_DIR = join(__dirname, '..', 'docs', 'sprint-artifacts', 'stories');
+
+// A title and branch that satisfy rules 1–3, so only rule 4 can fail.
+const CLEAN_TITLE = 'chore(ci): guard PR bodies against CI-skip markers';
+const CLEAN_REF = 'chore/guard-ci-skip-markers';
+
+// First lines of the violations, i.e. the ::error:: annotation text.
+const RULE_1 = 'PR title is not a Conventional Commit.';
+const RULE_2 = 'Branch name does not follow the convention.';
+const RULE_3 = 'Spec-first: this looks like a code change but references no story.';
+const RULE_4 = 'PR title/body must not contain a CI-skip marker.';
+
+// resolveStorySlugs only returns slugs whose file exists and there is no seam to point
+// it at a fixture, so the rule-3 case needs a real story. Discover one at run time —
+// hardcoding an id would rot the moment that story is renamed. The id-shaped filter
+// skips the validation reports and other non-story .md files in the same directory.
+const A_REAL_STORY = readdirSync(STORIES_DIR)
+  .filter((f) => /^\d+-\d+[a-z]?-.+\.md$/.test(f))
+  .sort()[0];
+
+// [name, { title?, body?, ref? }] — one child process each.
+const CASES = [
+  // Each of the six skip instructions GitHub recognises, plus the trailer's other
+  // spelling. Any one of these reaching main disables the gate run.
+  ['skip ci', { body: 'Tidy-up only [skip ci]' }],
+  ['ci skip', { body: 'Tidy-up only [ci skip]' }],
+  ['no ci', { body: 'Tidy-up only [no ci]' }],
+  ['skip actions', { body: 'Tidy-up only [skip actions]' }],
+  ['actions skip', { body: 'Tidy-up only [actions skip]' }],
+  ['skip-checks trailer', { body: 'Tidy-up only\n\n\nskip-checks: true' }],
+  ['skip-checks trailer unspaced', { body: 'Tidy-up only\n\n\nskip-checks:true' }],
+
+  // Shapes a naive check misses.
+  [
+    'backticked prose',
+    { body: 'committed to the default branch with `[skip ci]` so nothing re-runs.' }
+  ],
+  ['uppercase', { body: 'Tidy-up only [SKIP CI]' }],
+  ['inner whitespace', { body: 'Tidy-up only [ skip\tci ]' }],
+  ['in the title', { title: 'chore(sprint): mark story done after merge [skip ci]' }],
+
+  // The safe ways to write about a marker, and prose that merely contains "no CI".
+  // "clean body" is the non-vacuity guard: without it a harness that always failed
+  // would still make every positive case above pass.
+  ['clean body', { body: 'Adds a fourth rule to scripts/check-pr-conventions.mjs.' }],
+  ['hyphenated', { body: 'The bot commit carries a skip-ci marker; this PR must not.' }],
+  ['split code spans', { body: 'Write it as `[skip` `ci]` to stay clear of this check.' }],
+  ['innocent no CI prose', { body: 'There was no CI guard for this before.' }],
+  ['skip-checks false', { body: 'The trailer only counts as skip-checks: false here.' }],
+  ['skipped ci', { body: 'Nothing was [skipped ci] in this run.' }],
+
+  // Rules 1–3 must be unaffected. "story ref in body" is the one that matters: it is
+  // the only case proving the TITLE_AND_BODY constant still carries the body through
+  // to resolveStorySlugs, since a non-exempt title with a resolvable story passes.
+  ['bad title', { title: 'no type here' }],
+  ['bad branch', { ref: 'feat/wrong-prefix' }],
+  [
+    'story ref in body',
+    { title: 'feat(ci): x', body: `Implements docs/sprint-artifacts/stories/${A_REAL_STORY}` }
+  ],
+  ['code change without story', { title: 'feat(ci): x', body: 'No story anywhere in here.' }]
+];
+
+// Run one case and reduce its output to the contract: exit code, how many violations
+// fired, and which rules they were.
+const run = ({ title = CLEAN_TITLE, body = '', ref = CLEAN_REF }) => {
+  const env = {
+    PATH: process.env.PATH,
+    PR_TITLE: title,
+    PR_BODY: body,
+    HEAD_REF: ref,
+    PR_LABELS: ''
+  };
+
+  let status = 0;
+  let stdout;
+  try {
+    stdout = execFileSync(process.execPath, [SCRIPT], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env
+    });
+  } catch (err) {
+    if (err.status === undefined || err.status === null) {
+      throw new Error(`check-pr-conventions did not exit cleanly:\n${err.stderr || err.message}`);
+    }
+    status = err.status;
+    stdout = err.stdout ?? '';
+  }
+
+  const count = stdout.match(/\((\d+) issue\(s\)\)/);
+  return {
+    status,
+    issues: count ? Number(count[1]) : 0,
+    rules: [RULE_1, RULE_2, RULE_3, RULE_4].filter((r) => stdout.includes(r))
+  };
+};
+
+describe('check-pr-conventions', () => {
+  let results;
+
+  beforeAll(() => {
+    results = Object.fromEntries(CASES.map(([name, input]) => [name, run(input)]));
+  });
+
+  // Every rule-4 case is a `chore:` PR on a `chore/` branch, so `issues: 1` with only
+  // RULE_4 present means rule 4 fired and nothing else did.
+  const onlyRule4 = { status: 1, issues: 1, rules: [RULE_4] };
+  const passes = { status: 0, issues: 0, rules: [] };
+
+  describe('rule 4 rejects every skip instruction GitHub recognises', () => {
+    it('rejects [skip ci]', () => {
+      expect(results['skip ci']).toEqual(onlyRule4);
+    });
+
+    it('rejects [ci skip]', () => {
+      expect(results['ci skip']).toEqual(onlyRule4);
+    });
+
+    it('rejects [no ci]', () => {
+      expect(results['no ci']).toEqual(onlyRule4);
+    });
+
+    it('rejects [skip actions]', () => {
+      expect(results['skip actions']).toEqual(onlyRule4);
+    });
+
+    it('rejects [actions skip]', () => {
+      expect(results['actions skip']).toEqual(onlyRule4);
+    });
+
+    it('rejects a skip-checks trailer', () => {
+      expect(results['skip-checks trailer']).toEqual(onlyRule4);
+    });
+
+    it('rejects a skip-checks trailer written without a space', () => {
+      expect(results['skip-checks trailer unspaced']).toEqual(onlyRule4);
+    });
+  });
+
+  describe('rule 4 catches the shapes a naive check misses', () => {
+    // The 115709d regression. Backticks are ordinary adjacent characters to GitHub's
+    // scanner, so wrapping a marker in them protects nothing.
+    it('rejects a marker wrapped in backticks as prose', () => {
+      expect(results['backticked prose']).toEqual(onlyRule4);
+    });
+
+    it('rejects an uppercase marker', () => {
+      expect(results['uppercase']).toEqual(onlyRule4);
+    });
+
+    it('rejects a marker padded with extra whitespace and tabs', () => {
+      expect(results['inner whitespace']).toEqual(onlyRule4);
+    });
+
+    // A marker in the title is worse: it becomes the commit subject, and rule 1's
+    // Conventional-Commit regex accepts it as a valid `chore(sprint): …` summary.
+    it('rejects a marker in the title, not just the body', () => {
+      expect(results['in the title']).toEqual(onlyRule4);
+    });
+  });
+
+  describe('rule 4 leaves safe prose alone', () => {
+    it('passes a PR that mentions no marker at all', () => {
+      expect(results['clean body']).toEqual(passes);
+    });
+
+    it('passes the hyphenated form the error message recommends', () => {
+      expect(results['hyphenated']).toEqual(passes);
+    });
+
+    it('passes a marker split across two code spans', () => {
+      expect(results['split code spans']).toEqual(passes);
+    });
+
+    it('passes prose that merely contains "no CI"', () => {
+      expect(results['innocent no CI prose']).toEqual(passes);
+    });
+
+    it('passes a skip-checks trailer set to false', () => {
+      expect(results['skip-checks false']).toEqual(passes);
+    });
+
+    it('passes a bracketed near-miss like [skipped ci]', () => {
+      expect(results['skipped ci']).toEqual(passes);
+    });
+  });
+
+  describe('rules 1-3 still behave', () => {
+    // A malformed title also trips rule 3: `type` is undefined, so the docs/chore
+    // exemption does not apply and the story scan runs.
+    it('still rejects a non-Conventional-Commit title', () => {
+      expect(results['bad title'].rules).toEqual([RULE_1, RULE_3]);
+    });
+
+    it('still rejects an off-convention branch prefix', () => {
+      expect(results['bad branch']).toEqual({ status: 1, issues: 1, rules: [RULE_2] });
+    });
+
+    it('still resolves a story path out of the body', () => {
+      expect(results['story ref in body']).toEqual(passes);
+    });
+
+    it('still rejects a code change that references no story', () => {
+      expect(results['code change without story']).toEqual({
+        status: 1,
+        issues: 1,
+        rules: [RULE_3]
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A PR body that merely *discusses* a CI-skip marker silently suppresses the quality gates on `main`. Squash-merge absorbs the PR title into the commit subject and the PR body into the commit body, and GitHub honours a skip instruction found **anywhere** in that message. `ci-quality-gates.yml` runs on `push: branches: [main]` with no skip guard of its own — so the gates `CONTRIBUTING.md` calls "never bypass" simply don't run.

This adds a fourth rule to `scripts/check-pr-conventions.mjs`, which already runs on every PR and already reads the title and body.

## Confirmed, not hypothetical

Verified against the Actions API:

| commit | `ci-quality-gates` run |
| --- | --- |
| `115709d` — marker written as prose on body line 12 | **none** |
| `0a4a018` — absorbed bot subject from a stacked squash | **none** |
| `df309ae` — ordinary merge, no marker (control) | `push` / success |
| `be1ccda` — the bot's own commit | none, correctly |

Both offenders sit inside the same query window as the control, so the absences are real skips rather than pagination artifacts.

## Related story / issue

None — `chore:` titles are story-exempt under the spec-first rule.

## Type of change

- [x] 🔧 `chore` — tooling / maintenance

## What the rule does

Six patterns over title + body, case-insensitive: GitHub's five bracketed instructions and the `skip-checks` trailer. Two design points worth reviewing:

- **Bracket-anchored.** Requiring the square brackets keeps the repo's existing innocent prose clear of the check — `no CI guard`, `// Locally (no CI):`, `(no CI environment pollution)` — and leaves the hyphenated form free as a safe way to write about a marker.
- **`[ \t]` rather than `\s` between the words**, so a line ending in "skip" followed by one starting with "ci]" cannot false-positive across the newline.

**Backticks are no protection.** `115709d` wrapped its marker in them and GitHub honoured it anyway — to the scanner they are ordinary adjacent characters. The error message therefore recommends hyphenating, or splitting across two code spans so a backtick lands *between* the words.

The legitimate producer is untouched: `mark-story-done.yml` commits straight to the default branch and never opens a PR, and this workflow already skips Bot authors. Its `be1ccda` commit skipped correctly today.

## How was this tested?

- New `scripts/check-pr-conventions.test.js` — 21 black-box cases spawning the real script, which reads env at module scope and exits at top level and so cannot be imported. 11 positives including the backticked shape and a title-position marker, 6 false-positive guards, and 4 pinning the pre-existing rules.
- **Mutation-checked:** disabling the new rule fails exactly the 11 positives and nothing else, so no case is vacuous.
- **Self-checked:** the PR template, the whole of `CONTRIBUTING.md`, the workflow header, and this very PR body were each fed through the script — all pass. That matters most for the PR template, whose text becomes the initial body of every PR.
- Test results: 173 suites / 2067 tests green; `format:check`, `typecheck` and `lint` (0 errors) clean.

- [x] Not a user-visible change (no screenshots needed)

## Docs

Updated the four siblings that describe this check: the gates-table row and the rule paragraph in `CONTRIBUTING.md`, the workflow header comment, and the PR template. All of them use only the safe prose forms, so the text stays quotable into a PR body without tripping the new rule. `CONTRIBUTING.md`'s mark-story-done note now distinguishes the bot's own commit message from a PR title or body — it previously read as legitimising the marker.

Rebased onto `fad7f0e`, which independently documents the same hazard class from the release angle: a tag push inheriting the tip commit's skip marker.

## Author checklist

- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally (I did **not** use `--no-verify`)
- [x] New behavior has co-located tests; coverage is not regressed
- [x] Follows the layer boundaries & rules in `docs/project-context.md` and `AGENTS.md`
- [x] I performed a self-review of my own changes

## Follow-ups (deliberately not in this PR)

- `CONTRIBUTING.md`'s "CI — quality" list has nine steps; the workflow runs ten — `check:story-catalogue-sync` is missing, despite the line above the list asking that it be kept in sync.
- `docs/cicd.md` still omits `pr-conventions.yml`, `chromatic.yml` and `wear-os-build.yml`, and names 2 of the 10 quality-gate checks.
